### PR TITLE
Fixed a Phi parameter range for WB-MAP templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.49.1) stable; urgency=medium
+
+  * Fixed a Phi parameter range for WB-MAP templates
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 1 Feb 2022 23:46:00 +0300
+
 wb-mqtt-serial (2.49.0) stable; urgency=medium
 
   * "deprecated" parameter is added to mark deprecated device templates

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.49.1) stable; urgency=medium
 
-  * Fixed a Phi parameter range for WB-MAP templates
+  * Extended range of phi parameter for WB-MAP templates from -32768 to 32767
 
  -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 1 Feb 2022 23:46:00 +0300
 

--- a/wb-mqtt-serial-templates/config-map12e-fw2.json
+++ b/wb-mqtt-serial-templates/config-map12e-fw2.json
@@ -116,7 +116,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l1",
                 "order": 2
             },
@@ -146,7 +147,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l2",
                 "order": 2
             },
@@ -176,7 +178,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l3",
                 "order": 2
             },
@@ -206,7 +209,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l1",
                 "order": 2
             },
@@ -236,7 +240,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l2",
                 "order": 2
             },
@@ -266,7 +271,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l3",
                 "order": 2
             },
@@ -296,7 +302,8 @@
                 "address": "0x3463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l1",
                 "order": 2
             },
@@ -326,7 +333,8 @@
                 "address": "0x3464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l2",
                 "order": 2
             },
@@ -356,7 +364,8 @@
                 "address": "0x3465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l3",
                 "order": 2
             },
@@ -386,7 +395,8 @@
                 "address": "0x4463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l1",
                 "order": 2
             },
@@ -416,7 +426,8 @@
                 "address": "0x4464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l2",
                 "order": 2
             },
@@ -446,7 +457,8 @@
                 "address": "0x4465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l3",
                 "order": 2
             },

--- a/wb-mqtt-serial-templates/config-map12h-fw2-all-harmonics.json
+++ b/wb-mqtt-serial-templates/config-map12h-fw2-all-harmonics.json
@@ -116,7 +116,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l1",
                 "order": 2
             },
@@ -134,7 +135,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l2",
                 "order": 2
             },
@@ -152,7 +154,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l3",
                 "order": 2
             },
@@ -170,7 +173,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l1",
                 "order": 2
             },
@@ -188,7 +192,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l2",
                 "order": 2
             },
@@ -206,7 +211,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l3",
                 "order": 2
             },
@@ -224,7 +230,8 @@
                 "address": "0x3463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l1",
                 "order": 2
             },
@@ -242,7 +249,8 @@
                 "address": "0x3464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l2",
                 "order": 2
             },
@@ -260,7 +268,8 @@
                 "address": "0x3465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l3",
                 "order": 2
             },
@@ -278,7 +287,8 @@
                 "address": "0x4463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l1",
                 "order": 2
             },
@@ -296,7 +306,8 @@
                 "address": "0x4464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l2",
                 "order": 2
             },
@@ -314,7 +325,8 @@
                 "address": "0x4465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map12h-fw2-basic.json
+++ b/wb-mqtt-serial-templates/config-map12h-fw2-basic.json
@@ -116,7 +116,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l1",
                 "order": 2
             },
@@ -134,7 +135,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l2",
                 "order": 2
             },
@@ -152,7 +154,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l3",
                 "order": 2
             },
@@ -170,7 +173,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l1",
                 "order": 2
             },
@@ -188,7 +192,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l2",
                 "order": 2
             },
@@ -206,7 +211,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l3",
                 "order": 2
             },
@@ -224,7 +230,8 @@
                 "address": "0x3463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l1",
                 "order": 2
             },
@@ -242,7 +249,8 @@
                 "address": "0x3464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l2",
                 "order": 2
             },
@@ -260,7 +268,8 @@
                 "address": "0x3465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l3",
                 "order": 2
             },
@@ -278,7 +287,8 @@
                 "address": "0x4463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l1",
                 "order": 2
             },
@@ -296,7 +306,8 @@
                 "address": "0x4464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l2",
                 "order": 2
             },
@@ -314,7 +325,8 @@
                 "address": "0x4465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map12h-fw2-harmonics.json
+++ b/wb-mqtt-serial-templates/config-map12h-fw2-harmonics.json
@@ -116,7 +116,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l1",
                 "order": 2
             },
@@ -134,7 +135,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l2",
                 "order": 2
             },
