### PR TITLE
WB-MS v2 template revert to 2.7.1 state

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.22.1-wb2) stable; urgency=medium
+
+  * WB-MS v2 template is reverted to v2.7.1 state. It will be updated in future releases.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 23 Aug 2021 16:39:33 +0500
+
 wb-mqtt-serial (2.22.1-wb1) stable; urgency=medium
 
   * WB-MAP templates are reverted to v2.7.1 state. They will be updated in future releases.

--- a/wb-mqtt-serial-templates/config-wb-ms_v2.json
+++ b/wb-mqtt-serial-templates/config-wb-ms_v2.json
@@ -6,22 +6,6 @@
         "max_read_registers": 0,
         "response_timeout_ms": 1,
         "frame_timeout_ms": 12,
-        "parameters": {
-          "in1_mode": {
-            "title": "Input 1 mode",
-            "address": 275,
-            "enum": [ 0, 1 ],
-            "default": 0,
-            "enum_titles": [ "1-Wire", "discrete input"]
-          },
-          "in2_mode": {
-            "title": "Input 2 mode",
-            "address": 276,
-            "enum": [ 0, 1 ],
-            "default": 0,
-            "enum_titles": [ "1-Wire", "discrete input"]
-          }
-        },
         "channels": [
             {
                 "name": "Temperature",
@@ -85,13 +69,6 @@
                 "reg_type": "input",
                 "address": 270,
                 "format": "u32"
-            },
-            {
-                "name": "Uptime",
-                "reg_type": "input",
-                "address": 104,
-                "format": "u32",
-                "enabled": false
             }
         ]
     }


### PR DESCRIPTION
Сравнил мастер и 2.7.1. У тех, шаблонов, где есть subdevices в master, только в MS v2 увидел конфликт.