### PR TITLE
Feature/38428 add write address for channels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.47.0) stable; urgency=medium
+
+  * Added separate read and write register addresses for the Modbus device.
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Mon, 31 Jan 2022 12:49:00 +0300
+
 wb-mqtt-serial (2.46.3) stable; urgency=medium
 
   * WB-MIR v2 template: ROMs count increased to 40

--- a/src/devices/curtains/dooya_device.cpp
+++ b/src/devices/curtains/dooya_device.cpp
@@ -14,9 +14,9 @@ namespace
     };
 
     const TRegisterTypes RegTypes{
-        {POSITION, "position", "value", U8},
-        {PARAM, "param", "value", U8},
-        {COMMAND, "command", "value", U8},
+        {POSITION, "position", "value", RegisterFormat::U8},
+        {PARAM, "param", "value", RegisterFormat::U8},
+        {COMMAND, "command", "value", RegisterFormat::U8},
     };
 
     enum TCommands

--- a/src/devices/curtains/somfy_sdn_device.cpp
+++ b/src/devices/curtains/somfy_sdn_device.cpp
@@ -13,9 +13,9 @@ namespace
         COMMAND
     };
 
-    const TRegisterTypes RegTypes{{POSITION, "position", "value", U8},
-                                  {PARAM, "param", "value", U64, true},
-                                  {COMMAND, "command", "value", U64}};
+    const TRegisterTypes RegTypes{{POSITION, "position", "value", RegisterFormat::U8},
+                                  {PARAM, "param", "value", RegisterFormat::U64, true},
+                                  {COMMAND, "command", "value", RegisterFormat::U64}};
 
     const size_t CRC_SIZE = 2;
     const uint32_t HOST_ADDRESS = 0x0000FFFF;

--- a/src/devices/curtains/windeco_device.cpp
+++ b/src/devices/curtains/windeco_device.cpp
@@ -9,9 +9,9 @@ namespace
         COMMAND
     };
 
-    const TRegisterTypes RegTypes{{POSITION, "position", "value", U8},
-                                  {PARAM, "param", "value", U8, true},
-                                  {COMMAND, "command", "value", U8}};
+    const TRegisterTypes RegTypes{{POSITION, "position", "value", RegisterFormat::U8},
+                                  {PARAM, "param", "value", RegisterFormat::U8, true},
+                                  {COMMAND, "command", "value", RegisterFormat::U8}};
 
     const size_t PACKET_SIZE = 7;
     const size_t DATA_BYTE = 5;

--- a/src/devices/dlms_device.cpp
+++ b/src/devices/dlms_device.cpp
@@ -341,7 +341,7 @@ namespace
 void TDlmsDevice::Register(TSerialDeviceFactory& factory)
 {
     factory.RegisterProtocol(
-        new TUint32SlaveIdProtocol("dlms", TRegisterTypes({{0, "default", "value", Double, true}})),
+        new TUint32SlaveIdProtocol("dlms", TRegisterTypes({{0, "default", "value", RegisterFormat::Double, true}})),
         new TDlmsDeviceFactory());
 }
 

--- a/src/devices/energomera_iec_device.cpp
+++ b/src/devices/energomera_iec_device.cpp
@@ -15,7 +15,7 @@ namespace
 void TEnergomeraIecWithFastReadDevice::Register(TSerialDeviceFactory& factory)
 {
     factory.RegisterProtocol(
-        new TIEC61107Protocol("energomera_iec", {{0, "group_single", "value", Double, true}}),
+        new TIEC61107Protocol("energomera_iec", {{0, "group_single", "value", RegisterFormat::Double, true}}),
         new TBasicDeviceFactory<TEnergomeraIecWithFastReadDevice>("#/definitions/simple_device_with_broadcast",
                                                                   "#/definitions/common_channel"));
 }

--- a/src/devices/energomera_iec_mode_c_device.cpp
+++ b/src/devices/energomera_iec_mode_c_device.cpp
@@ -23,14 +23,14 @@ namespace
 
     // clang-format off
     const TRegisterTypes RegisterTypes {
-        { RegisterType::DEFAULT, "default", "value", Double, true },
-        { RegisterType::ITEM_1,  "item_1",  "value", Double, true },
-        { RegisterType::ITEM_2,  "item_2",  "value", Double, true },
-        { RegisterType::ITEM_3,  "item_3",  "value", Double, true },
-        { RegisterType::ITEM_4,  "item_4",  "value", Double, true },
-        { RegisterType::ITEM_5,  "item_5",  "value", Double, true },
-        { RegisterType::DATE,    "date",    "value", U32,    true },
-        { RegisterType::TIME,    "time",    "value", U32,    true }
+        { RegisterType::DEFAULT, "default", "value", RegisterFormat::Double, true },
+        { RegisterType::ITEM_1,  "item_1",  "value", RegisterFormat::Double, true },
+        { RegisterType::ITEM_2,  "item_2",  "value", RegisterFormat::Double, true },
+        { RegisterType::ITEM_3,  "item_3",  "value", RegisterFormat::Double, true },
+        { RegisterType::ITEM_4,  "item_4",  "value", RegisterFormat::Double, true },
+        { RegisterType::ITEM_5,  "item_5",  "value", RegisterFormat::Double, true },
+        { RegisterType::DATE,    "date",    "value", RegisterFormat::U32,    true },
+        { RegisterType::TIME,    "time",    "value", RegisterFormat::U32,    true }
     };
     // clang-format on
 
@@ -91,7 +91,7 @@ uint64_t TEnergomeraIecModeCDevice::GetRegisterValue(const TRegister& reg, const
             return strtoull(v.c_str(), nullptr, 10);
         }
         case RegisterType::DEFAULT: {
-            if (reg.Format == U64) {
+            if (reg.Format == RegisterFormat::U64) {
                 return strtoull(v.c_str(), nullptr, 10);
             }
             return CopyDoubleToUint64(strtod(v.c_str(), nullptr));

--- a/src/devices/ivtm_device.cpp
+++ b/src/devices/ivtm_device.cpp
@@ -17,7 +17,7 @@
 void TIVTMDevice::Register(TSerialDeviceFactory& factory)
 {
     factory.RegisterProtocol(
-        new TUint32SlaveIdProtocol("ivtm", TRegisterTypes({{0, "default", "value", Float, true}})),
+        new TUint32SlaveIdProtocol("ivtm", TRegisterTypes({{0, "default", "value", RegisterFormat::Float, true}})),
         new TBasicDeviceFactory<TIVTMDevice>("#/definitions/simple_device", "#/definitions/common_channel"));
 }
 

--- a/src/devices/lls_device.cpp
+++ b/src/devices/lls_device.cpp
@@ -5,7 +5,7 @@
 void TLLSDevice::Register(TSerialDeviceFactory& factory)
 {
     factory.RegisterProtocol(
-        new TUint32SlaveIdProtocol("lls", TRegisterTypes({{0, "default", "value", Float, true}})),
+        new TUint32SlaveIdProtocol("lls", TRegisterTypes({{0, "default", "value", RegisterFormat::Float, true}})),
         new TBasicDeviceFactory<TLLSDevice>("#/definitions/simple_device", "#/definitions/common_channel"));
 }
 

--- a/src/devices/mercury200_device.cpp
+++ b/src/devices/mercury200_device.cpp
@@ -12,10 +12,11 @@ namespace
     const size_t REQUEST_LEN = 7;
     const ptrdiff_t HEADER_SZ = 5;
 
-    const TRegisterTypes RegisterTypes{{TMercury200Device::REG_PARAM_VALUE16, "param8", "value", RegisterFormat::U8, true},
-                                       {TMercury200Device::REG_PARAM_VALUE16, "param16", "value", RegisterFormat::BCD16, true},
-                                       {TMercury200Device::REG_PARAM_VALUE24, "param24", "value", RegisterFormat::BCD24, true},
-                                       {TMercury200Device::REG_PARAM_VALUE32, "param32", "value", RegisterFormat::BCD32, true}};
+    const TRegisterTypes RegisterTypes{
+        {TMercury200Device::REG_PARAM_VALUE16, "param8", "value", RegisterFormat::U8, true},
+        {TMercury200Device::REG_PARAM_VALUE16, "param16", "value", RegisterFormat::BCD16, true},
+        {TMercury200Device::REG_PARAM_VALUE24, "param24", "value", RegisterFormat::BCD24, true},
+        {TMercury200Device::REG_PARAM_VALUE32, "param32", "value", RegisterFormat::BCD32, true}};
 }
 
 void TMercury200Device::Register(TSerialDeviceFactory& factory)

--- a/src/devices/mercury200_device.cpp
+++ b/src/devices/mercury200_device.cpp
@@ -12,10 +12,10 @@ namespace
     const size_t REQUEST_LEN = 7;
     const ptrdiff_t HEADER_SZ = 5;
 
-    const TRegisterTypes RegisterTypes{{TMercury200Device::REG_PARAM_VALUE16, "param8", "value", U8, true},
-                                       {TMercury200Device::REG_PARAM_VALUE16, "param16", "value", BCD16, true},
-                                       {TMercury200Device::REG_PARAM_VALUE24, "param24", "value", BCD24, true},
-                                       {TMercury200Device::REG_PARAM_VALUE32, "param32", "value", BCD32, true}};
+    const TRegisterTypes RegisterTypes{{TMercury200Device::REG_PARAM_VALUE16, "param8", "value", RegisterFormat::U8, true},
+                                       {TMercury200Device::REG_PARAM_VALUE16, "param16", "value", RegisterFormat::BCD16, true},
+                                       {TMercury200Device::REG_PARAM_VALUE24, "param24", "value", RegisterFormat::BCD24, true},
+                                       {TMercury200Device::REG_PARAM_VALUE32, "param32", "value", RegisterFormat::BCD32, true}};
 }
 
 void TMercury200Device::Register(TSerialDeviceFactory& factory)