@@ -152,7 +154,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l3",
                 "order": 2
             },
@@ -170,7 +173,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l1",
                 "order": 2
             },
@@ -188,7 +192,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l2",
                 "order": 2
             },
@@ -206,7 +211,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l3",
                 "order": 2
             },
@@ -224,7 +230,8 @@
                 "address": "0x3463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l1",
                 "order": 2
             },
@@ -242,7 +249,8 @@
                 "address": "0x3464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l2",
                 "order": 2
             },
@@ -260,7 +268,8 @@
                 "address": "0x3465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l3",
                 "order": 2
             },
@@ -278,7 +287,8 @@
                 "address": "0x4463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l1",
                 "order": 2
             },
@@ -296,7 +306,8 @@
                 "address": "0x4464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l2",
                 "order": 2
             },
@@ -314,7 +325,8 @@
                 "address": "0x4465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map12h-fw2.json
+++ b/wb-mqtt-serial-templates/config-map12h-fw2.json
@@ -116,7 +116,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l1",
                 "order": 2
             },
@@ -134,7 +135,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l2",
                 "order": 2
             },
@@ -152,7 +154,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel1_l3",
                 "order": 2
             },
@@ -170,7 +173,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l1",
                 "order": 2
             },
@@ -188,7 +192,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l2",
                 "order": 2
             },
@@ -206,7 +211,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel2_l3",
                 "order": 2
             },
@@ -224,7 +230,8 @@
                 "address": "0x3463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l1",
                 "order": 2
             },
@@ -242,7 +249,8 @@
                 "address": "0x3464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l2",
                 "order": 2
             },
@@ -260,7 +268,8 @@
                 "address": "0x3465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel3_l3",
                 "order": 2
             },
@@ -278,7 +287,8 @@
                 "address": "0x4463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l1",
                 "order": 2
             },
@@ -296,7 +306,8 @@
                 "address": "0x4464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l2",
                 "order": 2
             },
@@ -314,7 +325,8 @@
                 "address": "0x4465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel4_l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map3e-fw2.json
+++ b/wb-mqtt-serial-templates/config-map3e-fw2.json
@@ -56,7 +56,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l1",
                 "order": 2
             },
@@ -86,7 +87,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l2",
                 "order": 2
             },
@@ -116,7 +118,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l3",
                 "order": 2
             },

--- a/wb-mqtt-serial-templates/config-map3h-fw2-basic.json
+++ b/wb-mqtt-serial-templates/config-map3h-fw2-basic.json
@@ -56,7 +56,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l1",
                 "order": 2
             },
@@ -74,7 +75,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l2",
                 "order": 2
             },
@@ -92,7 +94,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map3h-fw2-harmonics.json
+++ b/wb-mqtt-serial-templates/config-map3h-fw2-harmonics.json
@@ -56,7 +56,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l1",
                 "order": 2
             },
@@ -74,7 +75,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l2",
                 "order": 2
             },
@@ -92,7 +94,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map3h-fw2.json
+++ b/wb-mqtt-serial-templates/config-map3h-fw2.json
@@ -56,7 +56,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l1",
                 "order": 2
             },
@@ -74,7 +75,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l2",
                 "order": 2
             },
@@ -92,7 +94,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "l3",
                 "order": 2
             }

--- a/wb-mqtt-serial-templates/config-map6s-fw2.json
+++ b/wb-mqtt-serial-templates/config-map6s-fw2.json
@@ -66,7 +66,8 @@
                 "address": "0x1465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_1",
                 "order": 2
             },
@@ -84,7 +85,8 @@
                 "address": "0x1464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_2",
                 "order": 2
             },
@@ -102,7 +104,8 @@
                 "address": "0x1463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_3",
                 "order": 2
             },
@@ -120,7 +123,8 @@
                 "address": "0x2465",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_4",
                 "order": 2
             },
@@ -138,7 +142,8 @@
                 "address": "0x2464",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_5",
                 "order": 2
             },
@@ -156,7 +161,8 @@
                 "address": "0x2463",
                 "reg_type": "holding",
                 "format": "s16",
-                "min": 0,
+                "min": -32768,
+                "max": 32767,
                 "group": "channel_6",
                 "order": 2
             }


### PR DESCRIPTION
Поправил шаблоны для WB-MAP*, чтобы Phi параметр мог принимать как отрицательные, так и положительные значения в диапазоне [-32768, 32767].