### PR TITLE
Performace optimizations during register polling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.12.1) experimental; urgency=medium
+
+  * Performace optimizations during register polling.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 23 Apr 2021 14:21:00 +0500
+
 wb-mqtt-serial (2.12.0) experimental; urgency=medium
 
   * Do not show response errors as warnings for disconnected devices. They are now in debug channel.

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -49,6 +49,10 @@ namespace Modbus    // modbus protocol declarations
         };
     };
 
+    class TModbusRegisterRange;
+    void ComposeReadRequestPDU(uint8_t* pdu, TModbusRegisterRange& range, int shift);
+    size_t InferReadResponsePDUSize(TModbusRegisterRange& range);
+
     class TModbusRegisterRange: public TRegisterRange
     {
     public:
@@ -67,14 +71,37 @@ namespace Modbus    // modbus protocol declarations
         bool ShouldReadOneByOne() const { return ReadOneByOne; }
         void SetReadOneByOne(bool readOneByOne) { ReadOneByOne = readOneByOne; }
 
+        const TRequest& GetRequest(IModbusTraits& traits, uint8_t slaveId, int shift)
+        {
+            if (Request.empty()) {
+                // 1 byte - function code, 2 bytes - starting register address, 2 bytes - quantity of registers
+                const uint16_t REQUEST_PDU_SIZE = 5;
+
+                Request.resize(traits.GetPacketSize(REQUEST_PDU_SIZE));
+                Modbus::ComposeReadRequestPDU(traits.GetPDU(Request), *this, shift);
+                traits.FinalizeRequest(Request, slaveId);
+            }
+            return Request;
+        }
+
+        size_t GetResponseSize(IModbusTraits& traits)
+        {
+            if (ResponseSize == 0) {
+                ResponseSize = traits.GetPacketSize(InferReadResponsePDUSize(*this));
+            }
+            return ResponseSize;
+        }
+
     private:
-        bool            ReadOneByOne    = false;
-        bool            HasHolesFlg     = false;
-        int             Start;
-        int             Count;
-        uint8_t*        Bits  = 0;
-        uint16_t*       Words = 0;
-        EStatus         Status = ST_UNKNOWN_ERROR;
+        bool      ReadOneByOne    = false;
+        bool      HasHolesFlg     = false;
+        int       Start;
+        int       Count;
+        uint8_t*  Bits  = 0;
+        uint16_t* Words = 0;
+        EStatus   Status = ST_UNKNOWN_ERROR;
+        TRequest  Request;
+        size_t    ResponseSize = 0;
     };
 
     using PModbusRegisterRange = std::shared_ptr<TModbusRegisterRange>;
