### PR TITLE
Regeneration of JSON schema for wb-mqtt-homeui after config saving is fixed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.61.3) stable; urgency=medium
+
+  * Unwanted regeneration of JSON schema for wb-mqtt-homeui after config saving is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 06 Jun 2022 17:53:57 +0500
+
 wb-mqtt-serial (2.61.2) stable; urgency=medium
 
   * WB-MR6C v.3 jinja template

--- a/debian/wb-mqtt-serial.postinst
+++ b/debian/wb-mqtt-serial.postinst
@@ -27,3 +27,7 @@ ucf --debconf-ok $BOARD_CONF $CONFFILE
 rm -f /usr/share/wb-mqtt-confed/schemas/wb-mqtt-serial.schema.json
 
 #DEBHELPER#
+
+# deb-systemd-invoke doesn't start it.
+# "is a disabled or a static unit not running, not starting it"
+systemctl start wb-mqtt-serial-templates.service || true

--- a/debian/wb-mqtt-serial.postinst
+++ b/debian/wb-mqtt-serial.postinst
@@ -27,7 +27,3 @@ ucf --debconf-ok $BOARD_CONF $CONFFILE
 rm -f /usr/share/wb-mqtt-confed/schemas/wb-mqtt-serial.schema.json
 
 #DEBHELPER#
-
-# deb-systemd-invoke doesn't start it.
-# "is a disabled or a static unit not running, not starting it"
-systemctl start wb-mqtt-serial-templates.service || true

--- a/debian/wb-mqtt-serial.wb-mqtt-serial-templates.service
+++ b/debian/wb-mqtt-serial.wb-mqtt-serial-templates.service
@@ -3,3 +3,6 @@ Description=Generates wb-mqtt-serial UI schema for wb-mqtt-confed
 
 [Service]
 ExecStart=/usr/bin/wb-mqtt-serial -g
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/wb-mqtt-serial.wb-mqtt-serial.service
+++ b/debian/wb-mqtt-serial.wb-mqtt-serial.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=MQTT Driver for serial devices
-Wants=wb-hwconf-manager.service wb-modules.service wb-mqtt-serial-templates.service
-After=network.target wb-hwconf-manager.service wb-modules.service wb-mqtt-serial-templates.service
+Wants=wb-hwconf-manager.service wb-modules.service
+After=network.target wb-hwconf-manager.service wb-modules.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
При сохранении конфига `wb-mqtt-confed` перезапускал `wb-mqtt-serial`. Тот в свою очередь запускал `wb-mqtt-serial-templates`, т.к. оно было в `Wants`. В результате схема перегенерировалась каждый раз, как сохраняли конфиг через web-интерфейс.