--- a/src/devices/mercury230_device.cpp
+++ b/src/devices/mercury230_device.cpp
@@ -8,13 +8,13 @@ namespace
 {
     // clang-format off
     const TRegisterTypes RegisterTypes{
-        { TMercury230Device::REG_VALUE_ARRAY,       "array",               "power_consumption", U32, true },
-        { TMercury230Device::REG_VALUE_ARRAY12,     "array12",             "power_consumption", U32, true },
-        { TMercury230Device::REG_PARAM,             "param",               "value",             U24, true },
-        { TMercury230Device::REG_PARAM_SIGN_ACT,    "param_sign_active",   "value",             S24, true },
-        { TMercury230Device::REG_PARAM_SIGN_REACT,  "param_sign_reactive", "value",             S24, true },
-        { TMercury230Device::REG_PARAM_SIGN_IGNORE, "param_sign_ignore",   "value",             U24, true },
-        { TMercury230Device::REG_PARAM_BE,          "param_be",            "value",             S24, true }
+        { TMercury230Device::REG_VALUE_ARRAY,       "array",               "power_consumption", RegisterFormat::U32, true },
+        { TMercury230Device::REG_VALUE_ARRAY12,     "array12",             "power_consumption", RegisterFormat::U32, true },
+        { TMercury230Device::REG_PARAM,             "param",               "value",             RegisterFormat::U24, true },
+        { TMercury230Device::REG_PARAM_SIGN_ACT,    "param_sign_active",   "value",             RegisterFormat::S24, true },
+        { TMercury230Device::REG_PARAM_SIGN_REACT,  "param_sign_reactive", "value",             RegisterFormat::S24, true },
+        { TMercury230Device::REG_PARAM_SIGN_IGNORE, "param_sign_ignore",   "value",             RegisterFormat::U24, true },
+        { TMercury230Device::REG_PARAM_BE,          "param_be",            "value",             RegisterFormat::S24, true }
     };
     // clang-format on
 }

--- a/src/devices/milur_device.cpp
+++ b/src/devices/milur_device.cpp
@@ -15,11 +15,12 @@ namespace
         };
     }
 
