### PR TITLE
debian: depends on libwbmqtt1-3 (to fix libmosquittopp dep)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.36.0) stable; urgency=medium
+
+  * Update dependency on libwbmqtt1 to support fixed libmosquitto facade
+    (required for newer mosquitto backports)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 21 Sep 2021 19:49:26 +0300
+
 wb-mqtt-serial (2.35.0) stable; urgency=medium
 
   * Web-interface for channel's poll_interval editing is changed

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.0.0), libwbmqtt1-3-test-utils (>= 3.0.0)
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.1.0), libwbmqtt1-3-test-utils (>= 3.1.0)
 Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-3 (>= 3.0.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-3 (>= 3.1.0)
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.4.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.2.5), wb-mqtt-homeui (<< 2.16.0)


### PR DESCRIPTION
Rebase #308 