### PR TITLE
Show only first warning about failed connection to Milur

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.61.7) stable; urgency=medium
+
+  * Amount of warnings about failed connection to Milur meter is reduced
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 20 Jun 2022 20:55:38 +0500
+
 wb-mqtt-serial (2.61.6) stable; urgency=medium
 
   * Title is updated for deprecated templates

--- a/src/devices/milur_device.cpp
+++ b/src/devices/milur_device.cpp
@@ -161,7 +161,6 @@ void TMilurDevice::PrepareImpl()
     Port()->WriteBytes(buf, sizeof(buf) / sizeof(buf[0]));
     TSerialDevice::PrepareImpl();
     Port()->SkipNoise();
-    SetTransferResult(true);
 }
 
 uint64_t TMilurDevice::BuildIntVal(uint8_t* p, int sz) const


### PR DESCRIPTION
Убрал установку признака, подключения Милура в Prepare. Там реально нет проверки, что Милур отвечает, только посылка с нашей стороны. В результате, если Милур не отвечает, при каждом обращении считалось, что он подключен, потом шёл опрос регистров и ошибка в лог. Логи забивались ошибками.