### PR TITLE
Bugfix/clang format update fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildDebSbuild defaultTargets: 'wb6',
+buildDebSbuild defaultTargets: 'current-armhf',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.67.1) stable; urgency=medium
+
+  * Fix code formatting after clang-format update (15.0-20220704)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 28 Jul 2022 21:45:08 +0300
+
 wb-mqtt-serial (2.67.0) stable; urgency=medium
 
   * Slave id is preserved after device type switching in wb-mqtt-homeui

--- a/src/confed_config_generator.cpp
+++ b/src/confed_config_generator.cpp
@@ -121,7 +121,8 @@ namespace
             auto it = regs.find(ch["name"].asString());
             if (it != regs.end()) {
                 if (TryToTransformSubDeviceChannel(ch, templates, subdeviceTypeHashes) ||
-                    TryToTransformSimpleChannel(ch, it->second)) {
+                    TryToTransformSimpleChannel(ch, it->second))
+                {
                     channels.append(ch);
                 }
             }

--- a/src/devices/curtains/dooya_device.cpp
+++ b/src/devices/curtains/dooya_device.cpp
@@ -71,7 +71,8 @@ namespace
             throw TSerialDeviceTransientErrorException("Bad CRC");
         }
         if (Get<uint16_t>(bytes.cbegin() + ADDRESS_POSITION, bytes.cbegin() + ADDRESS_POSITION + ADDRESS_SIZE) !=
-            address) {
+            address)
+        {
             throw TSerialDeviceTransientErrorException("Bad address");
         }
         if ((bytes[3] != fn) || (bytes[4] != dataAddress)) {

--- a/src/devices/dlms_device.cpp
+++ b/src/devices/dlms_device.cpp
@@ -276,7 +276,8 @@ namespace
                       << GetDescription(logicalName, obj, &cnv, obisHints);
             if (printAttributes) {
                 if ((obj->GetObjectType() == DLMS_OBJECT_TYPE_PROFILE_GENERIC) ||
-                    (dynamic_cast<CGXDLMSCustomObject*>(obj) != nullptr)) {
+                    (dynamic_cast<CGXDLMSCustomObject*>(obj) != nullptr))
+                {
                     std::cout << " (unsupported by wb-mqtt-serial)" << std::endl;
                     continue;
                 }
@@ -629,7 +630,8 @@ const CGXDLMSObjectCollection& TDlmsDevice::ReadAllObjects(bool readAttributes)
     if (readAttributes) {
         for (auto obj: objs) {
             if ((obj->GetObjectType() == DLMS_OBJECT_TYPE_PROFILE_GENERIC) ||
-                (dynamic_cast<CGXDLMSCustomObject*>(obj) != nullptr)) {
+                (dynamic_cast<CGXDLMSCustomObject*>(obj) != nullptr))
+            {
                 continue;
             }
             std::vector<int> attributes;

--- a/src/devices/mercury230_device.cpp
+++ b/src/devices/mercury230_device.cpp
@@ -160,7 +160,8 @@ uint32_t TMercury230Device::ReadParam(uint32_t address, unsigned resp_payload_le
 
     if (resp_payload_len == 3) {
         if ((reg_type == REG_PARAM_SIGN_ACT) || (reg_type == REG_PARAM_SIGN_REACT) ||
-            (reg_type == REG_PARAM_SIGN_IGNORE)) {
+            (reg_type == REG_PARAM_SIGN_IGNORE))
+        {
             uint32_t magnitude = (((uint32_t)buf[0] & 0x3f) << 16) + ((uint32_t)buf[2] << 8) + (uint32_t)buf[1];
 
             int active_power_sign = (buf[0] & (1 << 7)) ? -1 : 1;

--- a/src/iec_common.cpp
+++ b/src/iec_common.cpp
@@ -184,7 +184,8 @@ TIEC61107Device::TIEC61107Device(PDeviceConfig device_config, PPort port, PProto
     }
 
     if (SlaveId.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 ") !=
-        std::string::npos) {
+        std::string::npos)
+    {
         throw TSerialDeviceException("The characters in SlaveId can only be a...z, A...Z, 0...9 and space");
     }
 }


### PR DESCRIPTION
После обновления clang-format-15 (в nightly llvm, до 15.0.0-++20220704093357+5f0a054f8954-1~exp1~20220704093409.365) понадобилось исправить форматирование кода в некоторых местах (оно более правильное согласно конфигурации). Обновление затронуло wb-mqtt-serial и wb-mqtt-knx.

Текущую версию clang-format-15 мы заморозили, доступна в новой сборке devenv. Перед вливанием этого PR (и ещё аналогичного в wb-mqtt-knx) я переключу версию образа devenv на новую и пересоберу этот PR для проверки.