### PR TITLE
Support for wb-mqtt-homeui 2.39.2 is added

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mqtt-serial (2.61.6) stable; urgency=medium
 
   * Support for wb-mqtt-homeui 2.39.2 is added
+  * Loading of device templates with parameters defined as array is fixed 
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 15 Jun 2022 12:46:38 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.61.6) stable; urgency=medium
+
+  * Support for wb-mqtt-homeui 2.39.2 is added
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 15 Jun 2022 12:46:38 +0500
+
 wb-mqtt-serial (2.61.5) stable; urgency=medium
 
   * Continuous port closing and opening during Energomera CE303 polling is fixed.

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-3 (>= 3.7.0)
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
-Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.16.0)
+Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.39.2)
 Description: Wiren Board Smart Home MQTT serial protocol driver
  wb-mqtt-serial is a service which communicates with devices on RS-485
  via Modbus or other supported protocols. Modbus TCP is also supported.

--- a/src/confed_schema_generator_with_groups.cpp
+++ b/src/confed_schema_generator_with_groups.cpp
@@ -43,7 +43,7 @@ namespace
     //          "enumTitles" : [ ... ]
     //      }
     //  }
-    Json::Value MakeParameterSchemaForAnyOf(const Json::Value& setupRegister, int index, TContext& context)
+    Json::Value MakeParameterSchemaForOneOf(const Json::Value& setupRegister, int index, TContext& context)
     {
         Json::Value r;
         r["type"] = setupRegister.isMember("scale") ? "number" : "integer";
@@ -83,7 +83,7 @@ namespace
     //  }
     Json::Value MakeParameterSchema(const Json::Value& setupRegister, int index, TContext& context)
     {
-        Json::Value r(MakeParameterSchemaForAnyOf(setupRegister, index, context));
+        Json::Value r(MakeParameterSchemaForOneOf(setupRegister, index, context));
         r["title"] = context.AddHashedTranslation(setupRegister["title"].asString());
         r["propertyOrder"] = index;
         SetIfExists(r, "group", setupRegister, "group");
@@ -102,7 +102,7 @@ namespace
         src.removeMember(key);
     }
 
-    void ConvertToAnyOfParameter(Json::Value& prop)
+    void ConvertToOneOfParameter(Json::Value& prop)
     {
         Json::Value newProp;
         SetAndRemoveIfExists(newProp, prop, "group");
@@ -115,8 +115,8 @@ namespace
                 prop.removeMember("options");
             }
         }
-        newProp["anyOf"] = Json::Value(Json::arrayValue);
-        newProp["anyOf"].append(prop);
+        newProp["oneOf"] = Json::Value(Json::arrayValue);
+        newProp["oneOf"].append(prop);
         prop = newProp;
     }
 
@@ -136,10 +136,10 @@ namespace
                 if (prop.empty()) {
                     prop = MakeParameterSchema(*it, firstParameterOrder + order, context);
                 } else {
-                    if (!prop.isMember("anyOf")) {
-                        ConvertToAnyOfParameter(prop);
+                    if (!prop.isMember("oneOf")) {
+                        ConvertToOneOfParameter(prop);
                     }
-                    prop["anyOf"].append(MakeParameterSchemaForAnyOf(*it, firstParameterOrder + order, context));
+                    prop["oneOf"].append(MakeParameterSchemaForOneOf(*it, firstParameterOrder + order, context));
                 }
                 ++n;
             }

