### PR TITLE
Energomera CE303 polling doesn't lead to continuous port closing and opening

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.61.5) stable; urgency=medium
+
+  * Continuous port closing and opening during Energomera CE303 polling is fixed.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 10 Jun 2022 15:15:57 +0500
+
 wb-mqtt-serial (2.61.4) stable; urgency=medium
 
   * Read timeout calculation for WB7 is fixed

--- a/src/devices/energomera_iec_device.cpp
+++ b/src/devices/energomera_iec_device.cpp
@@ -242,6 +242,7 @@ void TEnergomeraIecWithFastReadDevice::ReadRegisterRange(PRegisterRange abstract
         char* presp = ReadResponse(*Port(), resp, RESPONSE_BUF_LEN, *DeviceConfig());
 
         ProcessResponse(*range, presp);
+        SetTransferResult(true);
     } catch (TSerialDeviceException& e) {
         for (auto& r: range->RegisterList()) {
             r->SetError(TRegister::TError::ReadError);
@@ -249,6 +250,7 @@ void TEnergomeraIecWithFastReadDevice::ReadRegisterRange(PRegisterRange abstract
         auto& logger = GetIsDisconnected() ? Debug : Warn;
         LOG(logger) << "TEnergomeraIecWithFastReadDevice::ReadRegisterRange(): " << e.what() << " [slave_id is "
                     << ToString() + "]";
+        SetTransferResult(false);
     }
 }
 


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-mqtt-serial/pull/446