### PR TITLE
Config validation time is decreased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ debian/wb-mqtt-serial
 debian/*.substvars
 debhelper-build-stamp
 .clang-format
+build

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.19.1) stable; urgency=medium
+
+  * Config validation time is decreased
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 13 Jul 2021 18:38:17 +0500
+
 wb-mqtt-serial (2.19.0) stable; urgency=medium
 
   * Retry of failed registers writes for "on" topic messages is added

--- a/src/config_schema_generator.cpp
+++ b/src/config_schema_generator.cpp
@@ -46,7 +46,16 @@ namespace
 
     //  {
     //      "oneOf": [
-    //          { "$ref": "#/definitions/DEVICE_SCHEMA_NAME" },
+    //          {
+    //              "allOf": [ { "$ref": "#/definitions/DEVICE_SCHEMA_NAME" } ],
+    //              "properties": {
+    //                  "device_type": {
+    //                      "type": "string",
+    //                      "enum": [ DEVICE_TYPE ]
+    //                  }
+    //              },
+    //              "required": [ "device_type" ]
+    //          },
     //          ...
     //      ],
     //      "properties": {
@@ -55,19 +64,22 @@ namespace
     //              "enum": [ CHANNEL_NAME ]
     //          }
     //      },
-    //      "required": ["name", "device_type"]
+    //      "required": ["name"]
     //  }
     Json::Value MakeTabOneOfChannelSchema(const Json::Value& channelTemplate, const std::string& deviceType)
     {
         Json::Value r;
         r["properties"]["name"] = MakeSingleValuePropery(channelTemplate["name"].asString());
-        auto& req = MakeArray("required", r);
-        req.append("name");
-        req.append("device_type");
+        MakeArray("required", r).append("name");
 
         auto& items = MakeArray("oneOf", r);
         for (const auto& subDeviceName: channelTemplate["oneOf"]) {
-            items.append(MakeObject("$ref", "#/definitions/" + GetSubdeviceSchemaKey(deviceType, subDeviceName.asString())));
+            auto name(subDeviceName.asString());
+            Json::Value i;
+            i["properties"]["device_type"] = MakeSingleValuePropery(name);
+            MakeArray("required", i).append("device_type");
+            MakeArray("allOf", i).append(MakeObject("$ref", "#/definitions/" + GetSubdeviceSchemaKey(deviceType, name)));
+            items.append(i);
         }
 
         return r;
@@ -105,7 +117,6 @@ namespace
 
     //  {
     //      "allOf": [
-    //          { "$ref": CUSTOM_CHANNEL_SCHEMA },
     //          {
     //              "not": {
     //                  "properties": {
@@ -115,7 +126,8 @@ namespace
     //                      }
     //                  }
     //              }
-    //          }
+    //          },
+    //          { "$ref": CUSTOM_CHANNEL_SCHEMA }
     //      ]
     //  }
     Json::Value MakeCustomChannelsSchema(const std::vector<std::string>& names, const std::string& customChannelsSchemaRef)
@@ -128,8 +140,8 @@ namespace
         }
         Json::Value r;
         auto& allOf = MakeArray("allOf", r);
-        allOf.append(MakeObject("$ref", customChannelsSchemaRef));
         allOf.append(n);
+        allOf.append(MakeObject("$ref", customChannelsSchemaRef));
         return r;
     }
 

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -76,6 +76,7 @@ class TTemplateMap: public ITemplateMap
 
         Json::Value Validate(const std::string& deviceType, const std::string& filePath);
         std::shared_ptr<TDeviceTemplate> GetTemplatePtr(const std::string& deviceType);
+        std::string GetDeviceType(const std::string& templatePath) const;
     public:
         TTemplateMap() = default;
 

--- a/test/TConfigParserTest.UnsuccessfulParse.dat
+++ b/test/TConfigParserTest.UnsuccessfulParse.dat
@@ -56,7 +56,7 @@ Error 18
   desc: Failed to validate against schema associated with property name 'devices'.
 Error 19
   context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 20
   context: <root>[ports][0]
   desc: Failed to validate against child schema #0.
@@ -140,7 +140,7 @@ Error 18
   desc: Failed to validate against schema associated with property name 'devices'.
 Error 19
   context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 20
   context: <root>[ports][0]
   desc: Failed to validate against child schema #0.
@@ -169,108 +169,75 @@ Error 27
 Parsing config test/configs/unsuccessful/unsuccessful-10.json
 File: test/configs/unsuccessful/unsuccessful-10.json error: Validation failed.
 Error 1
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Failed to match against any enum values.
+  context: <root>[ports][0][devices][0][channels][0]
+  desc: Missing required property 's12'.
 Error 2
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
+  desc: Failed to validate against child schema #0.
 Error 3
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against child schema #0.
 Error 4
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Failed to match against any enum values.
+  context: <root>[ports][0][devices][0][channels][0]
+  desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 5
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
+  desc: Failed to validate against child schema #0.
 Error 6
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
+  desc: Target should not validate against schema specified in 'not' constraint.
 Error 7
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 's12'.
+  desc: Failed to validate against child schema #0.
 Error 8
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #2.
+  desc: Failed to validate against child schema #1.
 Error 9
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 10
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 11
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Target should not validate against schema specified in 'not' constraint.
-Error 12
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
-Error 13
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 14
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 15
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 'consists_of'.
-Error 16
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 17
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 18
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 19
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 20
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 21
   context: <root>[ports][0][devices][0][channels]
   desc: Failed to validate item #0 in array.
-Error 22
+Error 11
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against schema associated with property name 'channels'.
-Error 23
+Error 12
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against child schema #0.
-Error 24
+Error 13
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 25
+Error 14
   context: <root>[ports][0][devices]
   desc: Failed to validate item #0 in array.
-Error 26
+Error 15
   context: <root>[ports][0]
   desc: Failed to validate against schema associated with property name 'devices'.
-Error 27
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 28
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 29
-  context: <root>[ports][0]
-  desc: Missing required property 'port_type'.
-Error 30
+Error 16
   context: <root>[ports][0]
   desc: Failed to validate against child schema #1.
-Error 31
+Error 17
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #0.
+Error 18
   context: <root>[ports][0]
   desc: Missing required property 'port_type'.
-Error 32
+Error 19
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #1.
+Error 20
+  context: <root>[ports][0]
+  desc: Missing required property 'port_type'.
+Error 21
   context: <root>[ports][0]
   desc: Failed to validate against child schema #2.
-Error 33
+Error 22
   context: <root>[ports][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 34
+Error 23
   context: <root>[ports]
   desc: Failed to validate item #0 in array.
-Error 35
+Error 24
   context: <root>
   desc: Failed to validate against schema associated with property name 'ports'.
 
@@ -332,7 +299,7 @@ Error 18
   desc: Failed to validate against schema associated with property name 'devices'.
 Error 19
   context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 20
   context: <root>[ports][0]
   desc: Failed to validate against child schema #0.
@@ -416,7 +383,7 @@ Error 18
   desc: Failed to validate against schema associated with property name 'devices'.
 Error 19
   context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 20
   context: <root>[ports][0]
   desc: Failed to validate against child schema #0.
@@ -457,186 +424,135 @@ Error 4
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against child schema #0.
 Error 5
-  context: <root>[ports][0][devices][0][channels][0][device_type]
+  context: <root>[ports][0][devices][0][channels][0]
   desc: Target should not validate against schema specified in 'not' constraint.
 Error 6
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
+  desc: Failed to validate against child schema #0.
 Error 7
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 8
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 9
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 'consists_of'.
-Error 10
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 11
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 12
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 13
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 14
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 15
   context: <root>[ports][0][devices][0][channels]
   desc: Failed to validate item #0 in array.
-Error 16
+Error 10
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against schema associated with property name 'channels'.
-Error 17
+Error 11
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against child schema #0.
-Error 18
+Error 12
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 19
+Error 13
   context: <root>[ports][0][devices]
   desc: Failed to validate item #0 in array.
-Error 20
+Error 14
   context: <root>[ports][0]
   desc: Failed to validate against schema associated with property name 'devices'.
-Error 21
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 22
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 23
-  context: <root>[ports][0]
-  desc: Missing required property 'port_type'.
-Error 24
+Error 15
   context: <root>[ports][0]
   desc: Failed to validate against child schema #1.
-Error 25
+Error 16
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #0.
+Error 17
   context: <root>[ports][0]
   desc: Missing required property 'port_type'.
-Error 26
+Error 18
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #1.
+Error 19
+  context: <root>[ports][0]
+  desc: Missing required property 'port_type'.
+Error 20
   context: <root>[ports][0]
   desc: Failed to validate against child schema #2.
-Error 27
+Error 21
   context: <root>[ports][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 28
+Error 22
   context: <root>[ports]
   desc: Failed to validate item #0 in array.
-Error 29
+Error 23
   context: <root>
   desc: Failed to validate against schema associated with property name 'ports'.
 
 Parsing config test/configs/unsuccessful/unsuccessful-5.json
 File: test/configs/unsuccessful/unsuccessful-5.json error: Validation failed.
 Error 1
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Failed to match against any enum values.
+  context: <root>[ports][0][devices][0][channels][0]
+  desc: Missing required property 's12'.
 Error 2
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
+  desc: Failed to validate against child schema #0.
 Error 3
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against child schema #0.
 Error 4
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Failed to match against any enum values.
+  context: <root>[ports][0][devices][0][channels][0]
+  desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 5
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
+  desc: Failed to validate against child schema #0.
 Error 6
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
+  desc: Target should not validate against schema specified in 'not' constraint.
 Error 7
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 's12'.
+  desc: Failed to validate against child schema #0.
 Error 8
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #2.
+  desc: Failed to validate against child schema #1.
 Error 9
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 10
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 11
-  context: <root>[ports][0][devices][0][channels][0][device_type]
-  desc: Target should not validate against schema specified in 'not' constraint.
-Error 12
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against schema associated with property name 'device_type'.
-Error 13
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 14
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 15
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 'consists_of'.
-Error 16
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 17
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 18
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #0.
-Error 19
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
-Error 20
-  context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 21
   context: <root>[ports][0][devices][0][channels]
   desc: Failed to validate item #0 in array.
-Error 22
+Error 11
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against schema associated with property name 'channels'.
-Error 23
+Error 12
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against child schema #0.
-Error 24
+Error 13
   context: <root>[ports][0][devices][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 25
+Error 14
   context: <root>[ports][0][devices]
   desc: Failed to validate item #0 in array.
-Error 26
+Error 15
   context: <root>[ports][0]
   desc: Failed to validate against schema associated with property name 'devices'.
-Error 27
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 28
-  context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
-Error 29
-  context: <root>[ports][0]
-  desc: Missing required property 'port_type'.
-Error 30
+Error 16
   context: <root>[ports][0]
   desc: Failed to validate against child schema #1.
-Error 31
+Error 17
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #0.
+Error 18
   context: <root>[ports][0]
   desc: Missing required property 'port_type'.
-Error 32
+Error 19
+  context: <root>[ports][0]
+  desc: Failed to validate against child schema #1.
+Error 20
+  context: <root>[ports][0]
+  desc: Missing required property 'port_type'.
+Error 21
   context: <root>[ports][0]
   desc: Failed to validate against child schema #2.
-Error 33
+Error 22
   context: <root>[ports][0]
   desc: Failed to validate against any child schemas allowed by oneOf constraint.
-Error 34
+Error 23
   context: <root>[ports]
   desc: Failed to validate item #0 in array.
-Error 35
+Error 24
   context: <root>
   desc: Failed to validate against schema associated with property name 'ports'.
 
@@ -648,7 +564,7 @@ Parsing config test/configs/unsuccessful/unsuccessful-8.json
 File: test/configs/unsuccessful/unsuccessful-8.json error: Validation failed.
 Error 1
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Missing required property 'device_type'.
+  desc: Failed to validate against any child schemas allowed by oneOf constraint.
 Error 2
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against child schema #0.
@@ -657,7 +573,7 @@ Error 3
   desc: Target should not validate against schema specified in 'not' constraint.
 Error 4
   context: <root>[ports][0][devices][0][channels][0]
-  desc: Failed to validate against child schema #1.
+  desc: Failed to validate against child schema #0.
 Error 5
   context: <root>[ports][0][devices][0][channels][0]
   desc: Failed to validate against child schema #1.
@@ -684,7 +600,7 @@ Error 12
   desc: Failed to validate against schema associated with property name 'devices'.
 Error 13
   context: <root>[ports][0]
-  desc: Failed to validate against child schema #0.
+  desc: Failed to validate against child schema #1.
 Error 14
   context: <root>[ports][0]
   desc: Failed to validate against child schema #0.

--- a/wb-mqtt-serial-device-template.schema.json
+++ b/wb-mqtt-serial-device-template.schema.json
@@ -161,87 +161,6 @@
       "required": ["device_type", "device"]
     },
 
-    "dlms_device_template": {
-      "allOf": [
-        { "$ref": "#/definitions/deviceProperties" },
-        { "$ref": "#/definitions/dlms_device_properties" },
-        { "$ref": "#/definitions/dlms_channels" },
-        { "$ref": "#/definitions/no_setup" },
-        { "$ref": "#/definitions/groups" },
-        {
-          "properties": {
-            "protocol": {
-              "type": "string",
-              "enum": ["dlms"]
-            },
-            "parameters": { "not" : {} },
-            "subdevices": { "not" : {} }
-          },
-          "required": ["protocol"]
-        }
-      ]
-    },
-
-    "somfy_device_template": {
-      "allOf": [
-        { "$ref": "#/definitions/deviceProperties" },
-        { "$ref": "#/definitions/no_setup" },
-        { "$ref": "#/definitions/common_channels" },
-        { "$ref": "#/definitions/somfy_device_properties" },
-        {
-          "properties": {
-            "protocol": {
-              "type": "string",
-              "enum": ["somfy"]
-            },
-            "parameters": { "not" : {} },
-            "subdevices": { "not" : {} }
-          },
-          "required": ["protocol"]
-        }
-      ]
-    },
-
-    "simple_device_template": {
-      "allOf": [
-        { "$ref": "#/definitions/deviceProperties" },
-        { "$ref": "#/definitions/no_setup" },
-        { "$ref": "#/definitions/common_channels" },
-        { "$ref": "#/definitions/groups" },
-        {
-          "properties": {
-            "protocol": {
-              "type": "string",
-              "enum": ["milur", "mercury230", "ivtm", "pulsar", "mercury200", "lls", "neva", "energomera_iec", "windeco", "dooya"]
-            },
-            "parameters": { "not" : {} },
-            "subdevices": { "not" : {} }
-          },
-          "required": ["protocol"]
-        }
-      ]
-    },
-
-    "simple_device_with_setup_template": {
-      "allOf": [
-        { "$ref": "#/definitions/deviceProperties" },
-        { "$ref": "#/definitions/common_channels" },
-        { "$ref": "#/definitions/common_setup" },
-        { "$ref": "#/definitions/groups" },
-        {
-          "properties": {
-            "protocol": {
-              "type": "string",
-              "enum": ["uniel", "s2k"]
-            }
-          },
-          "parameters": { "not" : {} },
-          "subdevices": { "not" : {} },
-          "required": ["protocol"]
-        }
-      ]
-    },
-
     "modbus_device_template": {
       "allOf": [
         { "$ref": "#/definitions/deviceProperties" },
@@ -274,11 +193,104 @@
     "title": { "$ref": "#/definitions/device_type" },
     "device": {
       "oneOf": [
-        { "$ref": "#/definitions/modbus_device_template" },
-        { "$ref": "#/definitions/simple_device_template" },
-        { "$ref": "#/definitions/simple_device_with_setup_template"},
-        { "$ref": "#/definitions/dlms_device_template" },
-        { "$ref": "#/definitions/somfy_device_template" }
+        {
+          "allOf": [
+            { "$ref": "#/definitions/deviceProperties" },
+            { "$ref": "#/definitions/no_setup" },
+            { "$ref": "#/definitions/common_channels" },
+            { "$ref": "#/definitions/groups" }
+          ],
+          "properties": {
+            "protocol": {
+              "type": "string",
+              "enum": ["milur", "mercury230", "ivtm", "pulsar", "mercury200", "lls", "neva", "energomera_iec", "windeco", "dooya"]
+            },
+            "parameters": { "not" : {} },
+            "subdevices": { "not" : {} }
+          },
+          "required": ["protocol"]
+        },
+
+        {
+          "allOf": [
+            { "$ref": "#/definitions/deviceProperties" },
+            { "$ref": "#/definitions/common_channels" },
+            { "$ref": "#/definitions/common_setup" },
+            { "$ref": "#/definitions/groups" }
+          ],
+          "properties": {
+            "protocol": {
+              "type": "string",
+              "enum": ["uniel", "s2k"]
+            }
+          },
+          "parameters": { "not" : {} },
+          "subdevices": { "not" : {} },
+          "required": ["protocol"]
+        },
+
+        {
+          "allOf": [
+            { "$ref": "#/definitions/deviceProperties" },
+            { "$ref": "#/definitions/dlms_device_properties" },
+            { "$ref": "#/definitions/dlms_channels" },
+            { "$ref": "#/definitions/no_setup" },
+            { "$ref": "#/definitions/groups" }
+          ],
+          "properties": {
+            "protocol": {
+              "type": "string",
+              "enum": ["dlms"]
+            },
+            "parameters": { "not" : {} },
+            "subdevices": { "not" : {} }
+          },
+          "required": ["protocol"]
+        },
+
+        {
+          "allOf": [
+            { "$ref": "#/definitions/deviceProperties" },
+            { "$ref": "#/definitions/no_setup" },
+            { "$ref": "#/definitions/common_channels" },
+            { "$ref": "#/definitions/somfy_device_properties" }
+          ],
+          "properties": {
+            "protocol": {
+              "type": "string",
+              "enum": ["somfy"]
+            },
+            "parameters": { "not" : {} },
+            "subdevices": { "not" : {} }
+          },
+          "required": ["protocol"]
+        },
+
+        {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "not": {
+                    "required": ["protocol"]
+                  }
+                },
+                {
+                  "properties": {
+                    "protocol": {
+                      "type": "string",
+                      "enum": ["modbus",  "modbus_io"]
+                    }
+                  },
+                  "required": ["protocol"]
+                }
+              ]
+            },
+            { "$ref": "#/definitions/deviceProperties" },
+            { "$ref": "#/definitions/subdevice_device" },
+            { "$ref": "#/definitions/groups" }
+          ]
+        }
       ]
     }
   },

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -54,7 +54,6 @@
       "title": "Serial port",
       "type": "object",
       "allOf": [
-        { "$ref" : "#/definitions/commonPortSettings"},
         {
           "properties": {
             "port_type": {
@@ -103,7 +102,8 @@
             }
           },
           "required": ["path"]
-        }
+        },
+        { "$ref" : "#/definitions/commonPortSettings"}
       ],
       "defaultProperties": ["port_type", "path", "baud_rate", "parity", "data_bits", "stop_bits", "devices", "poll_interval"],
       "_format": "grid",


### PR DESCRIPTION
1. При запуске не гружу все шаблоны через парсер json. Ищу название устройства в первых 5 строках файла. Выиграл больше секунды.
2. Перекомпоновал схемы проверки конфига и шаблонов так, чтобы лучше работали оптимизации проверки oneOf из новой libwbmqtt. Т.е. в каждом варианте был параметры из required и с выбором значения из enum. Тогда libwbmtt находит схему по ассоциативному массиву, а не пытается все схемы попробовать.