-    const TRegisterTypes RegisterTypes{{TMilurDevice::REG_PARAM, "param", "value", U24, true},
-                                       {TMilurDevice::REG_POWER, "power", "power", S32, true},
-                                       {TMilurDevice::REG_ENERGY, "energy", "power_consumption", BCD32, true},
-                                       {TMilurDevice::REG_FREQ, "freq", "value", U16, true},
-                                       {TMilurDevice::REG_POWERFACTOR, "power_factor", "value", S16, true}};
+    const TRegisterTypes RegisterTypes{
+        {TMilurDevice::REG_PARAM, "param", "value", RegisterFormat::U24, true},
+        {TMilurDevice::REG_POWER, "power", "power", RegisterFormat::S32, true},
+        {TMilurDevice::REG_ENERGY, "energy", "power_consumption", RegisterFormat::BCD32, true},
+        {TMilurDevice::REG_FREQ, "freq", "value", RegisterFormat::U16, true},
+        {TMilurDevice::REG_POWERFACTOR, "power_factor", "value", RegisterFormat::S16, true}};
 }
 
 void TMilurDevice::Register(TSerialDeviceFactory& factory)

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -3,12 +3,13 @@
 
 namespace
 {
-    const TRegisterTypes ModbusRegisterTypes({{Modbus::REG_HOLDING, "holding", "value", U16},
-                                              {Modbus::REG_HOLDING_SINGLE, "holding_single", "value", U16},
-                                              {Modbus::REG_HOLDING_MULTI, "holding_multi", "value", U16},
-                                              {Modbus::REG_COIL, "coil", "switch", U8},
-                                              {Modbus::REG_DISCRETE, "discrete", "switch", U8, true},
-                                              {Modbus::REG_INPUT, "input", "value", U16, true}});
+    const TRegisterTypes ModbusRegisterTypes(
+        {{Modbus::REG_HOLDING, "holding", "value", RegisterFormat::U16},
+         {Modbus::REG_HOLDING_SINGLE, "holding_single", "value", RegisterFormat::U16},
+         {Modbus::REG_HOLDING_MULTI, "holding_multi", "value", RegisterFormat::U16},
+         {Modbus::REG_COIL, "coil", "switch", RegisterFormat::U8},
+         {Modbus::REG_DISCRETE, "discrete", "switch", RegisterFormat::U8, true},
+         {Modbus::REG_INPUT, "input", "value", RegisterFormat::U16, true}});
 
     class TModbusProtocol: public IProtocol
     {

--- a/src/devices/modbus_io_device.cpp
+++ b/src/devices/modbus_io_device.cpp
@@ -4,10 +4,10 @@
 
 namespace
 {
-    const TRegisterTypes ModbusIORegisterTypes({{Modbus::REG_HOLDING, "holding", "value", U16},
-                                                {Modbus::REG_COIL, "coil", "switch", U8},
-                                                {Modbus::REG_DISCRETE, "discrete", "switch", U8, true},
-                                                {Modbus::REG_INPUT, "input", "value", U16, true}});
+    const TRegisterTypes ModbusIORegisterTypes({{Modbus::REG_HOLDING, "holding", "value", RegisterFormat::U16},
+                                                {Modbus::REG_COIL, "coil", "switch", RegisterFormat::U8},
+                                                {Modbus::REG_DISCRETE, "discrete", "switch", RegisterFormat::U8, true},
+                                                {Modbus::REG_INPUT, "input", "value", RegisterFormat::U16, true}});
 
     int GetSecondaryId(const std::string& fullId)
     {

--- a/src/devices/neva_device.cpp
+++ b/src/devices/neva_device.cpp
@@ -11,23 +11,23 @@ namespace
     const char* LOG_PREFIX = "[NEVA] ";
 
     const TRegisterTypes RegisterTypes{// Deprecated. For backward compatibility
-                                       {0, "obis_cdef", "value", Double, true},
-                                       {1, "obis_cdef_pf", "value", Double, true},
-                                       {2, "obis_cdef_temp", "value", Double, true},
-                                       {3, "obis_cdef_1", "value", Double, true},
-                                       {4, "obis_cdef_2", "value", Double, true},
-                                       {5, "obis_cdef_3", "value", Double, true},
-                                       {6, "obis_cdef_4", "value", Double, true},
-                                       {7, "obis_cdef_5", "value", Double, true},
+                                       {0, "obis_cdef", "value", RegisterFormat::Double, true},
+                                       {1, "obis_cdef_pf", "value", RegisterFormat::Double, true},
+                                       {2, "obis_cdef_temp", "value", RegisterFormat::Double, true},
+                                       {3, "obis_cdef_1", "value", RegisterFormat::Double, true},
+                                       {4, "obis_cdef_2", "value", RegisterFormat::Double, true},
+                                       {5, "obis_cdef_3", "value", RegisterFormat::Double, true},
+                                       {6, "obis_cdef_4", "value", RegisterFormat::Double, true},
+                                       {7, "obis_cdef_5", "value", RegisterFormat::Double, true},
                                        // Actual register types
-                                       {8, "default", "value", Double, true},
-                                       {9, "power_factor", "value", Double, true},
-                                       {10, "temperature", "value", Double, true},
-                                       {11, "item_1", "value", Double, true},
-                                       {12, "item_2", "value", Double, true},
-                                       {13, "item_3", "value", Double, true},
-                                       {14, "item_4", "value", Double, true},
-                                       {15, "item_5", "value", Double, true}};
+                                       {8, "default", "value", RegisterFormat::Double, true},
+                                       {9, "power_factor", "value", RegisterFormat::Double, true},
+                                       {10, "temperature", "value", RegisterFormat::Double, true},
+                                       {11, "item_1", "value", RegisterFormat::Double, true},
+                                       {12, "item_2", "value", RegisterFormat::Double, true},
+                                       {13, "item_3", "value", RegisterFormat::Double, true},
+                                       {14, "item_4", "value", RegisterFormat::Double, true},
+                                       {15, "item_5", "value", RegisterFormat::Double, true}};
 
     std::unordered_map<std::string, size_t> RegisterTypeValueIndices = {
         // Deprecated. For backward compatibility

--- a/src/devices/pulsar_device.cpp
+++ b/src/devices/pulsar_device.cpp
@@ -7,8 +7,8 @@
 
 namespace
 {
-    const TRegisterTypes RegisterTypes{{TPulsarDevice::REG_DEFAULT, "default", "value", Double, true},
-                                       {TPulsarDevice::REG_SYSTIME, "systime", "value", U64, true}};
+    const TRegisterTypes RegisterTypes{{TPulsarDevice::REG_DEFAULT, "default", "value", RegisterFormat::Double, true},
+                                       {TPulsarDevice::REG_SYSTIME, "systime", "value", RegisterFormat::U64, true}};
 }
 
 void TPulsarDevice::Register(TSerialDeviceFactory& factory)

--- a/src/devices/s2k_device.cpp
+++ b/src/devices/s2k_device.cpp
@@ -14,10 +14,11 @@
 
 namespace
 {
-    const TRegisterTypes RegisterTypes{{TS2KDevice::REG_RELAY, "relay", "switch", U8},
-                                       {TS2KDevice::REG_RELAY_MODE, "relay_mode", "value", U8, true},
-                                       {TS2KDevice::REG_RELAY_DEFAULT, "relay_default", "value", U8, true},
-                                       {TS2KDevice::REG_RELAY_DELAY, "relay_delay", "value", U8, true}};
+    const TRegisterTypes RegisterTypes{
+        {TS2KDevice::REG_RELAY, "relay", "switch", RegisterFormat::U8},
+        {TS2KDevice::REG_RELAY_MODE, "relay_mode", "value", RegisterFormat::U8, true},
+        {TS2KDevice::REG_RELAY_DEFAULT, "relay_default", "value", RegisterFormat::U8, true},
+        {TS2KDevice::REG_RELAY_DELAY, "relay_delay", "value", RegisterFormat::U8, true}};
 }
 
 void TS2KDevice::Register(TSerialDeviceFactory& factory)

--- a/src/devices/uniel_device.cpp
+++ b/src/devices/uniel_device.cpp
@@ -24,11 +24,11 @@ namespace
         SET_BRIGHTNESS_CMD = 0x0a
     };
 
-    const TRegisterTypes RegisterTypes{{TUnielDevice::REG_RELAY, "relay", "switch", U8},
-                                       {TUnielDevice::REG_INPUT, "input", "value", U8, true},
-                                       {TUnielDevice::REG_PARAM, "param", "value", U8},
+    const TRegisterTypes RegisterTypes{{TUnielDevice::REG_RELAY, "relay", "switch", RegisterFormat::U8},
+                                       {TUnielDevice::REG_INPUT, "input", "value", RegisterFormat::U8, true},
+                                       {TUnielDevice::REG_PARAM, "param", "value", RegisterFormat::U8},
                                        // "value", not "range" because 'max' cannot be specified here.
-                                       {TUnielDevice::REG_BRIGHTNESS, "brightness", "value", U8}};
+                                       {TUnielDevice::REG_BRIGHTNESS, "brightness", "value", RegisterFormat::U8}};
 }
 
 void TUnielDevice::Register(TSerialDeviceFactory& factory)

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -468,7 +468,7 @@ namespace Modbus // modbus protocol common utilities
 
         pdu[0] = GetFunction(reg, OperationType::OP_WRITE);
 
-        auto addr = GetUint32RegisterAddress(reg.GetAddress());
+        auto addr = GetUint32RegisterAddress(reg.GetWriteAddress());
         auto baseAddress = addr + shift;
         const auto bitWidth = reg.GetBitWidth();
 
@@ -529,7 +529,8 @@ namespace Modbus // modbus protocol common utilities
         TAddress address;
 
         address.Type = reg.Type;
-        auto addr = GetUint32RegisterAddress(reg.GetAddress());
+
+        auto addr = GetUint32RegisterAddress(reg.GetWriteAddress());
         address.Address = addr + shift + wordIndex;
 
         uint16_t cachedValue;

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -8,20 +8,20 @@
 size_t RegisterFormatByteWidth(RegisterFormat format)
 {
     switch (format) {
-        case S64:
-        case U64:
-        case Double:
+        case RegisterFormat::S64:
+        case RegisterFormat::U64:
+        case RegisterFormat::Double:
             return 8;
-        case U32:
-        case S32:
-        case BCD32:
-        case Float:
+        case RegisterFormat::U32:
+        case RegisterFormat::S32:
+        case RegisterFormat::BCD32:
+        case RegisterFormat::Float:
             return 4;
-        case U24:
-        case S24:
-        case BCD24:
+        case RegisterFormat::U24:
+        case RegisterFormat::S24:
+        case RegisterFormat::BCD24:
             return 3;
-        case Char8:
+        case RegisterFormat::Char8:
             return 1;
         default:
             return 2;
@@ -131,6 +131,14 @@ const IRegisterAddress& TRegisterConfig::GetAddress() const
     return *Address;
 }
 
+const IRegisterAddress& TRegisterConfig::GetWriteAddress() const
+{
+    if (WriteAddress == nullptr) {
+        return *Address;
+    }
+    return *WriteAddress;
+}
+
 std::string TRegister::ToString() const
 {
     if (Device()) {
@@ -181,6 +189,7 @@ std::mutex TRegister::Mutex;
 
 TRegisterConfig::TRegisterConfig(int type,
                                  std::shared_ptr<IRegisterAddress> address,
+                                 std::shared_ptr<IRegisterAddress> writeAddress,
                                  RegisterFormat format,
                                  double scale,
                                  double offset,
@@ -194,6 +203,7 @@ TRegisterConfig::TRegisterConfig(int type,
                                  uint8_t bit_width,
                                  std::unique_ptr<uint64_t> unsupported_value)
     : Address(address),
+      WriteAddress(writeAddress),
       Type(type),
       Format(format),
       Scale(scale),
@@ -226,6 +236,7 @@ TRegisterConfig::TRegisterConfig(const TRegisterConfig& config)
 {
     Type = config.Type;
     Address = config.Address;
+    WriteAddress = config.WriteAddress;
     Format = config.Format;
     Scale = config.Scale;
     Offset = config.Offset;
@@ -268,6 +279,7 @@ uint8_t TRegisterConfig::GetBitWidth() const
 
 PRegisterConfig TRegisterConfig::Create(int type,
                                         std::shared_ptr<IRegisterAddress> address,
+                                        std::shared_ptr<IRegisterAddress> writeAddress,
                                         RegisterFormat format,
                                         double scale,
                                         double offset,
@@ -283,6 +295,7 @@ PRegisterConfig TRegisterConfig::Create(int type,
 {
     return std::make_shared<TRegisterConfig>(type,
                                              address,
+                                             writeAddress,
                                              format,
                                              scale,
                                              offset,
@@ -314,6 +327,7 @@ PRegisterConfig TRegisterConfig::Create(int type,
 {
     return Create(type,
                   std::make_shared<TUint32RegisterAddress>(address),
+                  nullptr,
                   format,
                   scale,
                   offset,
@@ -521,47 +535,47 @@ template<> double FromScaledTextValue(const TRegisterConfig& reg, const std::str
 uint64_t GetRawValue(const TRegisterConfig& reg, const std::string& str)
 {
     switch (reg.Format) {
-        case S8:
+        case RegisterFormat::S8:
             return FromScaledTextValue<int64_t>(reg, str) & 0xff;
-        case S16:
+        case RegisterFormat::S16:
             return FromScaledTextValue<int64_t>(reg, str) & 0xffff;
-        case S24:
+        case RegisterFormat::S24:
             return FromScaledTextValue<int64_t>(reg, str) & 0xffffff;
-        case S32:
+        case RegisterFormat::S32:
             return FromScaledTextValue<int64_t>(reg, str) & 0xffffffff;
-        case S64:
+        case RegisterFormat::S64:
             return FromScaledTextValue<int64_t>(reg, str);
-        case U8:
+        case RegisterFormat::U8:
             return FromScaledTextValue<uint64_t>(reg, str) & 0xff;
-        case U16:
+        case RegisterFormat::U16:
             return FromScaledTextValue<uint64_t>(reg, str) & 0xffff;
-        case U24:
+        case RegisterFormat::U24:
             return FromScaledTextValue<uint64_t>(reg, str) & 0xffffff;
-        case U32:
+        case RegisterFormat::U32:
             return FromScaledTextValue<uint64_t>(reg, str) & 0xffffffff;
-        case U64:
+        case RegisterFormat::U64:
             return FromScaledTextValue<uint64_t>(reg, str);
-        case Float: {
+        case RegisterFormat::Float: {
             float v = FromScaledTextValue<double>(reg, str);
             uint64_t raw = 0;
             memcpy(&raw, &v, sizeof(v));
             return raw;
         }
-        case Double: {
+        case RegisterFormat::Double: {
             double v = FromScaledTextValue<double>(reg, str);
             uint64_t raw = 0;
             memcpy(&raw, &v, sizeof(v));
             return raw;
         }
-        case Char8:
+        case RegisterFormat::Char8:
             return str.empty() ? 0 : uint8_t(str[0]);
-        case BCD8:
+        case RegisterFormat::BCD8:
             return IntToPackedBCD(FromScaledTextValue<uint64_t>(reg, str) & 0xFF, WordSizes::W8_SZ);
-        case BCD16:
+        case RegisterFormat::BCD16:
             return IntToPackedBCD(FromScaledTextValue<uint64_t>(reg, str) & 0xFFFF, WordSizes::W16_SZ);
-        case BCD24:
+        case RegisterFormat::BCD24:
             return IntToPackedBCD(FromScaledTextValue<uint64_t>(reg, str) & 0xFFFFFF, WordSizes::W24_SZ);
-        case BCD32:
+        case RegisterFormat::BCD32:
             return IntToPackedBCD(FromScaledTextValue<uint64_t>(reg, str) & 0xFFFFFFFF, WordSizes::W32_SZ);
         default:
             return FromScaledTextValue<uint64_t>(reg, str);
@@ -596,39 +610,39 @@ std::string ConvertFromRawValue(const TRegisterConfig& reg, uint64_t value)
 {
     value = InvertWordOrderIfNeeded(reg, value);
     switch (reg.Format) {
-        case S8:
+        case RegisterFormat::S8:
             return ToScaledTextValue(reg, int8_t(value & 0xff));
-        case S16:
+        case RegisterFormat::S16:
             return ToScaledTextValue(reg, int16_t(value & 0xffff));
-        case S24: {
+        case RegisterFormat::S24: {
             uint32_t v = value & 0xffffff;
             if (v & 0x800000)
                 v |= 0xff000000;
             return ToScaledTextValue(reg, int32_t(v));
         }
-        case S32:
+        case RegisterFormat::S32:
             return ToScaledTextValue(reg, int32_t(value & 0xffffffff));
-        case S64:
+        case RegisterFormat::S64:
             return ToScaledTextValue(reg, int64_t(value));
-        case BCD8:
+        case RegisterFormat::BCD8:
             return ToScaledTextValue(reg, PackedBCD2Int(value, WordSizes::W8_SZ));
-        case BCD16:
+        case RegisterFormat::BCD16:
             return ToScaledTextValue(reg, PackedBCD2Int(value, WordSizes::W16_SZ));
-        case BCD24:
+        case RegisterFormat::BCD24:
             return ToScaledTextValue(reg, PackedBCD2Int(value, WordSizes::W24_SZ));
-        case BCD32:
+        case RegisterFormat::BCD32:
             return ToScaledTextValue(reg, PackedBCD2Int(value, WordSizes::W32_SZ));
-        case Float: {
+        case RegisterFormat::Float: {
             float v;
             memcpy(&v, &value, sizeof(v));
             return ToScaledTextValue(reg, v);
         }
-        case Double: {
+        case RegisterFormat::Double: {
             double v;
             memcpy(&v, &value, sizeof(v));
             return ToScaledTextValue(reg, v);
         }
-        case Char8:
+        case RegisterFormat::Char8:
             return std::string(1, value & 0xff);
         default:
             return ToScaledTextValue(reg, value);

--- a/src/register.h
+++ b/src/register.h
@@ -15,7 +15,7 @@
 
 #include "serial_exc.h"
 
-enum RegisterFormat
+enum class RegisterFormat
 {
     AUTO,
     U8,
@@ -68,13 +68,13 @@ struct TRegisterType
     TRegisterType(int index,
                   const std::string& name,
                   const std::string& defaultControlType,
-                  RegisterFormat defaultFormat = U16,
+                  RegisterFormat defaultFormat = RegisterFormat::U16,
                   bool readOnly = false,
                   EWordOrder defaultWordOrder = EWordOrder::BigEndian);
 
     int Index = 0;
     std::string Name, DefaultControlType;
-    RegisterFormat DefaultFormat = U16;
+    RegisterFormat DefaultFormat = RegisterFormat::U16;
     EWordOrder DefaultWordOrder = EWordOrder::BigEndian;
     bool ReadOnly = false;
 };
@@ -185,6 +185,7 @@ public:
 class TRegisterConfig: public std::enable_shared_from_this<TRegisterConfig>
 {
     std::shared_ptr<IRegisterAddress> Address;
+    std::shared_ptr<IRegisterAddress> WriteAddress;
 
 public:
     int Type;
@@ -204,6 +205,7 @@ public:
 
     TRegisterConfig(int type,
                     std::shared_ptr<IRegisterAddress> address,
+                    std::shared_ptr<IRegisterAddress> writeAddress,
                     RegisterFormat format,
                     double scale,
                     double offset,
@@ -229,7 +231,8 @@ public:
 
     static PRegisterConfig Create(int type = 0,
                                   std::shared_ptr<IRegisterAddress> address = std::shared_ptr<IRegisterAddress>(),
-                                  RegisterFormat format = U16,
+                                  std::shared_ptr<IRegisterAddress> writeAddress = std::shared_ptr<IRegisterAddress>(),
+                                  RegisterFormat format = RegisterFormat::U16,
                                   double scale = 1,
                                   double offset = 0,
                                   double round_to = 0,
@@ -245,7 +248,7 @@ public:
     //! Create register with TUint32RegisterAddress
     static PRegisterConfig Create(int type = 0,
                                   uint32_t address = 0,
-                                  RegisterFormat format = U16,
+                                  RegisterFormat format = RegisterFormat::U16,
                                   double scale = 1,
                                   double offset = 0,
                                   double round_to = 0,
@@ -259,6 +262,7 @@ public:
                                   std::unique_ptr<uint64_t> unsupported_value = std::unique_ptr<uint64_t>());
 
     const IRegisterAddress& GetAddress() const;
+    const IRegisterAddress& GetWriteAddress() const;
 };
 
 struct TRegister;
@@ -353,41 +357,41 @@ inline ::std::ostream& operator<<(::std::ostream& os, PRegister reg)
 inline const char* RegisterFormatName(RegisterFormat fmt)
 {
     switch (fmt) {
-        case AUTO:
+        case RegisterFormat::AUTO:
             return "AUTO";
-        case U8:
+        case RegisterFormat::U8:
             return "U8";
-        case S8:
+        case RegisterFormat::S8:
             return "S8";
-        case U16:
+        case RegisterFormat::U16:
             return "U16";
-        case S16:
+        case RegisterFormat::S16:
             return "S16";
-        case S24:
+        case RegisterFormat::S24:
             return "S24";
-        case U24:
+        case RegisterFormat::U24:
             return "U24";
-        case U32:
+        case RegisterFormat::U32:
             return "U32";
-        case S32:
+        case RegisterFormat::S32:
             return "S32";
-        case S64:
+        case RegisterFormat::S64:
             return "S64";
-        case U64:
+        case RegisterFormat::U64:
             return "U64";
-        case BCD8:
+        case RegisterFormat::BCD8:
             return "BCD8";
-        case BCD16:
+        case RegisterFormat::BCD16:
             return "BCD16";
-        case BCD24:
+        case RegisterFormat::BCD24:
             return "BCD24";
-        case BCD32:
+        case RegisterFormat::BCD32:
             return "BCD32";
-        case Float:
+        case RegisterFormat::Float:
             return "Float";
-        case Double:
+        case RegisterFormat::Double:
             return "Double";
-        case Char8:
+        case RegisterFormat::Char8:
             return "Char8";
         default:
             return "<unknown register type>";
@@ -397,39 +401,39 @@ inline const char* RegisterFormatName(RegisterFormat fmt)
 inline RegisterFormat RegisterFormatFromName(const std::string& name)
 {
     if (name == "s16")
-        return S16;
+        return RegisterFormat::S16;
     else if (name == "u8")
-        return U8;
+        return RegisterFormat::U8;
     else if (name == "s8")
-        return S8;
+        return RegisterFormat::S8;
     else if (name == "u24")
-        return U24;
+        return RegisterFormat::U24;
     else if (name == "s24")
-        return S24;
+        return RegisterFormat::S24;
     else if (name == "u32")
-        return U32;
+        return RegisterFormat::U32;
     else if (name == "s32")
-        return S32;
+        return RegisterFormat::S32;
     else if (name == "s64")
-        return S64;
+        return RegisterFormat::S64;
     else if (name == "u64")
-        return U64;
+        return RegisterFormat::U64;
     else if (name == "bcd8")
-        return BCD8;
+        return RegisterFormat::BCD8;
     else if (name == "bcd16")
-        return BCD16;
+        return RegisterFormat::BCD16;
     else if (name == "bcd24")
-        return BCD24;
+        return RegisterFormat::BCD24;
     else if (name == "bcd32")
-        return BCD32;
+        return RegisterFormat::BCD32;
     else if (name == "float")
-        return Float;
+        return RegisterFormat::Float;
     else if (name == "double")
-        return Double;
+        return RegisterFormat::Double;
     else if (name == "char8")
-        return Char8;
+        return RegisterFormat::Char8;
     else
-        return U16; // FIXME!
+        return RegisterFormat::U16; // FIXME!
 }
 
 size_t RegisterFormatByteWidth(RegisterFormat format);

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -1303,6 +1303,19 @@ void RegisterProtocols(TSerialDeviceFactory& deviceFactory)
     Somfy::TDevice::Register(deviceFactory);
 }
 
+namespace
+{
+    constexpr auto WRITE_ADDRESS_PROPERTY_NAME = "write_address";
+    constexpr auto ADDRESS_PROPERTY_NAME = "address";
+
+    inline bool HasWriteAddressProperty(const Json::Value& regCfg)
+    {
+        return regCfg.isMember(WRITE_ADDRESS_PROPERTY_NAME) &&
+               !(regCfg[WRITE_ADDRESS_PROPERTY_NAME].isString() &&
+                 regCfg[WRITE_ADDRESS_PROPERTY_NAME].asString().empty());
+    }
+}
+
 TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data, const std::string& jsonPropertyName)
 {
     TRegisterBitsAddress res;
@@ -1339,22 +1352,14 @@ TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data, c
     return res;
 }
 
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data){
+    return LoadRegisterBitsAddress( register_data, ADDRESS_PROPERTY_NAME);
+}
+
 TUint32RegisterAddressFactory::TUint32RegisterAddressFactory(size_t bytesPerRegister)
     : BaseRegisterAddress(0),
       BytesPerRegister(bytesPerRegister)
 {}
-
-namespace
-{
-    constexpr auto WRITE_ADDRESS_PROPERTY_NAME = "write_address";
-
-    inline bool HasWriteAddressProperty(const Json::Value& regCfg)
-    {
-        return regCfg.isMember(WRITE_ADDRESS_PROPERTY_NAME) &&
-               !(regCfg[WRITE_ADDRESS_PROPERTY_NAME].isString() &&
-                 regCfg[WRITE_ADDRESS_PROPERTY_NAME].asString().empty());
-    }
-}
 
 TRegisterDesc TUint32RegisterAddressFactory::LoadRegisterAddress(const Json::Value& regCfg,
                                                                  const IRegisterAddress& deviceBaseAddress,

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -1352,8 +1352,9 @@ TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data, c
     return res;
 }
 
-TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data){
-    return LoadRegisterBitsAddress( register_data, ADDRESS_PROPERTY_NAME);
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data)
+{
+    return LoadRegisterBitsAddress(register_data, ADDRESS_PROPERTY_NAME);
 }
 
 TUint32RegisterAddressFactory::TUint32RegisterAddressFactory(size_t bytesPerRegister)

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -1303,7 +1303,7 @@ void RegisterProtocols(TSerialDeviceFactory& deviceFactory)
     Somfy::TDevice::Register(deviceFactory);
 }
 
-TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value &register_data, const std::string& jsonPropertyName)
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data, const std::string& jsonPropertyName)
 {
     TRegisterBitsAddress res;
     const auto& addressValue = register_data[jsonPropertyName];
@@ -1344,12 +1344,15 @@ TUint32RegisterAddressFactory::TUint32RegisterAddressFactory(size_t bytesPerRegi
       BytesPerRegister(bytesPerRegister)
 {}
 
-namespace {
+namespace
+{
     constexpr auto WRITE_ADDRESS_PROPERTY_NAME = "write_address";
 
-    inline bool HasWriteAddressProperty(const Json::Value &regCfg) {
-        return regCfg.isMember(WRITE_ADDRESS_PROPERTY_NAME) && !(regCfg[WRITE_ADDRESS_PROPERTY_NAME].isString() &&
-                                                                 regCfg[WRITE_ADDRESS_PROPERTY_NAME].asString().empty());
+    inline bool HasWriteAddressProperty(const Json::Value& regCfg)
+    {
+        return regCfg.isMember(WRITE_ADDRESS_PROPERTY_NAME) &&
+               !(regCfg[WRITE_ADDRESS_PROPERTY_NAME].isString() &&
+                 regCfg[WRITE_ADDRESS_PROPERTY_NAME].asString().empty());
     }
 }
 
@@ -1363,7 +1366,7 @@ TRegisterDesc TUint32RegisterAddressFactory::LoadRegisterAddress(const Json::Val
     if (HasWriteAddressProperty(regCfg)) {
         auto writeAddress = LoadRegisterBitsAddress(regCfg, WRITE_ADDRESS_PROPERTY_NAME);
         res.WriteAddress = std::shared_ptr<IRegisterAddress>(
-                deviceBaseAddress.CalcNewAddress(writeAddress.Address, stride, registerByteWidth, BytesPerRegister));
+            deviceBaseAddress.CalcNewAddress(writeAddress.Address, stride, registerByteWidth, BytesPerRegister));
     }
     res.BitOffset = addr.BitOffset;
     res.BitWidth = addr.BitWidth;

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -283,7 +283,9 @@ struct TRegisterBitsAddress
 };
 
 TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data,
-                                             const std::string& jsonPropertyName = "address");
+                                             const std::string& jsonPropertyName);
+
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data);
 
 /*!
  * Basic device factory implementation with uint32 register addresses

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -282,8 +282,7 @@ struct TRegisterBitsAddress
     uint8_t BitOffset = 0;
 };
 
-TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data,
-                                             const std::string& jsonPropertyName);
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data, const std::string& jsonPropertyName);
 
 TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data);
 

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -151,6 +151,7 @@ Json::Value LoadConfigSchema(const std::string& schemaFileName);
 struct TRegisterDesc
 {
     std::shared_ptr<IRegisterAddress> Address; //! Register address
+    std::shared_ptr<IRegisterAddress> WriteAddress; //! Register address
     uint8_t BitOffset = 0;                     //! Offset of data in register in bits
     uint8_t BitWidth = 0;                      //! Width of data in register in bits
 };
@@ -281,7 +282,7 @@ struct TRegisterBitsAddress
     uint8_t BitOffset = 0;
 };
 
-TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& regCfg);
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value &register_data, const std::string &jsonPropertyName = "address");
 
 /*!
  * Basic device factory implementation with uint32 register addresses

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -150,10 +150,10 @@ Json::Value LoadConfigSchema(const std::string& schemaFileName);
 //! Register address
 struct TRegisterDesc
 {
-    std::shared_ptr<IRegisterAddress> Address; //! Register address
+    std::shared_ptr<IRegisterAddress> Address;      //! Register address
     std::shared_ptr<IRegisterAddress> WriteAddress; //! Register address
-    uint8_t BitOffset = 0;                     //! Offset of data in register in bits
-    uint8_t BitWidth = 0;                      //! Width of data in register in bits
+    uint8_t BitOffset = 0;                          //! Offset of data in register in bits
+    uint8_t BitWidth = 0;                           //! Width of data in register in bits
 };
 
 class IRegisterAddressFactory
@@ -282,7 +282,8 @@ struct TRegisterBitsAddress
     uint8_t BitOffset = 0;
 };
 
-TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value &register_data, const std::string &jsonPropertyName = "address");
+TRegisterBitsAddress LoadRegisterBitsAddress(const Json::Value& register_data,
+                                             const std::string& jsonPropertyName = "address");
 
 /*!
  * Basic device factory implementation with uint32 register addresses

--- a/test/em_test.cpp
+++ b/test/em_test.cpp
@@ -45,25 +45,35 @@ void TEMDeviceTest::SetUp()
     Mercury230Dev =
         std::make_shared<TMercury230Device>(Mercury230Config(), SerialPort, DeviceFactory.GetProtocol("mercury230"));
 
-    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
-    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::U24));
+    MilurPhaseCVoltageReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
+    MilurPhaseCCurrentReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::U24));
     MilurTotalConsumptionReg =
         TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, RegisterFormat::BCD32));
-    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
+    MilurFrequencyReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
     Mercury230TotalConsumptionReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
     Mercury230TotalReactiveEnergyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
     Mercury230U1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
     Mercury230I1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
     Mercury230U2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
     Mercury230TempReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::S16));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::S16));
     Mercury230PReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
 
     SerialPort->Open();
 }

--- a/test/em_test.cpp
+++ b/test/em_test.cpp
@@ -45,25 +45,25 @@ void TEMDeviceTest::SetUp()
     Mercury230Dev =
         std::make_shared<TMercury230Device>(Mercury230Config(), SerialPort, DeviceFactory.GetProtocol("mercury230"));
 
-    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, U24));
-    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, U24));
+    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
+    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::U24));
     MilurTotalConsumptionReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, BCD32));
-    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, U16));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, RegisterFormat::BCD32));
+    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
     Mercury230TotalConsumptionReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, U32));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
     Mercury230TotalReactiveEnergyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, U32));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
     Mercury230U1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
     Mercury230I1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
     Mercury230U2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
     Mercury230TempReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, S16));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::S16));
     Mercury230PReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
 
     SerialPort->Open();
 }

--- a/test/fake_serial_device.cpp
+++ b/test/fake_serial_device.cpp
@@ -28,10 +28,11 @@ std::list<TFakeSerialDevice*> TFakeSerialDevice::Devices;
 
 void TFakeSerialDevice::Register(TSerialDeviceFactory& factory)
 {
-    factory.RegisterProtocol(
-        new TUint32SlaveIdProtocol("fake", TRegisterTypes({{TFakeSerialDevice::REG_FAKE, "fake", "text", RegisterFormat::U16}})),
-        new TBasicDeviceFactory<TFakeSerialDevice>("#/definitions/simple_device_with_setup",
-                                                   "#/definitions/common_channel"));
+    factory.RegisterProtocol(new TUint32SlaveIdProtocol(
+                                 "fake",
+                                 TRegisterTypes({{TFakeSerialDevice::REG_FAKE, "fake", "text", RegisterFormat::U16}})),
+                             new TBasicDeviceFactory<TFakeSerialDevice>("#/definitions/simple_device_with_setup",
+                                                                        "#/definitions/common_channel"));
 }
 
 TFakeSerialDevice::TFakeSerialDevice(PDeviceConfig config, PPort port, PProtocol protocol)

--- a/test/fake_serial_device.cpp
+++ b/test/fake_serial_device.cpp
@@ -29,7 +29,7 @@ std::list<TFakeSerialDevice*> TFakeSerialDevice::Devices;
 void TFakeSerialDevice::Register(TSerialDeviceFactory& factory)
 {
     factory.RegisterProtocol(
-        new TUint32SlaveIdProtocol("fake", TRegisterTypes({{TFakeSerialDevice::REG_FAKE, "fake", "text", U16}})),
+        new TUint32SlaveIdProtocol("fake", TRegisterTypes({{TFakeSerialDevice::REG_FAKE, "fake", "text", RegisterFormat::U16}})),
         new TBasicDeviceFactory<TFakeSerialDevice>("#/definitions/simple_device_with_setup",
                                                    "#/definitions/common_channel"));
 }

--- a/test/ivtm_test.cpp
+++ b/test/ivtm_test.cpp
@@ -22,9 +22,9 @@ void TIVTMDeviceTest::SetUp()
                                         SerialPort,
                                         DeviceFactory.GetProtocol("ivtm"));
 
-    Dev1Temp = TRegister::Intern(Dev, TRegisterConfig::Create(0, 0, Float));
-    Dev1Humidity = TRegister::Intern(Dev, TRegisterConfig::Create(0, 4, Float));
-    Dev2Temp = TRegister::Intern(Dev, TRegisterConfig::Create(0, 0, Float));
+    Dev1Temp = TRegister::Intern(Dev, TRegisterConfig::Create(0, 0, RegisterFormat::Float));
+    Dev1Humidity = TRegister::Intern(Dev, TRegisterConfig::Create(0, 4, RegisterFormat::Float));
+    Dev2Temp = TRegister::Intern(Dev, TRegisterConfig::Create(0, 0, RegisterFormat::Float));
 
     SerialPort->Open();
 }

--- a/test/mercury200_test.cpp
+++ b/test/mercury200_test.cpp
@@ -36,21 +36,29 @@ void TMercury200Test::SetUp()
         std::make_shared<TMercury200Device>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("mercury200"));
 
     Mercury200RET1Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2700, RegisterFormat::BCD32));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2700, RegisterFormat::BCD32));
     Mercury200RET2Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2704, RegisterFormat::BCD32));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2704, RegisterFormat::BCD32));
     Mercury200RET3Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2708, RegisterFormat::BCD32));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2708, RegisterFormat::BCD32));
     Mercury200RET4Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x270C, RegisterFormat::BCD32));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x270C, RegisterFormat::BCD32));
     Mercury200UReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6300, RegisterFormat::BCD16));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6300, RegisterFormat::BCD16));
     Mercury200IReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6302, RegisterFormat::BCD16));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6302, RegisterFormat::BCD16));
     Mercury200PReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE24, 0x6304, RegisterFormat::BCD24));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE24, 0x6304, RegisterFormat::BCD24));
     Mercury200BatReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x2900, RegisterFormat::BCD16));
+        TRegister::Intern(Mercury200Dev,
+                          TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x2900, RegisterFormat::BCD16));
 
     SerialPort->Open();
 }

--- a/test/mercury200_test.cpp
+++ b/test/mercury200_test.cpp
@@ -36,21 +36,21 @@ void TMercury200Test::SetUp()
         std::make_shared<TMercury200Device>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("mercury200"));
 
     Mercury200RET1Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2700, BCD32));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2700, RegisterFormat::BCD32));
     Mercury200RET2Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2704, BCD32));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2704, RegisterFormat::BCD32));
     Mercury200RET3Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2708, BCD32));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x2708, RegisterFormat::BCD32));
     Mercury200RET4Reg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x270C, BCD32));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE32, 0x270C, RegisterFormat::BCD32));
     Mercury200UReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6300, BCD16));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6300, RegisterFormat::BCD16));
     Mercury200IReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6302, BCD16));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x6302, RegisterFormat::BCD16));
     Mercury200PReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE24, 0x6304, BCD24));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE24, 0x6304, RegisterFormat::BCD24));
     Mercury200BatReg =
-        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x2900, BCD16));
+        TRegister::Intern(Mercury200Dev, TRegisterConfig::Create(TMercury200Device::REG_PARAM_VALUE16, 0x2900, RegisterFormat::BCD16));
 
     SerialPort->Open();
 }

--- a/test/mercury230_test.cpp
+++ b/test/mercury230_test.cpp
@@ -53,63 +53,88 @@ void TMercury230Test::SetUp()
     Mercury230Dev =
         std::make_shared<TMercury230Device>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("mercury230"));
     Mercury230TotalConsumptionReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
     Mercury230TotalReactiveEnergyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
 
     Mercury230PReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
     Mercury230P1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1101, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1101, RegisterFormat::S24));
     Mercury230P2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1102, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1102, RegisterFormat::S24));
     Mercury230P3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1103, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1103, RegisterFormat::S24));
 
-    Mercury230QReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1104, RegisterFormat::S24));
-    Mercury230Q1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1105, RegisterFormat::S24));
-    Mercury230Q2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1106, RegisterFormat::S24));
-    Mercury230Q3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1107, RegisterFormat::S24));
+    Mercury230QReg = TRegister::Intern(
+        Mercury230Dev,
+        TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1104, RegisterFormat::S24));
+    Mercury230Q1Reg = TRegister::Intern(
+        Mercury230Dev,
+        TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1105, RegisterFormat::S24));
+    Mercury230Q2Reg = TRegister::Intern(
+        Mercury230Dev,
+        TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1106, RegisterFormat::S24));
+    Mercury230Q3Reg = TRegister::Intern(
+        Mercury230Dev,
+        TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1107, RegisterFormat::S24));
 
     Mercury230U1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
     Mercury230U2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
     Mercury230U3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1113, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1113, RegisterFormat::U24));
 
     Mercury230I1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
     Mercury230I2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1122, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1122, RegisterFormat::U24));
     Mercury230I3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1123, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1123, RegisterFormat::U24));
 
     Mercury230FrequencyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1140, RegisterFormat::U24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1140, RegisterFormat::U24));
 
     Mercury230PFReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1130, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1130, RegisterFormat::S24));
     Mercury230PF1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1131, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1131, RegisterFormat::S24));
     Mercury230PF2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1132, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1132, RegisterFormat::S24));
     Mercury230PF3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1133, RegisterFormat::S24));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1133, RegisterFormat::S24));
 
     Mercury230KU1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1161, RegisterFormat::U16));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1161, RegisterFormat::U16));
     Mercury230KU2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1162, RegisterFormat::U16));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1162, RegisterFormat::U16));
     Mercury230KU3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1163, RegisterFormat::U16));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1163, RegisterFormat::U16));
 
     Mercury230TempReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::U16));
+        TRegister::Intern(Mercury230Dev,
+                          TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::U16));
 
     SerialPort->Open();
 }

--- a/test/mercury230_test.cpp
+++ b/test/mercury230_test.cpp
@@ -53,63 +53,63 @@ void TMercury230Test::SetUp()
     Mercury230Dev =
         std::make_shared<TMercury230Device>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("mercury230"));
     Mercury230TotalConsumptionReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, U32));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0000, RegisterFormat::U32));
     Mercury230TotalReactiveEnergyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, U32));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_VALUE_ARRAY, 0x0002, RegisterFormat::U32));
 
     Mercury230PReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1100, RegisterFormat::S24));
     Mercury230P1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1101, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1101, RegisterFormat::S24));
     Mercury230P2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1102, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1102, RegisterFormat::S24));
     Mercury230P3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1103, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1103, RegisterFormat::S24));
 
     Mercury230QReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1104, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1104, RegisterFormat::S24));
     Mercury230Q1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1105, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1105, RegisterFormat::S24));
     Mercury230Q2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1106, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1106, RegisterFormat::S24));
     Mercury230Q3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1107, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_REACT, 0x1107, RegisterFormat::S24));
 
     Mercury230U1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1111, RegisterFormat::U24));
     Mercury230U2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1112, RegisterFormat::U24));
     Mercury230U3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1113, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1113, RegisterFormat::U24));
 
     Mercury230I1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1121, RegisterFormat::U24));
     Mercury230I2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1122, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1122, RegisterFormat::U24));
     Mercury230I3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1123, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1123, RegisterFormat::U24));
 
     Mercury230FrequencyReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1140, U24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1140, RegisterFormat::U24));
 
     Mercury230PFReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1130, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1130, RegisterFormat::S24));
     Mercury230PF1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1131, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1131, RegisterFormat::S24));
     Mercury230PF2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1132, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1132, RegisterFormat::S24));
     Mercury230PF3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1133, S24));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_SIGN_ACT, 0x1133, RegisterFormat::S24));
 
     Mercury230KU1Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1161, U16));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1161, RegisterFormat::U16));
     Mercury230KU2Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1162, U16));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1162, RegisterFormat::U16));
     Mercury230KU3Reg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1163, U16));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM, 0x1163, RegisterFormat::U16));
 
     Mercury230TempReg =
-        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, U16));
+        TRegister::Intern(Mercury230Dev, TRegisterConfig::Create(TMercury230Device::REG_PARAM_BE, 0x1170, RegisterFormat::U16));
 
     SerialPort->Open();
 }

--- a/test/milur_test.cpp
+++ b/test/milur_test.cpp
@@ -47,18 +47,28 @@ void TMilurTest::SetUp()
 
     MilurDev = std::make_shared<TMilurDevice>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("milur"));
 
-    MilurPhaseAVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 100, RegisterFormat::U24));
-    MilurPhaseBVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 101, RegisterFormat::U24));
-    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
+    MilurPhaseAVoltageReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 100, RegisterFormat::U24));
+    MilurPhaseBVoltageReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 101, RegisterFormat::U24));
+    MilurPhaseCVoltageReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
 
-    MilurPhaseACurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 103, RegisterFormat::S24));
-    MilurPhaseBCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 104, RegisterFormat::S24));
-    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::S24));
+    MilurPhaseACurrentReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 103, RegisterFormat::S24));
+    MilurPhaseBCurrentReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 104, RegisterFormat::S24));
+    MilurPhaseCCurrentReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::S24));
 
-    MilurPhaseAActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 106, RegisterFormat::S32));
-    MilurPhaseBActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 107, RegisterFormat::S32));
-    MilurPhaseCActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 108, RegisterFormat::S32));
-    MilurTotalActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 109, RegisterFormat::S32));
+    MilurPhaseAActivePowerReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 106, RegisterFormat::S32));
+    MilurPhaseBActivePowerReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 107, RegisterFormat::S32));
+    MilurPhaseCActivePowerReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 108, RegisterFormat::S32));
+    MilurTotalActivePowerReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 109, RegisterFormat::S32));
 
     MilurPhaseAReactivePowerReg =
         TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 110, RegisterFormat::S32));
@@ -73,7 +83,8 @@ void TMilurTest::SetUp()
         TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, RegisterFormat::BCD32));
     MilurTotalReactiveEnergyReg =
         TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 127, RegisterFormat::BCD32));
-    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
+    MilurFrequencyReg =
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
 
     SerialPort->Open();
 }

--- a/test/milur_test.cpp
+++ b/test/milur_test.cpp
@@ -47,33 +47,33 @@ void TMilurTest::SetUp()
 
     MilurDev = std::make_shared<TMilurDevice>(GetDeviceConfig(), SerialPort, DeviceFactory.GetProtocol("milur"));
 
-    MilurPhaseAVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 100, U24));
-    MilurPhaseBVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 101, U24));
-    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, U24));
+    MilurPhaseAVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 100, RegisterFormat::U24));
+    MilurPhaseBVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 101, RegisterFormat::U24));
+    MilurPhaseCVoltageReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 102, RegisterFormat::U24));
 
-    MilurPhaseACurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 103, S24));
-    MilurPhaseBCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 104, S24));
-    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, S24));
+    MilurPhaseACurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 103, RegisterFormat::S24));
+    MilurPhaseBCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 104, RegisterFormat::S24));
+    MilurPhaseCCurrentReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_PARAM, 105, RegisterFormat::S24));
 
-    MilurPhaseAActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 106, S32));
-    MilurPhaseBActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 107, S32));
-    MilurPhaseCActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 108, S32));
-    MilurTotalActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 109, S32));
+    MilurPhaseAActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 106, RegisterFormat::S32));
+    MilurPhaseBActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 107, RegisterFormat::S32));
+    MilurPhaseCActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 108, RegisterFormat::S32));
+    MilurTotalActivePowerReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 109, RegisterFormat::S32));
 
     MilurPhaseAReactivePowerReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 110, S32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 110, RegisterFormat::S32));
     MilurPhaseBReactivePowerReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 111, S32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 111, RegisterFormat::S32));
     MilurPhaseCReactivePowerReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 112, S32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 112, RegisterFormat::S32));
     MilurTotalReactivePowerReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 113, S32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_POWER, 113, RegisterFormat::S32));
 
     MilurTotalConsumptionReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, BCD32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, RegisterFormat::BCD32));
     MilurTotalReactiveEnergyReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 127, BCD32));
-    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, U16));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 127, RegisterFormat::BCD32));
+    MilurFrequencyReg = TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_FREQ, 9, RegisterFormat::U16));
 
     SerialPort->Open();
 }
@@ -235,7 +235,7 @@ void TMilur32Test::SetUp()
     TSerialDeviceTest::SetUp();
     MilurDev = std::make_shared<TMilurDevice>(MilurConfig(), SerialPort, DeviceFactory.GetProtocol("milur"));
     MilurTotalConsumptionReg =
-        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, BCD32));
+        TRegister::Intern(MilurDev, TRegisterConfig::Create(TMilurDevice::REG_ENERGY, 118, RegisterFormat::BCD32));
 
     SerialPort->Open();
 }

--- a/test/modbus_test.cpp
+++ b/test/modbus_test.cpp
@@ -49,17 +49,23 @@ void TModbusTest::SetUp()
                                                 GetDeviceConfig(),
                                                 SerialPort,
                                                 DeviceFactory.GetProtocol("modbus"));
-    ModbusCoil0 = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_COIL, 0, U8));
-    ModbusCoil1 = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_COIL, 1, U8));
-    ModbusDiscrete = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_DISCRETE, 20, U8));
-    ModbusHolding = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING, 70, U16));
-    ModbusInput = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_INPUT, 40, U16));
-    ModbusHoldingS64 = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING, 30, S64));
+    ModbusCoil0 = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_COIL, 0, RegisterFormat::U8));
+    ModbusCoil1 = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_COIL, 1, RegisterFormat::U8));
+    ModbusDiscrete =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_DISCRETE, 20, RegisterFormat::U8));
+    ModbusHolding = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING, 70, RegisterFormat::U16));
+    ModbusInput = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_INPUT, 40, RegisterFormat::U16));
+    ModbusHoldingS64 =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING, 30, RegisterFormat::S64));
 
-    ModbusHoldingU64Single = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_SINGLE, 90, U64));
-    ModbusHoldingU16Single = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_SINGLE, 94, U16));
-    ModbusHoldingU64Multi = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_MULTI, 95, U64));
-    ModbusHoldingU16Multi = TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_MULTI, 99, U16));
+    ModbusHoldingU64Single =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_SINGLE, 90, RegisterFormat::U64));
+    ModbusHoldingU16Single =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_SINGLE, 94, RegisterFormat::U16));
+    ModbusHoldingU64Multi =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_MULTI, 95, RegisterFormat::U64));
+    ModbusHoldingU16Multi =
+        TRegister::Intern(ModbusDev, TRegisterConfig::Create(Modbus::REG_HOLDING_MULTI, 99, RegisterFormat::U16));
 
     SerialPort->Open();
 }

--- a/test/pulsar_test.cpp
+++ b/test/pulsar_test.cpp
@@ -23,8 +23,8 @@ void TPulsarDeviceTest::SetUp()
         SerialPort,
         DeviceFactory.GetProtocol("pulsar"));
 
-    Heat_TempIn = TRegister::Intern(Dev, TRegisterConfig::Create(0, 2, Float));
-    Heat_TempOut = TRegister::Intern(Dev, TRegisterConfig::Create(0, 3, Float));
+    Heat_TempIn = TRegister::Intern(Dev, TRegisterConfig::Create(0, 2, RegisterFormat::Float));
+    Heat_TempOut = TRegister::Intern(Dev, TRegisterConfig::Create(0, 3, RegisterFormat::Float));
 
     SerialPort->Open();
 }

--- a/test/s2k_test.cpp
+++ b/test/s2k_test.cpp
@@ -25,10 +25,10 @@ void TS2KDeviceTest::SetUp()
                                        SerialPort,
                                        DeviceFactory.GetProtocol("s2k"));
 
-    RelayReg1 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x01, U8));
-    RelayReg2 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x02, U8));
-    RelayReg3 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x03, U8));
-    RelayReg4 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x04, U8));
+    RelayReg1 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x01, RegisterFormat::U8));
+    RelayReg2 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x02, RegisterFormat::U8));
+    RelayReg3 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x03, RegisterFormat::U8));
+    RelayReg4 = TRegister::Intern(Dev, TRegisterConfig::Create(TS2KDevice::REG_RELAY, 0x04, RegisterFormat::U8));
 
     SerialPort->Open();
 }

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -33,7 +33,7 @@ protected:
     void SetUp();
     void TearDown();
     PRegister Reg(int addr,
-                  RegisterFormat fmt = U16,
+                  RegisterFormat fmt = RegisterFormat::U16,
                   double scale = 1,
                   double offset = 0,
                   double round_to = 0,
@@ -146,8 +146,8 @@ TEST_F(TSerialClientTest, PortOpenError)
     // The test checks recovery logic after port opening failure
     // TSerialClient must try to open port during every cycle and set /meta/error for controls
 
-    PRegister reg0 = Reg(0, U8);
-    PRegister reg1 = Reg(1, U8);
+    PRegister reg0 = Reg(0, RegisterFormat::U8);
+    PRegister reg1 = Reg(1, RegisterFormat::U8);
 
     SerialClient->AddRegister(reg0);
     SerialClient->AddRegister(reg1);
@@ -171,8 +171,8 @@ TEST_F(TSerialClientReopenTest, ReopenTimeout)
     // The test checks recovery logic after port opening failure
     // TSerialClient must try to open port during every cycle and set /meta/error for controls
 
-    PRegister reg0 = Reg(0, U8);
-    PRegister reg1 = Reg(1, U8);
+    PRegister reg0 = Reg(0, RegisterFormat::U8);
+    PRegister reg1 = Reg(1, RegisterFormat::U8);
 
     SerialClient->AddRegister(reg0);
     SerialClient->AddRegister(reg1);
@@ -195,8 +195,8 @@ TEST_F(TSerialClientReopenTest, ReopenTimeout)
 TEST_F(TSerialClientTest, Poll)
 {
 
-    PRegister reg0 = Reg(0, U8);
-    PRegister reg1 = Reg(1, U8);
+    PRegister reg0 = Reg(0, RegisterFormat::U8);
+    PRegister reg1 = Reg(1, RegisterFormat::U8);
     PRegister discrete10 = Reg(10);
     PRegister reg22 = Reg(22);
     PRegister reg33 = Reg(33);
@@ -251,8 +251,8 @@ TEST_F(TSerialClientTest, Write)
 
 TEST_F(TSerialClientTest, S8)
 {
-    PRegister reg20 = Reg(20, S8);
-    PRegister reg30 = Reg(30, S8);
+    PRegister reg20 = Reg(20, RegisterFormat::S8);
+    PRegister reg30 = Reg(30, RegisterFormat::S8);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -289,8 +289,8 @@ TEST_F(TSerialClientTest, S8)
 
 TEST_F(TSerialClientTest, Char8)
 {
-    PRegister reg20 = Reg(20, Char8);
-    PRegister reg30 = Reg(30, Char8);
+    PRegister reg20 = Reg(20, RegisterFormat::Char8);
+    PRegister reg30 = Reg(30, RegisterFormat::Char8);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -312,8 +312,8 @@ TEST_F(TSerialClientTest, Char8)
 
 TEST_F(TSerialClientTest, S64)
 {
-    PRegister reg20 = Reg(20, S64);
-    PRegister reg30 = Reg(30, S64);
+    PRegister reg20 = Reg(20, RegisterFormat::S64);
+    PRegister reg30 = Reg(30, RegisterFormat::S64);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -354,8 +354,8 @@ TEST_F(TSerialClientTest, S64)
 
 TEST_F(TSerialClientTest, U64)
 {
-    PRegister reg20 = Reg(20, U64);
-    PRegister reg30 = Reg(30, U64);
+    PRegister reg20 = Reg(20, RegisterFormat::U64);
+    PRegister reg30 = Reg(30, RegisterFormat::U64);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -396,13 +396,13 @@ TEST_F(TSerialClientTest, U64)
 
 TEST_F(TSerialClientTest, S32)
 {
-    PRegister reg20 = Reg(20, S32);
-    PRegister reg30 = Reg(30, S32);
+    PRegister reg20 = Reg(20, RegisterFormat::S32);
+    PRegister reg30 = Reg(30, RegisterFormat::S32);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
     // create scaled register
-    PRegister reg24 = Reg(24, S32, 0.001);
+    PRegister reg24 = Reg(24, RegisterFormat::S32, 0.001);
     SerialClient->AddRegister(reg24);
 
     Note() << "server -> client: 10, 20";
@@ -449,13 +449,13 @@ TEST_F(TSerialClientTest, S32)
 
 TEST_F(TSerialClientTest, S24)
 {
-    PRegister reg20 = Reg(20, S24);
-    PRegister reg30 = Reg(30, S24);
+    PRegister reg20 = Reg(20, RegisterFormat::S24);
+    PRegister reg30 = Reg(30, RegisterFormat::S24);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
     // create scaled register
-    PRegister reg24 = Reg(24, S24, 0.001);
+    PRegister reg24 = Reg(24, RegisterFormat::S24, 0.001);
     SerialClient->AddRegister(reg24);
 
     Note() << "server -> client: 10, 20";
@@ -502,8 +502,8 @@ TEST_F(TSerialClientTest, S24)
 
 TEST_F(TSerialClientTest, WordSwap)
 {
-    PRegister reg20 = Reg(20, S32, 1, 0, 0, EWordOrder::LittleEndian);
-    PRegister reg24 = Reg(24, U64, 1, 0, 0, EWordOrder::LittleEndian);
+    PRegister reg20 = Reg(20, RegisterFormat::S32, 1, 0, 0, EWordOrder::LittleEndian);
+    PRegister reg24 = Reg(24, RegisterFormat::U64, 1, 0, 0, EWordOrder::LittleEndian);
     SerialClient->AddRegister(reg24);
     SerialClient->AddRegister(reg20);
 
@@ -536,8 +536,8 @@ TEST_F(TSerialClientTest, WordSwap)
 
 TEST_F(TSerialClientTest, U32)
 {
-    PRegister reg20 = Reg(20, U32);
-    PRegister reg30 = Reg(30, U32);
+    PRegister reg20 = Reg(20, RegisterFormat::U32);
+    PRegister reg30 = Reg(30, RegisterFormat::U32);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -584,7 +584,7 @@ TEST_F(TSerialClientTest, U32)
 
 TEST_F(TSerialClientTest, BCD32)
 {
-    PRegister reg20 = Reg(20, BCD32);
+    PRegister reg20 = Reg(20, RegisterFormat::BCD32);
     SerialClient->AddRegister(reg20);
     Device->Registers[22] = 123;
     Device->Registers[23] = 123;
@@ -619,7 +619,7 @@ TEST_F(TSerialClientTest, BCD32)
 
 TEST_F(TSerialClientTest, BCD24)
 {
-    PRegister reg20 = Reg(20, BCD24);
+    PRegister reg20 = Reg(20, RegisterFormat::BCD24);
     SerialClient->AddRegister(reg20);
     Device->Registers[22] = 123;
     Device->Registers[23] = 123;
@@ -646,7 +646,7 @@ TEST_F(TSerialClientTest, BCD24)
 
 TEST_F(TSerialClientTest, BCD16)
 {
-    PRegister reg20 = Reg(20, BCD16);
+    PRegister reg20 = Reg(20, RegisterFormat::BCD16);
     SerialClient->AddRegister(reg20);
     Device->Registers[21] = 123;
 
@@ -669,7 +669,7 @@ TEST_F(TSerialClientTest, BCD16)
 
 TEST_F(TSerialClientTest, BCD8)
 {
-    PRegister reg20 = Reg(20, BCD8);
+    PRegister reg20 = Reg(20, RegisterFormat::BCD8);
     SerialClient->AddRegister(reg20);
     Device->Registers[21] = 123;
 
@@ -693,11 +693,11 @@ TEST_F(TSerialClientTest, BCD8)
 TEST_F(TSerialClientTest, Float32)
 {
     // create scaled register
-    PRegister reg24 = Reg(24, Float, 100);
+    PRegister reg24 = Reg(24, RegisterFormat::Float, 100);
     SerialClient->AddRegister(reg24);
 
-    PRegister reg20 = Reg(20, Float);
-    PRegister reg30 = Reg(30, Float);
+    PRegister reg20 = Reg(20, RegisterFormat::Float);
+    PRegister reg30 = Reg(30, RegisterFormat::Float);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -746,11 +746,11 @@ TEST_F(TSerialClientTest, Float32)
 TEST_F(TSerialClientTest, Double64)
 {
     // create scaled register
-    PRegister reg24 = Reg(24, Double, 100);
+    PRegister reg24 = Reg(24, RegisterFormat::Double, 100);
     SerialClient->AddRegister(reg24);
 
-    PRegister reg20 = Reg(20, Double);
-    PRegister reg30 = Reg(30, Double);
+    PRegister reg20 = Reg(20, RegisterFormat::Double);
+    PRegister reg30 = Reg(30, RegisterFormat::Double);
     SerialClient->AddRegister(reg20);
     SerialClient->AddRegister(reg30);
 
@@ -814,7 +814,7 @@ TEST_F(TSerialClientTest, Double64)
 TEST_F(TSerialClientTest, offset)
 {
     // create scaled register with offset
-    PRegister reg24 = Reg(24, S16, 3, -15);
+    PRegister reg24 = Reg(24, RegisterFormat::S16, 3, -15);
     SerialClient->AddRegister(reg24);
 
     Note() << "client -> server: -87 (scaled)";
@@ -827,11 +827,11 @@ TEST_F(TSerialClientTest, offset)
 
 TEST_F(TSerialClientTest, Round)
 {
-    PRegister reg24_0_01 = Reg(24, Float, 1, 0, 0.01);
-    PRegister reg26_1 = Reg(26, Float, 1, 0, 1);
-    PRegister reg28_10 = Reg(28, Float, 1, 0, 10);
-    PRegister reg30_0_2 = Reg(30, Float, 1, 0, 0.2);
-    PRegister reg32_0_01 = Reg(32, Float, 1, 0, 0.01);
+    PRegister reg24_0_01 = Reg(24, RegisterFormat::Float, 1, 0, 0.01);
+    PRegister reg26_1 = Reg(26, RegisterFormat::Float, 1, 0, 1);
+    PRegister reg28_10 = Reg(28, RegisterFormat::Float, 1, 0, 10);
+    PRegister reg30_0_2 = Reg(30, RegisterFormat::Float, 1, 0, 0.2);
+    PRegister reg32_0_01 = Reg(32, RegisterFormat::Float, 1, 0, 0.01);
 
     SerialClient->AddRegister(reg24_0_01);
     SerialClient->AddRegister(reg26_1);

--- a/test/uniel_test.cpp
+++ b/test/uniel_test.cpp
@@ -25,10 +25,10 @@ void TUnielDeviceTest::SetUp()
                                          SerialPort,
                                          DeviceFactory.GetProtocol("uniel"));
 
-    InputReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_INPUT, 0x0a, U8));
-    RelayReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_RELAY, 0x1b, U8));
-    ThresholdReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_PARAM, 0x02, U8));
-    BrightnessReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_BRIGHTNESS, 0x141, U8));
+    InputReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_INPUT, 0x0a, RegisterFormat::U8));
+    RelayReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_RELAY, 0x1b, RegisterFormat::U8));
+    ThresholdReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_PARAM, 0x02, RegisterFormat::U8));
+    BrightnessReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_BRIGHTNESS, 0x141, RegisterFormat::U8));
 
     SerialPort->Open();
 }

--- a/test/uniel_test.cpp
+++ b/test/uniel_test.cpp
@@ -28,7 +28,8 @@ void TUnielDeviceTest::SetUp()
     InputReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_INPUT, 0x0a, RegisterFormat::U8));
     RelayReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_RELAY, 0x1b, RegisterFormat::U8));
     ThresholdReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_PARAM, 0x02, RegisterFormat::U8));
-    BrightnessReg = TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_BRIGHTNESS, 0x141, RegisterFormat::U8));
+    BrightnessReg =
+        TRegister::Intern(Dev, TRegisterConfig::Create(TUnielDevice::REG_BRIGHTNESS, 0x141, RegisterFormat::U8));
 
     SerialPort->Open();
 }

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -662,6 +662,14 @@
               "options": {
                 "keep_oneof_values": false
               }
+            },
+            "write_address": {
+              "$ref": "#/definitions/address",
+              "title": "Write Address",
+              "propertyOrder": 7,
+              "options": {
+                "keep_oneof_values": false
+              }
             }
           },
           "required": ["address"]

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -1678,6 +1678,7 @@
       "Command name": "Название команды",
       "Used for logging/debugging purposes only": "Используется только для диагностических сообщений",
       "Address": "Адрес",
+      "Write Address" : "Адрес записи",
       "Register index (0-65535 in case of Modbus)": "Номер регистра (0-65535 для Modbus)",
       "Value": "Значение",
       "Enabled": "Включено",


### PR DESCRIPTION
* Добавил в схему и в парсер конфига обработку адреса записи ("write_address") для modbus устройства
* Добавил функциональность: если для modbus устройства установлена опция write_address, то запись в регистр осуществляется по адресу записи. Если опция write_address не установлена, то чтение и запись происходит по одному и тому же адресу("address").
* Заменил enum на enum class для RegisterFormat. Считаю, что так будет правильно: много методов с большим числом  параметров по умолчанию использующих RegisterFormat - можно легко ошибиться при модификации методов и подстановке аргументов.