### PR TITLE
WBE2-I-OPENTHERM register format was changed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.16.6) stable; urgency=medium
+
+  * Module WBE2-I-OPENTHERM register 211 (input) format was changed from
+    u16 to s16
+
+ -- Dmitry Vorobjev <d.vorobjev@wirenboard.ru>  Wed, 23 Jun 2021 15:26:00 +0300
+
 wb-mqtt-serial (2.16.5) stable; urgency=medium
 
   * Remake of templates Modbus relay modules WB-MRxx using groups and parameters

--- a/wb-mqtt-serial-templates/config-wbe2-i-opentherm.json
+++ b/wb-mqtt-serial-templates/config-wbe2-i-opentherm.json
@@ -79,7 +79,7 @@
                 "address": 211,
                 "reg_type": "input",
                 "type": "temperature",
-                "format": "u16",
+                "format": "s16",
                 "scale": 0.1,
                 "offset": -100,
                 "group": "boiler_state",


### PR DESCRIPTION
Module WBE2-I-OPENTHERM register 211 (input) format was changed from u16 to s16