### PR TITLE
IDPAS is added to Energomera CE102M template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.22.2) stable; urgency=medium
+
+  * IDPAS parameter is added to Energomera CE102M device template
+  * Validation of custom channel's register addresses is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 23 Jul 2021 10:26:18 +0500
+
 wb-mqtt-serial (2.22.1) stable; urgency=medium
 
   * guard_interval_us description for web-interface is updated

--- a/test/energomera_ce102m_test.cpp
+++ b/test/energomera_ce102m_test.cpp
@@ -44,11 +44,6 @@ namespace
         void EnqueuePollRequests()
         {
             Expector()->Expect(
-                    ExpectVectorFromString("\x01R1\x02""ET0PE()\x03\x37"),
-                    ExpectVectorFromString("\x02""ET0PE(68.42)\r\n(45.54)\r\n(22.88)\r\n(0.00)\r\n(0.00)\r\n(0.00)\r\n\x03\x0f"),
-                    __func__);
-
-            Expector()->Expect(
                     ExpectVectorFromString("\x01R1\x02""CURRE()\x03\x5a"),
                     ExpectVectorFromString("\x02""CURRE(0.402)\r\n\x03\x60"),
                     __func__);
@@ -61,6 +56,11 @@ namespace
             Expector()->Expect(
                     ExpectVectorFromString("\x01R1\x02""VOLTA()\x03\x5f"),
                     ExpectVectorFromString("\x02""VOLTA(237.58)\r\n\x03\x28"),
+                    __func__);
+
+            Expector()->Expect(
+                    ExpectVectorFromString("\x01R1\x02""ET0PE()\x03\x37"),
+                    ExpectVectorFromString("\x02""ET0PE(68.42)\r\n(45.54)\r\n(22.88)\r\n(0.00)\r\n(0.00)\r\n(0.00)\r\n\x03\x0f"),
                     __func__);
         }
     };

--- a/wb-mqtt-serial-templates/config-energomera-ce102m.json
+++ b/wb-mqtt-serial-templates/config-energomera-ce102m.json
@@ -171,6 +171,12 @@
         "reg_type": "time",
         "address": "TIME_()",
         "enabled" : false
+      },
+      {
+        "name": "Address",
+        "reg_type": "default",
+        "address": "IDPAS()",
+        "enabled" : false
       }
     ]
   }


### PR DESCRIPTION
* IDPAS parameter in device template
* "default" register type is used instead of "item_1" if no reg_type is specified
* correct custom channels schema