### PR TITLE
Timeouts for NEVA and Energomera are adjusted

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.7.4) stable; urgency=medium
+
+  * Timeouts for NEVA and Energomera CE301/CE303 energy meters are adjusted
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 30 Mar 2021 14:34:00 +0500
+
 wb-mqtt-serial (2.7.3) stable; urgency=medium
 
   * Correct handling of little-endian register's error values.

--- a/src/devices/energomera_iec_device.cpp
+++ b/src/devices/energomera_iec_device.cpp
@@ -234,7 +234,7 @@ std::list<PRegisterRange> TEnergomeraIecDevice::ReadRegisterRange(PRegisterRange
         ProcessResponse(*range, presp);
     } catch (TSerialDeviceTransientErrorException& e) {
         range->SetError();
-        LOG(Warn) << "TEnergomeraIecDevice::ReadRegisterRange(): " << e.what();
+        LOG(Warn) << "TEnergomeraIecDevice::ReadRegisterRange(): " << e.what() << " [slave_id is " << ToString() + "]";
     }
     return { abstract_range };
 }

--- a/src/devices/neva_device.cpp
+++ b/src/devices/neva_device.cpp
@@ -242,6 +242,7 @@ void TNevaDevice::Prepare()
     size_t retryCount = 5;
     while (true) {
         try {
+            Port()->SleepSinceLastInteraction(DeviceConfig()->FrameTimeout);
             Port()->SkipNoise();
 
             // Send session start request
@@ -258,7 +259,7 @@ void TNevaDevice::Prepare()
             if (retryCount == 0) {
                 throw;
             }
-            LOG(Warn) << e.what();
+            LOG(Debug) << "TNevaDevice::Prepare(): " << e.what() << " [slave_id is " << ToString() + "]";
         }
     }
 }
@@ -272,7 +273,7 @@ void TNevaDevice::EndSession()
     IEC::WriteBytes(*Port(), (uint8_t*) req, sizeof(req), LOG_PREFIX);
 
     // A meter need some time to process the command
-    usleep(DeviceConfig()->FrameTimeout.count() * 1000);
+    std::this_thread::sleep_for(DeviceConfig()->FrameTimeout);
     TIECDevice::EndSession();
 }
 

--- a/src/iec_common.cpp
+++ b/src/iec_common.cpp
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <sstream>
+#include <iomanip>
 
 #include "serial_exc.h"
 #include "log.h"
@@ -19,7 +20,13 @@ namespace IEC
             case NAK:  ss << "<NAK>"; break;
             case '\r': ss << "<CR>"; break;
             case '\n': ss << "<LF>"; break;
-            default:   ss << c;
+            default: {
+                if (isprint(c)) {
+                    ss << c;
+                } else {
+                    ss << "0x" << std::hex << std::uppercase << std::setfill('0') << std::setw(2) << int(c);
+                }
+            }
         }
     }
 

--- a/wb-mqtt-serial-templates/config-energomera-ce301.json
+++ b/wb-mqtt-serial-templates/config-energomera-ce301.json
@@ -4,7 +4,8 @@
     "name": "Energomera CE301/CE303",
     "id": "energomera301",
     "protocol" : "energomera_iec",
-    "frame_timeout_ms" : 100,
+    "frame_timeout_ms" : 1500,
+    "response_timeout_ms": 1500,
     "channels": [
       {
         "name": "Total A energy",

--- a/wb-mqtt-serial-templates/config-neva-mt32x.json
+++ b/wb-mqtt-serial-templates/config-neva-mt32x.json
@@ -4,8 +4,8 @@
     "name": "NEVA MT 32x",
     "id": "neva32x",
     "protocol" : "neva",
-    "frame_timeout_ms" : 50,
-    "response_timeout_ms" : 500,
+    "frame_timeout_ms" : 1500,
+    "response_timeout_ms" : 1500,
     "channels": [
       {
         "name": "Total A energy",


### PR DESCRIPTION
* Timeouts for NEVA and Energomera CE301/CE303 energy meters are adjusted
* Show unprint symbols as hex values in debug messages for NEVA and Energomera
* Slave id is added to debug and error messages for NEVA and Energomera
* Timeout between session start retries for NEVA