### PR TITLE
Bugfix/45090 fix incorrect display of register in u8 format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.49.2) stable; urgency=medium
+
+  * Fixed a incorrect value of the modbus register in U8 format
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 2 Feb 2022 15:59:00 +0300
+
 wb-mqtt-serial (2.49.1) stable; urgency=medium
 
   * Extended range of phi parameter for WB-MAP templates from -32768 to 32767

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -538,6 +538,8 @@ std::string ConvertFromRawValue(const TRegisterConfig& reg, uint64_t value)
 {
     value = InvertWordOrderIfNeeded(reg, value);
     switch (reg.Format) {
+        case U8:
+            return ToScaledTextValue(reg, uint8_t(value & 0xff));
         case S8:
             return ToScaledTextValue(reg, int8_t(value & 0xff));
         case S16:

--- a/test/TSerialClientTest.U8.dat
+++ b/test/TSerialClientTest.U8.dat
@@ -1,0 +1,34 @@
+>>> server -> client: 10, 20
+>>> Cycle()
+Open()
+Sleep(100000)
+fake_serial_device '1': read address '20' value '10'
+fake_serial_device '1': transfer OK
+fake_serial_device '1': reconnected
+Read Callback: <fake:1:fake: 20> becomes 10
+Error Callback: <fake:1:fake: 20>: no error
+fake_serial_device '1': read address '30' value '20'
+Read Callback: <fake:1:fake: 30> becomes 20
+Error Callback: <fake:1:fake: 30>: no error
+>>> server -> client: 0x2010, 0x2011
+>>> Cycle()
+fake_serial_device '1': read address '20' value '8208'
+Read Callback: <fake:1:fake: 20> becomes 16
+fake_serial_device '1': read address '30' value '8209'
+Read Callback: <fake:1:fake: 30> becomes 17
+>>> client -> server: 10
+>>> Cycle()
+fake_serial_device '1': write to address '20' value '10'
+Read Callback: <fake:1:fake: 20> becomes 10
+fake_serial_device '1': read address '20' value '10'
+Read Callback: <fake:1:fake: 20> becomes 10 [unchanged]
+fake_serial_device '1': read address '30' value '8209'
+Read Callback: <fake:1:fake: 30> becomes 17 [unchanged]
+>>> client -> server: 257
+>>> Cycle()
+fake_serial_device '1': write to address '20' value '1'
+Read Callback: <fake:1:fake: 20> becomes 1
+fake_serial_device '1': read address '20' value '1'
+Read Callback: <fake:1:fake: 20> becomes 1 [unchanged]
+fake_serial_device '1': read address '30' value '8209'
+Read Callback: <fake:1:fake: 30> becomes 17 [unchanged]

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -282,6 +282,44 @@ TEST_F(TSerialClientTest, Write)
     }
 }
 
+TEST_F(TSerialClientTest, U8)
+{
+    PRegister reg20 = Reg(20, U8);
+    PRegister reg30 = Reg(30, U8);
+    SerialClient->AddRegister(reg20);
+    SerialClient->AddRegister(reg30);
+
+    Note() << "server -> client: 10, 20";
+    Device->Registers[20] = 10;
+    Device->Registers[30] = 20;
+    Note() << "Cycle()";
+    SerialClient->Cycle();
+    EXPECT_EQ(to_string(10), GetTextValue(reg20));
+    EXPECT_EQ(to_string(20), GetTextValue(reg30));
+
+    Note() << "server -> client: 0x2010, 0x2011";
+    Device->Registers[20] = 0x2010;
+    Device->Registers[30] = 0x2011;
+    Note() << "Cycle()";
+    SerialClient->Cycle();
+    EXPECT_EQ(to_string(0x10), GetTextValue(reg20));
+    EXPECT_EQ(to_string(0x11), GetTextValue(reg30));
+
+    Note() << "client -> server: 10";
+    SerialClient->SetTextValue(reg20, "10");
+    Note() << "Cycle()";
+    SerialClient->Cycle();
+    EXPECT_EQ(to_string(10), GetTextValue(reg20));
+    EXPECT_EQ(10, Device->Registers[20]);
+
+    Note() << "client -> server: 257";
+    SerialClient->SetTextValue(reg20, "257");
+    Note() << "Cycle()";
+    SerialClient->Cycle();
+    EXPECT_EQ(to_string(1), GetTextValue(reg20));
+    EXPECT_EQ(1, Device->Registers[20]);
+}
+
 TEST_F(TSerialClientTest, S8)
 {
     PRegister reg20 = Reg(20, S8);


### PR DESCRIPTION
Исправил некорректное отображение значение пользовательского канала, сконфигурированного c форматом u8.

https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/45090/