### PR TITLE
WB-MR6C template translation to Russian

### DIFF
--- a/wb-mqtt-serial-templates/config-wb-mr6c.json
+++ b/wb-mqtt-serial-templates/config-wb-mr6c.json
@@ -1,4 +1,5 @@
 {
+    "title": "WB-MR6C (v.1, v.2), WB-MR6LV/x, WB-MR6HV/x (6-channel relay Modbus-module)",
     "device_type": "WB-MR6C",
     "device": {
         "name": "WB-MR6C",
@@ -69,7 +70,7 @@
                 "title": "Input 0 Mode",
                 "address": 16,
                 "reg_type": "holding",
-                "enum": [ 2, 3, 4 ],
+                "enum": [2, 3, 4],
                 "default": 2,
                 "enum_titles": [
                     "turn off all outputs",
@@ -93,7 +94,7 @@
                 "title": "Input 1 Mode",
                 "address": 9,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -119,7 +120,7 @@
                 "title": "Input 2 Mode",
                 "address": 10,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -145,7 +146,7 @@
                 "title": "Input 3 Mode",
                 "address": 11,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -171,7 +172,7 @@
                 "title": "Input 4 Mode",
                 "address": 12,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -197,7 +198,7 @@
                 "title": "Input 5 Mode",
                 "address": 13,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -223,7 +224,7 @@
                 "title": "Input 6 Mode",
                 "address": 14,
                 "reg_type": "holding",
-                "enum": [ 0, 1, 2, 3, 4 ],
+                "enum": [0, 1, 2, 3, 4],
                 "default": 0,
                 "enum_titles": [
                     "push button",
@@ -249,12 +250,9 @@
                 "title": "Restore Last Outputs State After Power On",
                 "address": 6,
                 "reg_type": "holding",
-                "enum": [ 0, 1 ],
+                "enum": [0, 1],
                 "default": 0,
-                "enum_titles": [
-                    "no",
-                    "yes"
-                ],
+                "enum_titles": ["no", "yes"],
                 "group": "outputs",
                 "order": 1
             },
@@ -289,7 +287,7 @@
                 "address": 54,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_0"
@@ -314,7 +312,7 @@
                 "address": 40,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_1"
@@ -339,7 +337,7 @@
                 "address": 42,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_2"
@@ -364,7 +362,7 @@
                 "address": 44,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_3"
@@ -389,7 +387,7 @@
                 "address": 46,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_4"
@@ -414,7 +412,7 @@
                 "address": 48,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_5"
@@ -439,7 +437,7 @@
                 "address": 50,
                 "type": "value",
                 "format": "u32",
-                "scale": 1.52588e-05,
+                "scale": 1.52588e-5,
                 "round_to": 0.001,
                 "enabled": false,
                 "group": "input_6"
@@ -512,7 +510,60 @@
                 "enabled": false,
                 "group": "hw_info"
             }
-        ]        
-
+        ],
+        "translations": {
+            "ru": {
+                "WB-MR6C (v.1, v.2), WB-MR6LV/x, WB-MR6HV/x (6-channel relay Modbus-module)": "WB-MR6C (v.1, v.2), WB-MR6LV/x, WB-MR6HV/x (6-канальный Modbus-модуль реле)",
+                "Input 0": "Вход 0",
+                "Input 1": "Вход 1",
+                "Input 2": "Вход 2",
+                "Input 3": "Вход 3",
+                "Input 4": "Вход 4",
+                "Input 5": "Вход 5",
+                "Input 6": "Вход 6",
+                "Outputs": "Выходы",
+                "HW Info": "Данные Модуля",
+                "Input 0 Mode": "Вход 0: Режим Работы",
+                "Input 1 Mode": "Вход 1: Режим Работы",
+                "Input 2 Mode": "Вход 2: Режим Работы",
+                "Input 3 Mode": "Вход 3: Режим Работы",
+                "Input 4 Mode": "Вход 4: Режим Работы",
+                "Input 5 Mode": "Вход 5: Режим Работы",
+                "Input 6 Mode": "Вход 6: Режим Работы",
+                "push button": "кнопка без фиксации",
+                "latching switch": "переключатель с фиксацией",
+                "turn off all outputs": "отключить все выходы",
+                "control disabled": "управление отключено",
+                "operate according to mapping-matix": "управлять согласно mapping-матрицы",
+                "Input 0 Debounce (ms)": "Вход 0: Время Защиты От Дребезга (мс)",
+                "Input 1 Debounce (ms)": "Вход 1: Время Защиты От Дребезга (мс)",
+                "Input 2 Debounce (ms)": "Вход 2: Время Защиты От Дребезга (мс)",
+                "Input 3 Debounce (ms)": "Вход 3: Время Защиты От Дребезга (мс)",
+                "Input 4 Debounce (ms)": "Вход 4: Время Защиты От Дребезга (мс)",
+                "Input 5 Debounce (ms)": "Вход 5: Время Защиты От Дребезга (мс)",
+                "Input 6 Debounce (ms)": "Вход 6: Время Защиты От Дребезга (мс)",
+                "Restore Last Outputs State After Power On": "Восстанавливать Состояния Выходов При Включении",
+                "no": "нет",
+                "yes": "да",
+                "Safety Timer (s)": "Таймаут Безопасного Режима (сек.)",
+                "Input 0 counter": "Вход 0 Счетчик",
+                "Input 1 counter": "Вход 1 Счетчик",
+                "Input 2 counter": "Вход 2 Счетчик",
+                "Input 3 counter": "Вход 3 Счетчик",
+                "Input 4 counter": "Вход 4 Счетчик",
+                "Input 5 counter": "Вход 5 Счетчик",
+                "Input 6 counter": "Вход 6 Счетчик",
+                "Input 0 freq": "Вход 0 Частота",
+                "Input 1 freq": "Вход 1 Частота",
+                "Input 2 freq": "Вход 2 Частота",
+                "Input 3 freq": "Вход 3 Частота",
+                "Input 4 freq": "Вход 4 Частота",
+                "Input 5 freq": "Вход 5 Частота",
+                "Input 6 freq": "Вход 6 Частота",
+                "Serial": "Серийный номер",
+                "Supply Voltage": "Напряжение питания",
+                "Uptime": "Время работы (сек.)"
+            }
+        }
     }
 }


### PR DESCRIPTION
Перевел шаблон WB-MR6C на русский язык, в поле "title" указал, что он подходит для WB-MR6C (v1, v2), WB-MR6LV/x, WB-MR6HV/x.
Предлагаю шаблон WB-MR6LV пометить как не актуальный, только для совместимости. Он был сделан, так как не было опции title для всего шаблона.