--- a/src/config_merge_template.cpp
+++ b/src/config_merge_template.cpp
@@ -45,10 +45,12 @@ void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config, TE
     }
 
     if (deviceTemplate.isMember("parameters")) {
+        Json::Value& templateParameters = deviceTemplate["parameters"];
         TJsonParams params(config);
-        for (auto it = deviceTemplate["parameters"].begin(); it != deviceTemplate["parameters"].end(); ++it) {
-            if (config.isMember(it.name())) {
-                auto& cfgItem = config[it.name()];
+        for (auto it = templateParameters.begin(); it != templateParameters.end(); ++it) {
+            auto name = templateParameters.isArray() ? (*it)["id"].asString() : it.name();
+            if (config.isMember(name)) {
+                auto& cfgItem = config[name];
                 if (cfgItem.isNumeric()) {
                     if (CheckCondition(*it, params, exprs)) {
                         Json::Value item(*it);
@@ -56,9 +58,9 @@ void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config, TE
                         newSetup.append(item);
                     }
                 } else {
-                    LOG(Warn) << it.name() << " is not an integer";
+                    LOG(Warn) << name << " is not an integer";
                 }
-                deviceTemplate.removeMember(it.name());
+                deviceTemplate.removeMember(name);
             }
         }
         deviceTemplate.removeMember("parameters");

--- a/test/TConfigParserTest.ParametersAsArray.dat
+++ b/test/TConfigParserTest.ParametersAsArray.dat
@@ -1,0 +1,61 @@
+Debug: 0
+PublishParams: 0 0
+Ports:
+    ------
+    ConnSettings: </dev/ttyNSC0 9600 8 N 1>
+    ConnectionMaxFailCycles: 2
+    MaxFailTime: 5000
+    GuardInterval: 0
+    Response timeout: -1
+    DeviceConfigs:
+        ------
+        Id: parameters array_2
+        Name: parameters array 2
+        SlaveId: 2
+        MaxRegHole: 0
+        MaxBitHole: 0
+        MaxReadRegisters: 1
+        GuardInterval: 0
+        DeviceTimeout: 3000
+        Response timeout: 500
+        Frame timeout: 20
+        DeviceChannels:
+            ------
+            Name: Temperature
+            Type: value
+            MqttId: Temperature
+            DeviceId: parameters array_2
+            Order: 1
+            OnValue: 
+            Max: not set
+            Min: not set
+            Precision: 0
+            ReadOnly: 1
+            Registers:
+                ------
+                Type and Address: input: 1284
+                Format: S32
+                Scale: 1
+                Offset: 0
+                RoundTo: 0
+                Poll: 1
+                ReadOnly: 1
+                TypeName: input
+                ErrorValue: not set
+                UnsupportedValue: not set
+                WordOrder: BigEndian
+        SetupItems:
+            ------
+            Name: p1
+            Address: 9992
+            Value: 1
+            RawValue: 0x01
+            Reg type: holding (0)
+            Reg format: U16
+            ------
+            Name: p2
+            Address: 9997
+            Value: 3
+            RawValue: 0x03
+            Reg type: holding (0)
+            Reg format: U16

--- a/test/configs/parse_test_parameters_array.json
+++ b/test/configs/parse_test_parameters_array.json
@@ -1,0 +1,16 @@
+{
+    "debug": false,
+    "ports": [
+        {
+            "path" : "/dev/ttyNSC0",
+            "devices" : [
+                {
+                    "device_type" : "parameters array",
+                    "slave_id": 2,
+                    "p1": 1,
+                    "p2": 3
+                }
+            ]
+        }
+    ]
+}

--- a/test/device-templates/config-parameters-array.json
+++ b/test/device-templates/config-parameters-array.json
@@ -1,0 +1,34 @@
+{
+    "device_type": "parameters array",
+    "device": {
+        "name": "parameters array",
+        "id": "parameters array",
+        "channels": [
+            {
+                "name": "Temperature",
+                "reg_type": "input",
+                "format": "s32",
+                "address": "0x0504"
+            }
+        ],
+        "parameters": [
+            {
+                "id": "p1",
+                "title": "p1",
+                "address": 9992
+            },
+            {
+                "id": "p2",
+                "title": "p2",
+                "address": 9996,
+                "condition": "p1==0"
+            },
+            {
+                "id": "p2",
+                "title": "p2",
+                "address": 9997,
+                "condition": "p1==1"
+            }
+        ]
+    }
+}

--- a/test/serial_config_test.cpp
+++ b/test/serial_config_test.cpp
@@ -174,6 +174,12 @@ TEST_F(TConfigParserTest, SameSetupItems)
     PrintConfig(GetConfig("configs/parse_test_setup.json"));
 }
 
+TEST_F(TConfigParserTest, ParametersAsArray)
+{
+    // Check loading device template with parameters defined as array
+    PrintConfig(GetConfig("configs/parse_test_parameters_array.json"));
+}
+
 TEST_F(TConfigParserTest, UnsuccessfulParse)
 {
     Json::Value configSchema = LoadConfigSchema(GetDataFilePath("../wb-mqtt-serial.schema.json"));


### PR DESCRIPTION
Parameters with same name are organized as oneOf array instead of anyOf. json-editor in homeui doesn't show validation errors for anyOf elements so oneOf is used.