### PR TITLE
Fix readonly parameters validation in device templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.68.3) stable; urgency=medium
+
+  * Fix readonly parameters validation in device templates
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 08 Aug 2022 16:43:52 +0500
+
 wb-mqtt-serial (2.68.2) stable; urgency=medium
 
   * Parameters visibility and order correction in templates for LED

--- a/test/device-templates/config-readonly-parameters.json
+++ b/test/device-templates/config-readonly-parameters.json
@@ -28,6 +28,12 @@
                 "title": "p3",
                 "address": 9997,
                 "condition": "p1==0"
+            },
+            {
+                "id": "p4",
+                "title": "p4",
+                "readonly": true,
+                "address": 12345
             }
         ]
     }

--- a/wb-mqtt-serial-device-template.schema.json
+++ b/wb-mqtt-serial-device-template.schema.json
@@ -111,7 +111,7 @@
           "required": ["title"]
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "required": ["address"]
             },


### PR DESCRIPTION
Параметры с одновремеено заданными адресом и `readonly` проходили валидацию по 2 схемам из `oneOf`, что считается ошибкой валидации.