### PR TITLE
Fixed error code on unsuccessful conversion from confed to config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.56.6) stable; urgency=medium
+
+  * Fixed error code on unsuccessful conversion from confed to config
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Fri, 8 Apr 2022 09:49:00 +0300
+
 wb-mqtt-serial (2.56.5) stable; urgency=medium
 
   * Fixed incorrect display of channel name when generating scheme

--- a/src/device_template_generator.cpp
+++ b/src/device_template_generator.cpp
@@ -88,5 +88,6 @@ void GenerateDeviceTemplate(const std::string& appName, const std::string& desti
         PrintDeviceTemplateGenerationOptionsUsage(appName);
     } catch (const exception& e) {
         Error.Log() << e.what();
+        exit(EXIT_FAILURE);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,7 @@ namespace
                 ->write(MakeJsonForConfed(CONFIG_FULL_FILE_PATH, *configSchema, *templates, deviceFactory), &cout);
         } catch (const exception& e) {
             LOG(Error) << e.what();
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -150,6 +151,7 @@ namespace
             dst << src.rdbuf();
         } catch (const exception& e) {
             LOG(Error) << e.what();
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,7 @@ namespace
             MakeJsonWriter("  ", "None")->write(MakeConfigFromConfed(std::cin, *templates), &cout);
         } catch (const exception& e) {
             LOG(Error) << e.what();
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -222,16 +223,16 @@ namespace
                     break;
                 case 'j': // make JSON for confed from config's JSON
                     ConfigToConfed();
-                    exit(0);
+                    exit(EXIT_SUCCESS);
                 case 'J': // make config JSON from confed's JSON
                     ConfedToConfig();
-                    exit(0);
+                    exit(EXIT_SUCCESS);
                 case 'g':
                     SchemaForConfed();
-                    exit(0);
+                    exit(EXIT_SUCCESS);
                 case 'G':
                     GenerateDeviceTemplate(APP_NAME, USER_TEMPLATES_DIR, optarg);
-                    exit(0);
+                    exit(EXIT_SUCCESS);
                 case '?':
                 default:
                     PrintStartupInfo();
@@ -316,7 +317,7 @@ int main(int argc, char* argv[])
         });
         WBMQTT::SignalHandling::SetOnTimeout(SERIAL_DRIVER_STOP_TIMEOUT_S, [&] {
             LOG(Error) << "Driver takes too long to stop. Exiting.";
-            exit(1);
+            exit(EXIT_FAILURE);
         });
         WBMQTT::SignalHandling::Start();
         WBMQTT::SignalHandling::Wait();


### PR DESCRIPTION
При возникновении ошибки во время сохранения конфига для wb-mqtt-serial, текущий конфиг затирался из-за того, что код возврата из приложения "wb-mqtt-serial -J" соответствовал успешному выполнению, даже при возникновении ошибки. 
wb-mqtt-confed не сохраняет конфиг в случае возврата из "wb-mqtt-serial -J" кода ошибки.