### PR TITLE
45814 Fixed incorrect display of channel name when generating scheme

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.56.5) stable; urgency=medium
+
+  * Fixed incorrect display of channel name when generating scheme
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 5 Apr 2022 20:01:00 +0300
+
 wb-mqtt-serial (2.56.4) stable; urgency=medium
 
   * WB-MRGBW-D fw3 template: added description for press settings,

--- a/src/confed_schema_generator.cpp
+++ b/src/confed_schema_generator.cpp
@@ -781,7 +781,7 @@ Json::Value MakeSchemaForConfed(const Json::Value& configSchema,
 
 void AddGroupTitleTranslations(const std::string& id, const std::string& title, Json::Value& mainSchemaTranslations)
 {
-    if (mainSchemaTranslations.empty()){
+    if (mainSchemaTranslations.empty()) {
         mainSchemaTranslations["en"] = Json::Value(Json::objectValue);
     }
 

--- a/src/confed_schema_generator.cpp
+++ b/src/confed_schema_generator.cpp
@@ -781,7 +781,7 @@ Json::Value MakeSchemaForConfed(const Json::Value& configSchema,
 
 void AddGroupTitleTranslations(const std::string& id, const std::string& title, Json::Value& mainSchemaTranslations)
 {
-    if (mainSchemaTranslations.empty()) {
+    if (!mainSchemaTranslations.isMember("en")) {
         mainSchemaTranslations["en"] = Json::Value(Json::objectValue);
     }
 

--- a/src/confed_schema_generator.cpp
+++ b/src/confed_schema_generator.cpp
@@ -781,6 +781,10 @@ Json::Value MakeSchemaForConfed(const Json::Value& configSchema,
 
 void AddGroupTitleTranslations(const std::string& id, const std::string& title, Json::Value& mainSchemaTranslations)
 {
+    if (mainSchemaTranslations.empty()){
+        mainSchemaTranslations["en"] = Json::Value(Json::objectValue);
+    }
+
     for (auto langIt = mainSchemaTranslations.begin(); langIt != mainSchemaTranslations.end(); ++langIt) {
         if (langIt->isMember(title)) {
             (*langIt)[id] = (*langIt)[title];


### PR DESCRIPTION
Поправил генерацию схемы конфига для confed для правильного отображения названий каналов устройства, если в его шаблоне отсутствует перевод ("translations").