### PR TITLE
add cross-compile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ ifeq ($(DEB_TARGET_ARCH),armel)
 CROSS_COMPILE=arm-linux-gnueabi-
 endif
 
+#brainroot add for cross-compile
+ifeq ($(DEB_TARGET_ARCH),armhf)
+CROSS_COMPILE=arm-linux-gnueabihf-
+endif
+
 CXX=$(CROSS_COMPILE)g++
 CXX_PATH := $(shell which $(CROSS_COMPILE)g++-4.7)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+wb-mqtt-serial (1.61.0) stable; urgency=medium
+
+  * add cross-compile for armhf
+
 wb-mqtt-serial (1.60.0) stable; urgency=medium
 
   * add RD ddl04r template


### PR DESCRIPTION
Восстановил путь, которым шел до переделок осходного образа.
Надо будет такиее изменения во все мэйк-файлы вносить, в смысле всех пакетов. В принципе пара строчек - зато никакой эмуляции. И никакого chroot. ;)
Версию обновлю - все ж изменение, сейчас коммит сделаю.