### PR TITLE
Maximum brightness was decreased to 254 in ECOdim DALI GW2 template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.68.3) stable; urgency=medium
+
+  * Maximum brightness was decreased to 254 in ECOdim DALI GW2 template
+
+ -- Dmitry Vorobjev <d.vorobjev@wirenboard.ru>  Tue, 09 Aug 2022 11:47:19 +0300
+
 wb-mqtt-serial (2.68.2) stable; urgency=medium
 
   * Parameters visibility and order correction in templates for LED

--- a/template-templates/config-ecodim-dali-gw2.json.jinja
+++ b/template-templates/config-ecodim-dali-gw2.json.jinja
@@ -199,7 +199,7 @@
                 "format": "u16",
                 "group": "broadcast_commands",
                 "min": 0,
-                "max": 255
+                "max": 254
             },
             {
                 "name": "Color Temperature",
@@ -287,7 +287,7 @@
                 "format": "u16",
                 "group": "group_commands",
                 "min": 0,
-                "max": 255
+                "max": 254
             },
             {
                 "name": "Group 0 Color Temperature",
@@ -382,7 +382,7 @@
                 "group": "group_commands",
                 "enabled": false,
                 "min": 0,
-                "max": 255
+                "max": 254
             },
             {
                 "name": "Group {{G}} Color Temperature",
@@ -473,7 +473,7 @@
                 "format": "u16",
                 "group": "individual_commands",
                 "min": 0,
-                "max": 255
+                "max": 254
             },
             {
                 "name": "Device 0 Color Temperature",
@@ -569,7 +569,7 @@
                 "group": "individual_commands",
                 "enabled": false,
                 "min": 0,
-                "max": 255
+                "max": 254
             },
             {
                 "name": "Device {{A}} Color Temperature",


### PR DESCRIPTION
Уменьшил максимальное значение регистров яркости шлюза до 254. Значение 255 не изменяет яркость светильников.