### PR TITLE
Config's setup section priority is raised

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.22.1-wb4) stable; urgency=medium
+
+  * Config's setup section priority is raised. Setup registers in config have higher priority than 
+    setup registers with same addresses from device templates.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 02 Sep 2021 18:11:01 +0500
+
 wb-mqtt-serial (2.22.1-wb3) stable; urgency=medium
 
   * Compatibility with old configs is improved. Config validator will not raise an error if 

--- a/src/config_merge_template.cpp
+++ b/src/config_merge_template.cpp
@@ -11,11 +11,7 @@ void UpdateChannels(Json::Value& dst, const Json::Value& userConfig, ITemplateMa
 
 void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config)
 {
-    if (!deviceTemplate.isMember("setup")) {
-        deviceTemplate["setup"] = Json::Value(Json::arrayValue);
-    }
-
-    auto& newSetup = deviceTemplate["setup"];
+    Json::Value newSetup(Json::arrayValue);
 
     if (config.isMember("setup")) {
         for (const auto& item: config["setup"]) {
@@ -41,8 +37,16 @@ void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config)
         }
     }
 
+    if (deviceTemplate.isMember("setup")) {
+        for (const auto& item: deviceTemplate["setup"]) {
+            newSetup.append(item);
+        }
+    }
+
     if (newSetup.empty()) {
         deviceTemplate.removeMember("setup");
+    } else {
+        deviceTemplate["setup"] = newSetup;
     }
 }
 

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -157,6 +157,20 @@ namespace {
         return deviceConfig.TypeMap->GetDefaultType();
     }
 
