### PR TITLE
Fix MAO4 name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (1.62.0) stable; urgency=medium
+
+  * Fix wrong device_type in config-wb-mao4.json (WB-MA04>WB-MAO4)
+
+ -- Andrey Radionov <andrey.radionov@wirenboard.ru>  Mon, 31 Aug 2020 16:21:36 +0300
+
 wb-mqtt-serial (1.61.0) stable; urgency=medium
 
   * add wbio-di-wd-14 template

--- a/wb-mqtt-serial-templates/config-wb-mao4.json
+++ b/wb-mqtt-serial-templates/config-wb-mao4.json
@@ -1,5 +1,5 @@
 {
-    "device_type": "WB-MA04",
+    "device_type": "WB-MAO4",
     "device": {
         "name": "WB-MAO4",
         "id": "wb-mao4",


### PR DESCRIPTION
Исправил имя в файле шаблона модуля по форуму:
https://support.wirenboard.com/t/oshibka-v-nazvanii-ustrojstva-wb-mao4/5656