### PR TITLE
Backward compatibility with previous device templates is improved

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.41.3-wb3) stable; urgency=medium
+
+  * Backward compatibility with previous device templates is improved.
+    Channels mentioned in config and not presented in template or not having addresses will be ignored with warning.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 22 Nov 2021 12:57:38 +0500
+
 wb-mqtt-serial (2.41.3-wb2) stable; urgency=medium
 
   * Backport of v2.42.2 changes:

--- a/src/confed_json_generator.cpp
+++ b/src/confed_json_generator.cpp
@@ -74,7 +74,14 @@ namespace
         for (const Json::Value& ch: device["channels"]) {
             auto it = regs.find(ch["name"].asString());
             if (it != regs.end()) {
-                customChannels.append(it->second);
+                // Some configs have settings for channels from old templates.
+                // They don't have appropriate definitions and will be treated as custom channels without addresses.
+                // It could lead to json-editor confusing and wrong web UI generation
+                // Just drop such channels
+                // TODO: It is not a good solution and should be deleted after template versions implementation
+                if (it->second.isMember("address") || it->second.isMember("consists_of")) {
+                    customChannels.append(it->second);
+                }
             }
         }
 

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -364,9 +364,15 @@ namespace
                                                  device_config->DeviceType);
             }
         } else {
-            auto reg = LoadRegisterConfig(channel_data, *device_config, errorMsgPrefix, context);
-            default_type_str = reg.DefaultControlType;
-            registers.push_back(reg.RegisterConfig);
+            try {
+                auto reg = LoadRegisterConfig(channel_data, *device_config, errorMsgPrefix, context);
+                default_type_str = reg.DefaultControlType;
+                registers.push_back(reg.RegisterConfig);
+            } catch (const std::exception& e) {
+                LOG(Warn) << device_config->GetDescription() << " channel \"" + mqtt_channel_name
+                          << "\" is ignored: " << e.what();
+                return;
+            }
         }
 
         std::string type_str(Read(channel_data, "type", default_type_str));


### PR DESCRIPTION
Channels mentioned in config and not presented in template or not having addresses will be ignored with warning.