@@ -745,15 +772,9 @@ namespace Modbus    // modbus protocol common utilities
     {
         range.SetStatus(TRegisterRange::ST_UNKNOWN_ERROR);
 
-        // 1 byte - function code, 2 bytes - starting register address, 2 bytes - quantity of registers
-        const uint16_t REQUEST_PDU_SIZE = 5;
-
-        TRequest request(traits.GetPacketSize(REQUEST_PDU_SIZE));
-        TResponse response(traits.GetPacketSize(InferReadResponsePDUSize(range)));
-        Modbus::ComposeReadRequestPDU(traits.GetPDU(request), range, shift);
-        traits.FinalizeRequest(request, slaveId);
-
+        TResponse response(range.GetResponseSize(traits));
         try {
+            const auto& request = range.GetRequest(traits, slaveId, shift);
             auto pduSize = ProcessRequest(traits, port, request, response, *range.Device()->DeviceConfig());
             ParseReadResponse(traits.GetPDU(response), pduSize, range);
             range.SetStatus(TRegisterRange::ST_OK);
@@ -781,13 +802,23 @@ namespace Modbus    // modbus protocol common utilities
         LOG(logger) << "failed to read " << range << ": " << msg;
     }
 
+    struct TTruncatedRegisterList
+    {
+        bool                 IsValid = false;
+        std::list<PRegister> Regs;
+    };
+
     // Remove unsupported registers on borders
-    std::list<PRegister> RemoveUnsupportedFromBorders(std::list<PRegister> l) {
-        auto it = std::find_if(l.begin(), l.end(), [](auto& r) {return r->IsAvailable();});
-        l.erase(l.begin(), it);
-        auto it2 = std::find_if(l.rbegin(), l.rend(), [](auto& r) {return r->IsAvailable();});
-        l.erase(it2.base(), l.end());
-        return l;
+    TTruncatedRegisterList RemoveUnsupportedFromBorders(const std::list<PRegister>& l)
+    {
+        TTruncatedRegisterList res;
+        auto s = std::find_if(l.begin(), l.end(), [](auto& r) {return r->IsAvailable();});
+        auto e = std::find_if(l.rbegin(), std::make_reverse_iterator(s), [](auto& r) {return r->IsAvailable();});
+        if ((s != l.begin()) || (e != l.rbegin())) {
+            std::copy(s, e.base(), std::back_inserter(res.Regs));
+            res.IsValid = true;
+        }
+        return res;
     }
 
     std::list<PRegisterRange> SplitRangeByHoles(const std::list<PRegister>& regs, bool onlyAvailable)
@@ -820,11 +851,15 @@ namespace Modbus    // modbus protocol common utilities
         std::list<PRegisterRange> newRanges;
         try {
             ReadRange(traits, *range, port, slaveId, shift);
-            auto l = RemoveUnsupportedFromBorders(range->RegisterList());
-            if (!l.empty()) {
-                auto newRange = std::make_shared<Modbus::TModbusRegisterRange>(l, range->HasHoles());
-                newRange->SetStatus(range->GetStatus());
-                newRanges.push_back(newRange);
+            auto res = RemoveUnsupportedFromBorders(range->RegisterList());
+            if (res.IsValid) {
+                if (!res.Regs.empty()) {
+                    auto newRange = std::make_shared<Modbus::TModbusRegisterRange>(res.Regs, range->HasHoles());
+                    newRange->SetStatus(range->GetStatus());
+                    newRanges.push_back(newRange);
+                }
+            } else {
+                newRanges.push_back(range);
             }
         } catch (const TSerialDeviceTransientErrorException& e) {
             ProcessRangeException(*range, e.what());
@@ -888,10 +923,10 @@ namespace Modbus    // modbus protocol common utilities
     {
         for (const auto& item : setupItems) {
             try {
+                WriteRegister(traits, port, slaveId, *item->Register, item->Value, shift);
                 LOG(Info) << "Init: " << item->Name 
                         << ": setup register " << item->Register->ToString()
                         << " <-- " << item->Value;
-                WriteRegister(traits, port, slaveId, *item->Register, item->Value, shift);
             } catch (const TSerialDevicePermanentRegisterException& e) {
                 WarnFailedRegisterSetup(item, e.what());
             } catch (const TSerialDeviceTransientErrorException& e) {

--- a/src/register_handler.cpp
+++ b/src/register_handler.cpp
@@ -53,13 +53,8 @@ TRegisterHandler::TErrorState TRegisterHandler::AcceptDeviceValue(uint64_t new_v
 {
     *changed = false;
 
-    // don't poll write-only and dirty registers
-    if (!NeedToPoll())
-        return ErrorStateUnchanged;
-
     if (!ok)
         return UpdateReadError(true);
-
 
     bool first_poll = !DidReadReg;
     DidReadReg = true;

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -207,7 +207,7 @@ void TSerialClient::OpenPortCycle()
     std::map<PSerialDevice, std::set<TRegisterRange::EStatus>> devicesRangesStatuses;
 
     Plan->ProcessPending([&](const PPollEntry& entry) {
-        auto pollEntry = std::dynamic_pointer_cast<TSerialPollEntry>(entry);
+        auto pollEntry = dynamic_cast<TSerialPollEntry*>(entry.get());
         std::list<PRegisterRange> newRanges;
         for (auto range: pollEntry->Ranges) {
             auto device = range->Device();

--- a/src/serial_driver.cpp
+++ b/src/serial_driver.cpp
@@ -23,7 +23,7 @@ TMQTTSerialDriver::TMQTTSerialDriver(PDeviceDriver mqttDriver, PHandlerConfig co
                 continue;
             }
 
-            PortDrivers.push_back(make_shared<TSerialPortDriver>(mqttDriver, portConfig));
+            PortDrivers.push_back(make_shared<TSerialPortDriver>(mqttDriver, portConfig, config->PublishParameters));
             PortDrivers.back()->SetUpDevices();
         }
     } catch (const exception & e) {

--- a/src/serial_port_driver.h
+++ b/src/serial_port_driver.h
@@ -29,8 +29,24 @@ struct TDeviceChannel : public TDeviceChannelConfig
         return "channel '" + Name + "' of device '" + DeviceId + "'";
     }
 
+    void UpdateError(WBMQTT::TDeviceDriver& deviceDriver, const std::string& error);
+    void UpdateValue(WBMQTT::TDeviceDriver& deviceDriver, const WBMQTT::TPublishParameters& publishPolicy, const std::string& error);
+
     PSerialDevice Device;
     std::vector<PRegister> Registers;
+    WBMQTT::PControl Control;
+
+private:
+    void PublishValue(WBMQTT::TDeviceDriver& deviceDriver, const std::string& value);
+    /* Current value of a channel, error flag and last update time.
+       They are used to prevent unnecessary calls to libwbmqtt1.
+       Although libwbmqtt1 implements publishing control with TPublishParams,
+       it is very expensive to call it on every channel update.
+       So we implement publish control logic in wb-mqtt-serial until libwbmqtt1 is fixed.
+    */
+    std::string                           CachedCurrentValue;
+    std::string                           CachedErrorFlg;
+    std::chrono::steady_clock::time_point LastControlUpdate;
 };
 
 typedef std::shared_ptr<TDeviceChannel> PDeviceChannel;
@@ -50,7 +66,10 @@ struct TDeviceChannelState
 class TSerialPortDriver: public std::enable_shared_from_this<TSerialPortDriver>
 {
 public:
-    TSerialPortDriver(WBMQTT::PDeviceDriver mqttDriver, PPortConfig port_config);
+    TSerialPortDriver(WBMQTT::PDeviceDriver             mqttDriver,
+                      PPortConfig                       port_config, 
+                      const WBMQTT::TPublishParameters& publishPolicy);
+
     void SetUpDevices();
     void Cycle();
     void ClearDevices() noexcept;
@@ -73,6 +92,7 @@ private:
     PSerialClient              SerialClient;
     std::vector<PSerialDevice> Devices;
     std::string                Description;
+    WBMQTT::TPublishParameters PublishPolicy;
 
     std::unordered_map<PRegister, TDeviceChannelState> RegisterToChannelStateMap;
 };


### PR DESCRIPTION
* Request caching is added to modbus protocol
* MQTT controls caching is added
* Publishing of unchanged value control is moved to wb-mqtt-serial from libwbmqtt1. Opening libwbmqtt1 transactions is very expensive. So publishing of unchanged values control is implemented in wb-mqtt-serial to prevent unnecessary calls to libwbmqtt1.