### PR TITLE
Read timeout calculation for WB7 is fixed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.61.3) stable; urgency=medium
+
+  * Read timeout calculation for WB7 is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 03 Jun 2022 20:17:20 +0500
+
 wb-mqtt-serial (2.61.2) stable; urgency=medium
 
   * WB-MR6C v.3 jinja template

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -81,16 +81,18 @@ namespace
         while (std::experimental::filesystem::is_symlink(dev)) {
             dev = std::experimental::filesystem::read_symlink(dev);
         }
-        std::experimental::filesystem::path rxTrigBytesPath("/sys/class/tty");
-        std::ifstream f;
-        f.open(rxTrigBytesPath / dev.filename() / "rx_trig_bytes");
+        auto rxTrigBytesPath = "/sys/class/tty" / dev.filename() / "rx_trig_bytes";
+        std::ifstream f(rxTrigBytesPath);
         if (f.is_open()) {
             size_t val;
             try {
                 f >> val;
-                if (f.good())
+                if (f.good()) {
+                    LOG(Info) << rxTrigBytesPath << " = " << val;
                     return val;
-            } catch (...) {
+                }
+            } catch (const std::exception& e) {
+                LOG(Warn) << rxTrigBytesPath << " read failed: " << e.what();
             }
         }
         return 0;

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -75,13 +75,15 @@ namespace
         return std::chrono::milliseconds(baudRate < 9600 ? 34 : 24);
     }
 
-    size_t GetRxTrigBytes(const std::string& path)
+    size_t GetRxBytesTrig(const std::string& path)
     {
         std::experimental::filesystem::path dev(path);
         while (std::experimental::filesystem::is_symlink(dev)) {
             dev = std::experimental::filesystem::read_symlink(dev);
         }
-        std::ifstream f("/sys/class/tty" / dev.filename() / "rx_trig_bytes");
+        std::experimental::filesystem::path rxBytesTrigPath("/sys/class/tty");
+        std::ifstream f;
+        f.open(rxBytesTrigPath / dev.filename() / "rx_trig_bytes");
         if (f.is_open()) {
             size_t val;
             try {
@@ -97,7 +99,7 @@ namespace
 
 TSerialPort::TSerialPort(const TSerialPortSettings& settings)
     : Settings(settings),
-      RxTrigBytes(GetRxTrigBytes(Settings.Device))
+      RxTrigBytes(GetRxBytesTrig(Settings.Device))
 {
     memset(&OldTermios, 0, sizeof(termios));
 }

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -75,15 +75,15 @@ namespace
         return std::chrono::milliseconds(baudRate < 9600 ? 34 : 24);
     }
 
-    size_t GetRxBytesTrig(const std::string& path)
+    size_t GetRxTrigBytes(const std::string& path)
     {
         std::experimental::filesystem::path dev(path);
         while (std::experimental::filesystem::is_symlink(dev)) {
             dev = std::experimental::filesystem::read_symlink(dev);
         }
-        std::experimental::filesystem::path rxBytesTrigPath("/sys/class/tty");
+        std::experimental::filesystem::path rxTrigBytesPath("/sys/class/tty");
         std::ifstream f;
-        f.open(rxBytesTrigPath / dev.filename() / "rx_trig_bytes");
+        f.open(rxTrigBytesPath / dev.filename() / "rx_trig_bytes");
         if (f.is_open()) {
             size_t val;
             try {
@@ -99,7 +99,7 @@ namespace
 
 TSerialPort::TSerialPort(const TSerialPortSettings& settings)
     : Settings(settings),
-      RxTrigBytes(GetRxBytesTrig(Settings.Device))
+      RxTrigBytes(GetRxTrigBytes(Settings.Device))
 {
     memset(&OldTermios, 0, sizeof(termios));
 }

--- a/src/serial_port.h
+++ b/src/serial_port.h
@@ -34,6 +34,7 @@ public:
 private:
     TSerialPortSettings Settings;
     termios OldTermios;
+    size_t RxTrigBytes;
 };
 
 using PSerialPort = std::shared_ptr<TSerialPort>;


### PR DESCRIPTION
Для длинных пакетов select не срабатывает, пока не будет получено `rx_trig_bytes` байт. Это может быть больше чем заданный таймаут ожидания ответа. Добавил к таймауту время на получение этих байт.