### PR TITLE
Compatibility with old configs is improved.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.31.1) stable; urgency=medium
+
+  * Compatibility with old configs is improved. Config validator will not raise an error if 
+    protocol property set simultaneously with device_type is same as defined in template.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 02 Sep 2021 12:38:17 +0500
+
 wb-mqtt-serial (2.31.0) stable; urgency=medium
 
   * Remake of MAP12E-fw2 template using groups and parameters

--- a/src/confed_schema_generator.cpp
+++ b/src/confed_schema_generator.cpp
@@ -38,7 +38,7 @@ namespace
     //  {
     //      "type": "string",
     //      "enum": [ VALUE ],
-    //      "default": VALUE
+    //      "default": VALUE,
     //      "options": { "hidden": true }
     //  }
     Json::Value MakeHiddenPropery(const std::string& value)
@@ -67,6 +67,24 @@ namespace
         Json::Value r;
         r["properties"]["name"] = MakeHiddenPropery(name);
         MakeArray("required", r).append("name");
+        return r;
+    }
+
+    //  {
+    //      "properties": {
+    //          "protocol": {
+    //              "type": "string",
+    //              "options": {
+    //                  "hidden": true
+    //              }
+    //          }
+    //      }
+    //  }
+    Json::Value MakeProtocolProperty()
+    {
+        Json::Value r;
+        r["properties"]["protocol"]["type"] = "string";
+        r["properties"]["protocol"]["options"]["hidden"] = true;
         return r;
     }
 
@@ -499,7 +517,8 @@ namespace
     //                  }
     //              },
     //              "allOf": [
-    //                  { "$ref": PROTOCOL_PARAMETERS }
+    //                  { "$ref": PROTOCOL_PARAMETERS },
+    //                  { HIDDEN_PROTOCOL }
     //              ],
     //              "properties": {
     //                  "standard_channels": STANDARD_CHANNELS_SCHEMA,
@@ -539,6 +558,7 @@ namespace
         auto& allOf = MakeArray("allOf", pr);
         auto protocol = GetProtocolName(schema);
         Append(allOf)["$ref"] = deviceFactory.GetCommonDeviceSchemaRef(protocol);
+        allOf.append(MakeProtocolProperty());
 
         if (!deviceFactory.GetProtocol(protocol)->SupportsBroadcast()) {
             MakeArray("required", pr).append("slave_id");

--- a/src/config_merge_template.cpp
+++ b/src/config_merge_template.cpp
@@ -206,8 +206,13 @@ Json::Value MergeDeviceConfigWithTemplate(const Json::Value& deviceData,
         res["id"] = deviceTemplate["id"].asString() + DecorateIfNotEmpty("_", deviceData["slave_id"].asString());
     }
 
+    if (deviceData.isMember("protocol")) {
+        LOG(Warn) << "\"" << deviceName << "\" has \"protocol\" property set in config. It is ignored. Protocol from device template will be used.";
+    }
+
+    const std::unordered_set<std::string> specialProperties({"channels", "setup", "name", "protocol"});
     for (auto itProp = deviceData.begin(); itProp != deviceData.end(); ++itProp) {
-        if (itProp.name() != "channels" && itProp.name() != "setup" && itProp.name() != "name") {
+        if (!specialProperties.count(itProp.name())) {
             SetPropertyWithNotification(res, itProp, deviceName);
         }
     }

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -891,14 +891,6 @@
       ]
     },
 
-    "no_protocol": {
-      "properties": {
-        "protocol": {
-          "not": {},
-          "options": { "hidden": true }
-        }
-      }
-    },
     "no_setup": {
       "properties": {
         "setup": {
@@ -1001,8 +993,7 @@
         { "$ref": "#/definitions/dlms_device_properties" },
         { "$ref": "#/definitions/dlms_channels" },
         { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_setup" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/no_setup" }
       ]
     },
     "dlms_device_no_channels": {
@@ -1010,7 +1001,6 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/dlms_device_properties" },
         { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" },
         { "$ref": "#/definitions/no_setup" }
       ]
     },
@@ -1041,7 +1031,6 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/somfy_device_properties" },
         { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" },
         { "$ref": "#/definitions/no_setup" }
       ]
     },
@@ -1104,15 +1093,13 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/no_setup" },
         { "$ref": "#/definitions/common_channels" },
-        { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id" }
       ]
     },
     "simple_device_no_channels": {
       "allOf": [
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" },
         { "$ref": "#/definitions/no_setup" }
       ]
     },
@@ -1122,8 +1109,7 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/no_setup" },
         { "$ref": "#/definitions/channels_with_string_addresses" },
-        { "$ref": "#/definitions/slave_id_broadcast" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id_broadcast" }
       ]
     },
 
@@ -1132,16 +1118,14 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/no_setup" },
         { "$ref": "#/definitions/common_channels" },
-        { "$ref": "#/definitions/slave_id_broadcast" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id_broadcast" }
       ]
     },
     "simple_device_with_broadcast_no_channels": {
       "allOf": [
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/no_setup" },
-        { "$ref": "#/definitions/slave_id_broadcast" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id_broadcast" }
       ]
     },
 
@@ -1149,8 +1133,7 @@
       "allOf": [
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/common_setup" },
-        { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id" }
       ]
     },
     "simple_device_with_setup": {
@@ -1158,8 +1141,7 @@
         { "$ref": "#/definitions/deviceProperties" },
         { "$ref": "#/definitions/common_channels" },
         { "$ref": "#/definitions/common_setup" },
-        { "$ref": "#/definitions/slave_id" },
-        { "$ref": "#/definitions/no_protocol" }
+        { "$ref": "#/definitions/slave_id" }
       ]
     },
 


### PR DESCRIPTION
Config validator will not raise an error if protocol property set simultaneously with device_type is same as defined in template.