### PR TITLE
Fix registers merging in a single read request

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.69.2) stable; urgency=medium
+
+  * Fix registers merging in a single read request
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 17 Aug 2022 11:32:42 +0500
+
 wb-mqtt-serial (2.69.1) stable; urgency=medium
 
   * Fixed translate to CO2 sensor for WB-MSWv3 template

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -168,10 +168,7 @@ void TSerialClient::PrepareRegisterRanges()
     auto now = std::chrono::steady_clock::now();
     for (auto& reg: RegList) {
         if (reg->AccessType != TRegisterConfig::EAccessType::WRITE_ONLY) {
-            // All registers are marked as high priority with poll time set to now.
-            // So they will be polled as soon as possible after service start.
-            // During next polls registers will be divided to low or high priority according to poll interval
-            Scheduler.AddEntry(reg, now, TPriority::High);
+            Scheduler.AddEntry(reg, now, IsHighPriority(*reg) ? TPriority::High : TPriority::Low);
         }
     }
 }


### PR DESCRIPTION
В первой реализации планировщика не было резервирования времени для опроса низкоприоритетных регистров. Поэтому первый опрос всех регистров я сделал с высоким приоритетом, чтоб точно все были опрошены. Сейчас есть резервирование времени для низкоприоритеных регистров. Для инсталляций с большим числом регистров срабатывает механизм резервирования. Часть регистров уже опрошена и им понижен приоритет, часть ещё не опрошена и приоритет высокий. Планировщик начинает опрашивать низкоприоритетные регистры. В результате последовательность регистров перемешивается в очереди, и они не объединяются в один запрос.
Убрал повышение приоритета для первого опроса, т.к. планировщик и так выделит время для них, зато группировка остаётся, и шина используется эффективнее. На моих тестах это может быть до 3 раз быстрее, чем было.