+    struct TLoadingContext
+    {
+        std::string             name_prefix;
+        std::string             mqtt_prefix;
+        const IDeviceFactory&   factory;
+        const IRegisterAddress& device_base_address;
+        size_t                  stride = 0;
+
+        TLoadingContext(const IDeviceFactory& f, const IRegisterAddress& base_address)
+            : factory(f),
+              device_base_address(base_address)
+        {}
+    };
+
     struct TLoadRegisterConfigResult
     {
         PRegisterConfig RegisterConfig;
@@ -165,10 +179,8 @@ namespace {
 
     TLoadRegisterConfigResult LoadRegisterConfig(const Json::Value&      register_data,
                                                  const TDeviceConfig&    device_config,
-                                                 const IRegisterAddress& device_base_address,
-                                                 size_t                  stride,
-                                                 const IDeviceFactory&   deviceFactory,
-                                                 const std::string&      readonly_override_error_message_prefix)
+                                                 const std::string&      readonly_override_error_message_prefix,
+                                                 const TLoadingContext&  context)
     {
         TLoadRegisterConfigResult res;
         TRegisterType regType = GetRegisterType(register_data, device_config);
@@ -200,10 +212,10 @@ namespace {
             unsupported_value = std::make_unique<uint64_t>(ToUint64(register_data["unsupported_value"], "unsupported_value"));
         }
 
-        auto address = deviceFactory.GetRegisterAddressFactory().LoadRegisterAddress(register_data,
-                                                                                     device_base_address,
-                                                                                     stride, 
-                                                                                     RegisterFormatByteWidth(regType.DefaultFormat));
+        auto address = context.factory.GetRegisterAddressFactory().LoadRegisterAddress(register_data,
+                                                                                       context.device_base_address,
+                                                                                       context.stride, 
+                                                                                       RegisterFormatByteWidth(regType.DefaultFormat));
 
         res.RegisterConfig = TRegisterConfig::Create(
             regType.Index, address.Address, regType.DefaultFormat, scale, offset,
@@ -216,20 +228,16 @@ namespace {
 
     void LoadSimpleChannel(TDeviceConfig*          device_config,
                            const Json::Value&      channel_data,
-                           const IRegisterAddress& device_base_address,
-                           size_t                  stride,
-                           const std::string&      name_prefix,
-                           const std::string&      mqtt_prefix,
-                           const IDeviceFactory&   device_factory)
+                           const TLoadingContext&  context)
     {
         std::string name(channel_data["name"].asString());
         std::string mqtt_channel_name(name);
         Get(channel_data, "id", mqtt_channel_name);
-        if (!mqtt_prefix.empty()) {
-            mqtt_channel_name = mqtt_prefix + " " + mqtt_channel_name;
+        if (!context.mqtt_prefix.empty()) {
+            mqtt_channel_name = context.mqtt_prefix + " " + mqtt_channel_name;
         }
-        if (!name_prefix.empty()) {
-            name = name_prefix + " " + name;
+        if (!context.name_prefix.empty()) {
+            name = context.name_prefix + " " + name;
         }
         auto errorMsgPrefix = "Channel \"" + mqtt_channel_name + "\"";
         std::string default_type_str;
@@ -240,7 +248,7 @@ namespace {
 
             const Json::Value& reg_data = channel_data["consists_of"];
             for(Json::ArrayIndex i = 0; i < reg_data.size(); ++i) {
-                auto reg = LoadRegisterConfig(reg_data[i], *device_config, device_base_address, stride, device_factory, errorMsgPrefix);
+                auto reg = LoadRegisterConfig(reg_data[i], *device_config, errorMsgPrefix, context);
                 /* the poll_interval specified for the specific register has a precedence over the one specified for the compound channel */
                 if ((reg.RegisterConfig->PollInterval.count() < 0) && (poll_interval.count() >= 0))
                     reg.RegisterConfig->PollInterval = poll_interval;
@@ -252,7 +260,7 @@ namespace {
                                                 "in one channel -- ") + device_config->DeviceType);
             }
         } else {
-            auto reg = LoadRegisterConfig(channel_data, *device_config, device_base_address, stride, device_factory, errorMsgPrefix);
+            auto reg = LoadRegisterConfig(channel_data, *device_config, errorMsgPrefix, context);
             default_type_str = reg.DefaultControlType;
             registers.push_back(reg.RegisterConfig);
         }
@@ -296,97 +304,79 @@ namespace {
 
     void LoadChannel(TDeviceConfig*          device_config,
                      const Json::Value&      channel_data,
-                     const IRegisterAddress& device_base_address,
-                     const IDeviceFactory&   device_factory,
-                     size_t                  stride              = 0,
-                     const std::string&      name_prefix         = "",
-                     const std::string&      mqtt_prefix         = "");
+                     const TLoadingContext&  context);
 
     void LoadSetupItem(TDeviceConfig*          device_config,
                        const Json::Value&      item_data,
-                       const IRegisterAddress& device_base_address,
-                       size_t                  stride,
-                       const std::string&      name_prefix,
-                       const IDeviceFactory&   device_factory);
+                       const TLoadingContext&  context);
 
     void LoadSubdeviceChannel(TDeviceConfig*          device_config,
                               const Json::Value&      channel_data,
-                              const IRegisterAddress& device_base_address,
-                              const std::string&      name_prefix,
-                              const std::string&      mqtt_prefix,
-                              const IDeviceFactory&   device_factory)
+                              const TLoadingContext&  context)
     {
-        std::string new_name_prefix(channel_data["name"].asString());
-        if (!name_prefix.empty()) {
-            new_name_prefix = name_prefix + " " + new_name_prefix;
-        }
-
-        std::string mqtt_channel_prefix(channel_data["name"].asString());
-        Get(channel_data, "id", mqtt_channel_prefix);
-        if (!mqtt_prefix.empty()) {
-            if (mqtt_channel_prefix.empty()) {
-                mqtt_channel_prefix = mqtt_prefix;
-            } else {
-                mqtt_channel_prefix = mqtt_prefix + " " + mqtt_channel_prefix;
-            }
-        }
-
         int shift = 0;
         if (channel_data.isMember("shift")) {
             shift = GetInt(channel_data, "shift");
         }
-        std::unique_ptr<IRegisterAddress> baseAddress(device_base_address.CalcNewAddress(shift, 0, 0, 0));
+        std::unique_ptr<IRegisterAddress> baseAddress(context.device_base_address.CalcNewAddress(shift, 0, 0, 0));
 
-        size_t stride = Read(channel_data, "stride", 0);
+        TLoadingContext newContext(context.factory, *baseAddress);
+        newContext.name_prefix = channel_data["name"].asString();
+        if (!context.name_prefix.empty()) {
+            newContext.name_prefix = context.name_prefix + " " + newContext.name_prefix;
+        }
+
+        newContext.mqtt_prefix = channel_data["name"].asString();
+        Get(channel_data, "id", newContext.mqtt_prefix);
+        if (!context.mqtt_prefix.empty()) {
+            if (newContext.mqtt_prefix.empty()) {
+                newContext.mqtt_prefix = context.mqtt_prefix;
+            } else {
+                newContext.mqtt_prefix = context.mqtt_prefix + " " + newContext.mqtt_prefix;
+            }
+        }
+
+        newContext.stride = Read(channel_data, "stride", 0);
         if (channel_data.isMember("setup")) {
             for(const auto& setupItem: channel_data["setup"])
-                LoadSetupItem(device_config, setupItem, *baseAddress, stride, new_name_prefix, device_factory);
+                LoadSetupItem(device_config, setupItem, newContext);
         }
 
 
         if (channel_data.isMember("channels")) {
             for (const auto& ch: channel_data["channels"]) {
-                LoadChannel(device_config, ch, *baseAddress, device_factory, stride, new_name_prefix, mqtt_channel_prefix);
+                LoadChannel(device_config, ch, newContext);
             }
         }
     }
 
     void LoadChannel(TDeviceConfig*          device_config,
                      const Json::Value&      channel_data,
-                     const IRegisterAddress& device_base_address,
-                     const IDeviceFactory&   device_factory,
-                     size_t                  stride,
-                     const std::string&      name_prefix,
-                     const std::string&      mqtt_prefix)
+                     const TLoadingContext&  context)
     {
         if (channel_data.isMember("enabled") && !channel_data["enabled"].asBool()) {
             return;
         }
 
         if (channel_data.isMember("device_type")) {
-            LoadSubdeviceChannel(device_config, channel_data, device_base_address, name_prefix, mqtt_prefix, device_factory);
+            LoadSubdeviceChannel(device_config, channel_data, context);
         } else {
-            LoadSimpleChannel(device_config, channel_data, device_base_address, stride, name_prefix, mqtt_prefix, device_factory);
+            LoadSimpleChannel(device_config, channel_data, context);
         }
     }
 
     void LoadSetupItem(TDeviceConfig*          device_config,
                        const Json::Value&      item_data,
-                       const IRegisterAddress& device_base_address,
-                       size_t                  stride,
-                       const std::string&      name_prefix,
-                       const IDeviceFactory&   device_factory)
+                       const TLoadingContext&  context)
     {
         std::string name(Read(item_data, "title", std::string("<unnamed>")));
-        if (!name_prefix.empty()) {
-            name = name_prefix + " " + name;
+        if (!context.name_prefix.empty()) {
+            name = context.name_prefix + " " + name;
         }
         auto reg = LoadRegisterConfig(item_data,
                                       *device_config,
-                                      device_base_address,
-                                      stride,
-                                      device_factory,
-                                      "Setup item \"" + name + "\"");
+                                      "Setup item \"" + name + "\"",
+                                      context);
         const auto& valueItem = item_data["value"];
         // libjsoncpp uses format "%.17g" in asString() and outputs strings with additional small numbers
         auto value = valueItem.isDouble() ? WBMQTT::StringFormat("%.15g", valueItem.asDouble()) : valueItem.asString();
@@ -396,14 +386,13 @@ namespace {
     void LoadDeviceTemplatableConfigPart(TDeviceConfig*          device_config,
                                          const Json::Value&      device_data,
                                          PRegisterTypeMap        registerTypes,
-                                         const IRegisterAddress& base_register_address,
-                                         const IDeviceFactory&   device_factory)
+                                         const TLoadingContext&  context)
     {
         device_config->TypeMap  = registerTypes;
 
         if (device_data.isMember("setup")) {
             for(const auto& setupItem: device_data["setup"])
-                LoadSetupItem(device_config, setupItem, base_register_address, 0, "", device_factory);
+                LoadSetupItem(device_config, setupItem, context);
         }
 
         if (device_data.isMember("password")) {
@@ -433,7 +422,7 @@ namespace {
 
         if (device_data.isMember("channels")) {
             for (const auto& channel_data: device_data["channels"]) {
-                LoadChannel(device_config, channel_data, base_register_address, device_factory);
+                LoadChannel(device_config, channel_data, context);
             }
         }
     }
@@ -1068,7 +1057,8 @@ PDeviceConfig LoadBaseDeviceConfig(const Json::Value&             dev,
             res->SlaveId = std::to_string(dev["slave_id"].asInt());
     }
 
-    LoadDeviceTemplatableConfigPart(res.get(), dev, protocol->GetRegTypes(), factory.GetRegisterAddressFactory().GetBaseRegisterAddress(), factory);
+    TLoadingContext context(factory, factory.GetRegisterAddressFactory().GetBaseRegisterAddress());
+    LoadDeviceTemplatableConfigPart(res.get(), dev, protocol->GetRegTypes(), context);
 
     if (res->DeviceChannelConfigs.empty())
         throw TConfigParserException("the device has no channels: " + res->Name);

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -263,6 +263,7 @@ struct TDeviceConfigLoadParams
     std::chrono::microseconds DefaultRequestDelay;
     std::chrono::milliseconds PortResponseTimeout;
     std::chrono::milliseconds DefaultPollInterval;
+    std::string               DeviceTemplateTitle;
 };
 
 PDeviceConfig LoadBaseDeviceConfig(const Json::Value&             deviceData,

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -106,13 +106,13 @@ struct TDeviceConfig
 
     int NextOrderValue() const;
     void AddChannel(PDeviceChannelConfig channel);
-    void AddSetupItem(PDeviceSetupItemConfig item);
+    void AddSetupItem(PDeviceSetupItemConfig item, const std::string& deviceTemplateTitle = std::string());
 
     std::string GetDescription() const;
 
 private:
     // map key is setup item address
-    std::unordered_map<std::string, std::string> SetupItemsByAddress;
+    std::unordered_map<std::string, PDeviceSetupItemConfig> SetupItemsByAddress;
 };
 
 typedef std::shared_ptr<TDeviceConfig> PDeviceConfig;

--- a/test/TConfigParserTest.Parse.dat
+++ b/test/TConfigParserTest.Parse.dat
@@ -980,6 +980,13 @@ Ports:
             Reg type: holding (0)
             Reg format: U16
             ------
+            Name: Sub s1
+            Address: 20100
+            Value: 63
+            RawValue: 0x3f
+            Reg type: holding (0)
+            Reg format: U16
+            ------
             Name: Sub s2
             Address: 10092
             Value: 0xfff2
@@ -998,13 +1005,6 @@ Ports:
             Address: 10095
             Value: 10
             RawValue: 0x05
-            Reg type: holding (0)
-            Reg format: U16
-            ------
-            Name: Sub s1
-            Address: 20100
-            Value: 63
-            RawValue: 0x3f
             Reg type: holding (0)
             Reg format: U16
             ------
@@ -1036,17 +1036,17 @@ Ports:
             Reg type: coil (2)
             Reg format: S32
             ------
-            Name: Sub2 c3 s21
-            Address: 20502
-            Value: 0xfff2
-            RawValue: 0xfff2
-            Reg type: holding (0)
-            Reg format: U16
-            ------
             Name: Sub2 c3 s22
             Address: 10494
             Value: 111
             RawValue: 0x6f
+            Reg type: holding (0)
+            Reg format: U16
+            ------
+            Name: Sub2 c3 s21
+            Address: 20502
+            Value: 0xfff2
+            RawValue: 0xfff2
             Reg type: holding (0)
             Reg format: U16
     ------

--- a/test/TConfigParserTest.SameSetupItems.dat
+++ b/test/TConfigParserTest.SameSetupItems.dat
@@ -1,0 +1,63 @@
+Debug: 0
+PublishParams: 0 0
+Ports:
+    ------
+    ConnSettings: </dev/ttyNSC0 9600 8 N 1>
+    ConnectionMaxFailCycles: 2
+    MaxFailTime: 5000
+    PollInterval: 20
+    GuardInterval: 0
+    Response timeout: -1
+    DeviceConfigs:
+        ------
+        Id: with setup_2
+        Name: with setup 2
+        SlaveId: 2
+        MaxRegHole: 0
+        MaxBitHole: 0
+        MaxReadRegisters: 1
+        GuardInterval: 0
+        DeviceTimeout: 3000
+        Response timeout: 500
+        Frame timeout: 20
+        DeviceChannels:
+            ------
+            Name: Temperature
+            Type: text
+            MqttId: Temperature
+            DeviceId: with setup_2
+            Order: 1
+            OnValue: 
+            Max: not set
+            Min: not set
+            Precision: 0
+            ReadOnly: 1
+            Registers:
+                ------
+                Type and Address: input: 1284
+                Format: S32
+                Scale: 1
+                Offset: 0
+                RoundTo: 0
+                Poll: 1
+                ReadOnly: 1
+                TypeName: input
+                PollInterval: 20
+                ErrorValue: not set
+                UnsupportedValue: not set
+                WordOrder: BigEndian
+        SetupItems:
+            ------
+            Name: s2 override
+            Address: 9992
+            Value: 100
+            RawValue: 0x64
+            Reg type: holding (0)
+            Reg format: U16
+            ------
+            Name: s3
+            Address: 9995
+            Value: 10
+            RawValue: 0x05
+            Reg type: holding (0)
+            Reg format: U16

--- a/test/configs/parse_test_setup.json
+++ b/test/configs/parse_test_setup.json
@@ -1,0 +1,21 @@
+{
+    "debug": false,
+    "ports": [
+        {
+            "path" : "/dev/ttyNSC0",
+            "devices" : [
+                {
+                    "device_type" : "with setup",
+                    "slave_id": 2,
+                    "setup": [
+                        {
+                            "title" : "s2 override",
+                            "address": 9992,
+                            "value": 100
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/device-templates/config-setup-items.json
+++ b/test/device-templates/config-setup-items.json
@@ -1,0 +1,28 @@
+{
+    "device_type": "with setup",
+    "device": {
+        "name": "with setup",
+        "id": "with setup",
+        "channels": [
+            {
+                "name": "Temperature",
+                "reg_type": "input",
+                "format": "s32",
+                "address": "0x0504"
+            }
+        ],
+        "setup": [
+            {
+                "title": "s2",
+                "address": 9992,
+                "value": "0xfff2"
+            },
+            {
+                "title": "s3",
+                "address": 9995,
+                "value": 10,
+                "scale": 2
+            }
+        ]
+    }
+}

--- a/test/parser_test/merge_template_res3.json
+++ b/test/parser_test/merge_template_res3.json
@@ -27,6 +27,11 @@
     "setup" : 
     [
         {
+            "address" : 50000,
+            "title" : "new setup",
+            "value" : "0xffff"
+        },
+        {
             "address" : 10000,
             "title" : "IODIR",
             "value" : "0xffff"
@@ -35,11 +40,6 @@
             "address" : 9999,
             "title" : "CONFIG-FLAG",
             "value" : 1
-        },
-        {
-                "address" : 50000,
-                "title" : "new setup",
-                "value" : "0xffff"
         }
     ],
     "slave_id" : 2

--- a/test/parser_test/merge_template_res5.json
+++ b/test/parser_test/merge_template_res5.json
@@ -37,6 +37,11 @@
             "setup" : 
             [
                 {
+                    "address" : 20000,
+                    "title" : "31",
+                    "value" : "0xffff"
+                },
+                {
                     "address" : 10000,
                     "title" : "s1",
                     "value" : "0xffff"
@@ -45,11 +50,6 @@
                     "address" : 9999,
                     "title" : "s2",
                     "value" : 1
-                },
-                {
-                        "address" : 20000,
-                        "title" : "31",
-                        "value" : "0xffff"
                 }
 
             ]

--- a/test/parser_test/merge_template_res7.json
+++ b/test/parser_test/merge_template_res7.json
@@ -39,6 +39,11 @@
                                         "setup" : 
                                         [
                                                 {
+                                                        "address" : 25000,
+                                                        "title" : "31",
+                                                        "value" : "0xffff"
+                                                },
+                                                {
                                                         "address" : 20000,
                                                         "title" : "s12",
                                                         "value" : "0xfff2"
@@ -47,11 +52,6 @@
                                                         "address" : 9992,
                                                         "title" : "s22",
                                                         "value" : 2
-                                                },
-                                                {
-                                                        "address" : 25000,
-                                                        "title" : "31",
-                                                        "value" : "0xffff"
                                                 }
                                         ],
                                         "shift" : 200

--- a/test/serial_config_test.cpp
+++ b/test/serial_config_test.cpp
@@ -22,124 +22,135 @@ class TConfigParserTest: public TLoggedFixture
             RegisterProtocols(DeviceFactory);
             TFakeSerialDevice::Register(DeviceFactory);
         }
+
+        void PrintConfig(PHandlerConfig config)
+        {
+            Emit() << "Debug: " << config->Debug;
+            Emit() << "PublishParams: " << config->PublishParameters.Policy << " " << config->PublishParameters.PublishUnchangedInterval.count();
+            Emit() << "Ports:";
+            for (auto port_config: config->PortConfigs) {
+                TTestLogIndent indent(*this);
+                Emit() << "------";
+                Emit() << "ConnSettings: " << port_config->Port->GetDescription();
+                Emit() << "ConnectionMaxFailCycles: " << port_config->OpenCloseSettings.ConnectionMaxFailCycles;
+                Emit() << "MaxFailTime: " << port_config->OpenCloseSettings.MaxFailTime.count();
+                Emit() << "PollInterval: " << port_config->PollInterval.count();
+                Emit() << "GuardInterval: " << port_config->RequestDelay.count();
+                Emit() << "Response timeout: " << port_config->ResponseTimeout.count();
+
+                if (port_config->Devices.empty()) {
+                    Emit() << "No device configs.";
+                    continue;
+                }
+                Emit() << "DeviceConfigs:";
+                for (auto device: port_config->Devices) {
+                    auto device_config = device->DeviceConfig();
+                    TTestLogIndent indent(*this);
+                    Emit() << "------";
+                    Emit() << "Id: " << device_config->Id;
+                    Emit() << "Name: " << device_config->Name;
+                    Emit() << "SlaveId: " << device_config->SlaveId;
+                    Emit() << "MaxRegHole: " << device_config->MaxRegHole;
+                    Emit() << "MaxBitHole: " << device_config->MaxBitHole;
+                    Emit() << "MaxReadRegisters: " << device_config->MaxReadRegisters;
+                    Emit() << "GuardInterval: " << device_config->RequestDelay.count();
+                    Emit() << "DeviceTimeout: " << device_config->DeviceTimeout.count();
+                    Emit() << "Response timeout: " << device_config->ResponseTimeout.count();
+                    Emit() << "Frame timeout: " << device_config->FrameTimeout.count();
+                    if (!device_config->DeviceChannelConfigs.empty()) {
+                        Emit() << "DeviceChannels:";
+                        for (auto device_channel: device_config->DeviceChannelConfigs) {
+                            TTestLogIndent indent(*this);
+                            Emit() << "------";
+                            Emit() << "Name: " << device_channel->Name;
+                            Emit() << "Type: " << device_channel->Type;
+                            Emit() << "MqttId: " << device_channel->MqttId;
+                            Emit() << "DeviceId: " << device_channel->DeviceId;
+                            Emit() << "Order: " << device_channel->Order;
+                            Emit() << "OnValue: " << device_channel->OnValue;
+                            if (!device_channel->OffValue.empty()) {
+                                Emit() << "OffValue: " << device_channel->OffValue;
+                            }
+                            if (isnan(device_channel->Max)) {
+                                Emit() << "Max: not set";
+                            } else {
+                                Emit() << "Max: " << device_channel->Max;
+                            }
+                            if (isnan(device_channel->Min)) {
+                                Emit() << "Min: not set";
+                            } else {
+                                Emit() << "Min: " << device_channel->Min;
+                            }
+                            Emit() << "Precision: " << device_channel->Precision;
+                            Emit() << "ReadOnly: " << device_channel->ReadOnly;
+                            if (!device_channel->RegisterConfigs.empty()) {
+                                Emit() << "Registers:";
+                            }
+                            for (auto reg: device_channel->RegisterConfigs) {
+                                TTestLogIndent indent(*this);
+                                Emit() << "------";
+                                Emit() << "Type and Address: " << reg;
+                                Emit() << "Format: " << RegisterFormatName(reg->Format);
+                                Emit() << "Scale: " << reg->Scale;
+                                Emit() << "Offset: " << reg->Offset;
+                                Emit() << "RoundTo: " << reg->RoundTo;
+                                Emit() << "Poll: " << reg->Poll;
+                                Emit() << "ReadOnly: " << reg->ReadOnly;
+                                Emit() << "TypeName: " << reg->TypeName;
+                                Emit() << "PollInterval: " << reg->PollInterval.count();
+                                if (reg->ErrorValue) {
+                                    Emit() << "ErrorValue: " << *reg->ErrorValue;
+                                } else {
+                                    Emit() << "ErrorValue: not set";
+                                }
+                                if (reg->UnsupportedValue) {
+                                    Emit() << "UnsupportedValue: " << *reg->UnsupportedValue;
+                                } else {
+                                    Emit() << "UnsupportedValue: not set";
+                                }
+                                Emit() << "WordOrder: " << reg->WordOrder;
+                            }
+                        }
+
+                        if (device_config->SetupItemConfigs.empty())
+                            continue;
+
+                        Emit() << "SetupItems:";
+                        for (auto setup_item: device_config->SetupItemConfigs) {
+                            TTestLogIndent indent(*this);
+                            Emit() << "------";
+                            Emit() << "Name: " << setup_item->GetName();
+                            Emit() << "Address: " << setup_item->GetRegisterConfig()->GetAddress();
+                            Emit() << "Value: " << setup_item->GetValue();
+                            Emit() << "RawValue: 0x" << std::setfill('0') << std::setw(2) << std::hex << setup_item->GetRawValue();
+                            Emit() << "Reg type: " <<  setup_item->GetRegisterConfig()->TypeName << " (" << setup_item->GetRegisterConfig()->Type << ")";
+                            Emit() << "Reg format: " << RegisterFormatName(setup_item->GetRegisterConfig()->Format);
+                        }
+                    }
+                }
+            }
+        }
+
+        PHandlerConfig GetConfig(const std::string& filePath)
+        {
+            Json::Value configSchema = LoadConfigSchema(GetDataFilePath("../wb-mqtt-serial.schema.json"));
+            TTemplateMap templateMap(GetDataFilePath("device-templates/"),
+                                    LoadConfigTemplatesSchema(GetDataFilePath("../wb-mqtt-serial-device-template.schema.json"),
+                                                                                    configSchema));
+
+            return LoadConfig(GetDataFilePath(filePath), DeviceFactory, configSchema, templateMap);
+        }
 };
 
 TEST_F(TConfigParserTest, Parse)
 {
-    Json::Value configSchema = LoadConfigSchema(GetDataFilePath("../wb-mqtt-serial.schema.json"));
-    TTemplateMap templateMap(GetDataFilePath("device-templates/"),
-                             LoadConfigTemplatesSchema(GetDataFilePath("../wb-mqtt-serial-device-template.schema.json"), 
-                                                                             configSchema));
+    PrintConfig(GetConfig("configs/parse_test.json"));
+}
 
-    PHandlerConfig config = LoadConfig(GetDataFilePath("configs/parse_test.json"), 
-                                                       DeviceFactory,
-                                                       configSchema,
-                                                       templateMap);
-
-    Emit() << "Debug: " << config->Debug;
-    Emit() << "PublishParams: " << config->PublishParameters.Policy << " " << config->PublishParameters.PublishUnchangedInterval.count();
-    Emit() << "Ports:";
-    for (auto port_config: config->PortConfigs) {
-        TTestLogIndent indent(*this);
-        Emit() << "------";
-        Emit() << "ConnSettings: " << port_config->Port->GetDescription();
-        Emit() << "ConnectionMaxFailCycles: " << port_config->OpenCloseSettings.ConnectionMaxFailCycles;
-        Emit() << "MaxFailTime: " << port_config->OpenCloseSettings.MaxFailTime.count();
-        Emit() << "PollInterval: " << port_config->PollInterval.count();
-        Emit() << "GuardInterval: " << port_config->RequestDelay.count();
-        Emit() << "Response timeout: " << port_config->ResponseTimeout.count();
-
-        if (port_config->Devices.empty()) {
-            Emit() << "No device configs.";
-            continue;
-        }
-        Emit() << "DeviceConfigs:";
-        for (auto device: port_config->Devices) {
-            auto device_config = device->DeviceConfig();
-            TTestLogIndent indent(*this);
-            Emit() << "------";
-            Emit() << "Id: " << device_config->Id;
-            Emit() << "Name: " << device_config->Name;
-            Emit() << "SlaveId: " << device_config->SlaveId;
-            Emit() << "MaxRegHole: " << device_config->MaxRegHole;
-            Emit() << "MaxBitHole: " << device_config->MaxBitHole;
-            Emit() << "MaxReadRegisters: " << device_config->MaxReadRegisters;
-            Emit() << "GuardInterval: " << device_config->RequestDelay.count();
-            Emit() << "DeviceTimeout: " << device_config->DeviceTimeout.count();
-            Emit() << "Response timeout: " << device_config->ResponseTimeout.count();
-            Emit() << "Frame timeout: " << device_config->FrameTimeout.count();
-            if (!device_config->DeviceChannelConfigs.empty()) {
-                Emit() << "DeviceChannels:";
-                for (auto device_channel: device_config->DeviceChannelConfigs) {
-                    TTestLogIndent indent(*this);
-                    Emit() << "------";
-                    Emit() << "Name: " << device_channel->Name;
-                    Emit() << "Type: " << device_channel->Type;
-                    Emit() << "MqttId: " << device_channel->MqttId;
-                    Emit() << "DeviceId: " << device_channel->DeviceId;
-                    Emit() << "Order: " << device_channel->Order;
-                    Emit() << "OnValue: " << device_channel->OnValue;
-                    if (!device_channel->OffValue.empty()) {
-                        Emit() << "OffValue: " << device_channel->OffValue;
-                    }
-                    if (isnan(device_channel->Max)) {
-                        Emit() << "Max: not set";
-                    } else {
-                        Emit() << "Max: " << device_channel->Max;
-                    }
-                    if (isnan(device_channel->Min)) {
-                        Emit() << "Min: not set";
-                    } else {
-                        Emit() << "Min: " << device_channel->Min;
-                    }
-                    Emit() << "Precision: " << device_channel->Precision;
-                    Emit() << "ReadOnly: " << device_channel->ReadOnly;
-                    if (!device_channel->RegisterConfigs.empty()) {
-                        Emit() << "Registers:";
-                    }
-                    for (auto reg: device_channel->RegisterConfigs) {
-                        TTestLogIndent indent(*this);
-                        Emit() << "------";
-                        Emit() << "Type and Address: " << reg;
-                        Emit() << "Format: " << RegisterFormatName(reg->Format);
-                        Emit() << "Scale: " << reg->Scale;
-                        Emit() << "Offset: " << reg->Offset;
-                        Emit() << "RoundTo: " << reg->RoundTo;
-                        Emit() << "Poll: " << reg->Poll;
-                        Emit() << "ReadOnly: " << reg->ReadOnly;
-                        Emit() << "TypeName: " << reg->TypeName;
-                        Emit() << "PollInterval: " << reg->PollInterval.count();
-                        if (reg->ErrorValue) {
-                            Emit() << "ErrorValue: " << *reg->ErrorValue;
-                        } else {
-                            Emit() << "ErrorValue: not set";
-                        }
-                        if (reg->UnsupportedValue) {
-                            Emit() << "UnsupportedValue: " << *reg->UnsupportedValue;
-                        } else {
-                            Emit() << "UnsupportedValue: not set";
-                        }
-                        Emit() << "WordOrder: " << reg->WordOrder;
-                    }
-                }
-
-                if (device_config->SetupItemConfigs.empty())
-                    continue;
-
-                Emit() << "SetupItems:";
-                for (auto setup_item: device_config->SetupItemConfigs) {
-                    TTestLogIndent indent(*this);
-                    Emit() << "------";
-                    Emit() << "Name: " << setup_item->GetName();
-                    Emit() << "Address: " << setup_item->GetRegisterConfig()->GetAddress();
-                    Emit() << "Value: " << setup_item->GetValue();
-                    Emit() << "RawValue: 0x" << std::setfill('0') << std::setw(2) << std::hex << setup_item->GetRawValue();
-                    Emit() << "Reg type: " <<  setup_item->GetRegisterConfig()->TypeName << " (" << setup_item->GetRegisterConfig()->Type << ")";
-                    Emit() << "Reg format: " << RegisterFormatName(setup_item->GetRegisterConfig()->Format);
-                }
-            }
-        }
-    }
+TEST_F(TConfigParserTest, SameSetupItems)
+{
+    // Check that setup registers in config have higher priority than setup registers with same addresses from template
+    PrintConfig(GetConfig("configs/parse_test_setup.json"));
 }
 
 TEST_F(TConfigParserTest, UnsuccessfulParse)


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-mqtt-serial/pull/261

Setup registers in config have higher priority than setup registers with same addresses from device templates.