### PR TITLE
Fix long read periods with big response_timeout_ms values

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.70.0) stable; urgency=medium
+
+  * Fix long read periods with big response_timeout_ms values
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 08 Sep 2022 10:13:37 +0500
+
 wb-mqtt-serial (2.69.9) stable; urgency=medium
 
   * Add T13 frequency inverter template

--- a/src/devices/modbus_device.h
+++ b/src/devices/modbus_device.h
@@ -8,6 +8,7 @@
 #include "serial_device.h"
 
 #include "modbus_common.h"
+#include "running_average.h"
 
 template<class Dev> class TModbusDeviceFactory: public IDeviceFactory
 {
@@ -36,6 +37,7 @@ class TModbusDevice: public TSerialDevice, public TUInt32SlaveId
 {
     std::unique_ptr<Modbus::IModbusTraits> ModbusTraits;
     Modbus::TRegisterCache ModbusCache;
+    TRunningAverage<std::chrono::microseconds, 10> ResponseTime;
 
 public:
     TModbusDevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits,

--- a/src/devices/modbus_io_device.h
+++ b/src/devices/modbus_io_device.h
@@ -8,12 +8,14 @@
 #include "serial_device.h"
 
 #include "modbus_common.h"
+#include "running_average.h"
 
 class TModbusIODevice: public TSerialDevice, public TUInt32SlaveId
 {
     std::unique_ptr<Modbus::IModbusTraits> ModbusTraits;
     int Shift = 0;
     Modbus::TRegisterCache ModbusCache;
+    TRunningAverage<std::chrono::microseconds, 10> ResponseTime;
 
 public:
     TModbusIODevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits,

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -120,7 +120,7 @@ namespace Modbus // modbus protocol common utilities
 
     TModbusRegisterRange::TModbusRegisterRange(std::chrono::microseconds averageResponseTime)
         : AverageResponseTime(averageResponseTime),
-          ResponseTime(averageResponseTimeout)
+          ResponseTime(averageResponseTime)
     {}
 
     TModbusRegisterRange::~TModbusRegisterRange()

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -55,48 +55,18 @@ namespace Modbus // modbus protocol declarations
         };
     };
 
-    class TModbusRegisterRange;
     void ComposeReadRequestPDU(uint8_t* pdu, TModbusRegisterRange& range, int shift);
     size_t InferReadResponsePDUSize(int type, size_t registerCount);
-
-    class TModbusRegisterRange: public TRegisterRange
-    {
-    public:
-        ~TModbusRegisterRange();
-
-        bool Add(PRegister reg, std::chrono::milliseconds pollLimit) override;
-
-        int GetStart() const;
-        int GetCount() const;
-        uint8_t* GetBits();
-        uint16_t* GetWords();
-        bool HasHoles() const;
-        const std::string& TypeName() const;
-        int Type() const;
-        PSerialDevice Device() const;
-
-        TRequest GetRequest(IModbusTraits& traits, uint8_t slaveId, int shift);
-        size_t GetResponseSize(IModbusTraits& traits);
-
-    private:
-        bool HasHolesFlg = false;
-        uint32_t Start;
-        size_t Count = 0;
-        uint8_t* Bits = 0;
-        uint16_t* Words = 0;
-
-        bool AddingRegisterIncreasesSize(bool isSingleBit, size_t extend)
-        {
-            if (!isSingleBit) {
-                return true;
-            }
-            if (Count % 16 == 0) {
-                return true;
-            }
-            auto maxRegsCount = ((Count / 16) + 1) * 16;
-            return (Count + extend) > maxRegsCount;
-        }
-    };
+    // parses modbus response and stores result
+    void ParseReadResponse(const uint8_t* pdu,
+                           size_t pduSize,
+                           TModbusRegisterRange& range,
+                           Modbus::TRegisterCache& cache);
+    size_t ReadResponse(IModbusTraits& traits,
+                        TPort& port,
+                        const TRequest& request,
+                        TResponse& response,
+                        const TDeviceConfig& config);
 }
 
 namespace // general utilities
@@ -147,6 +117,11 @@ namespace Modbus // modbus protocol common utilities
         TInvalidCRCError(): TMalformedResponseError("invalid crc")
         {}
     };
+
+    TModbusRegisterRange::TModbusRegisterRange(std::chrono::microseconds averageResponseTime)
+        : AverageResponseTime(averageResponseTime),
+          ResponseTime(averageResponseTimeout)
+    {}
 
     TModbusRegisterRange::~TModbusRegisterRange()
     {
@@ -229,8 +204,8 @@ namespace Modbus // modbus protocol common utilities
         // Request 8 bytes: SlaveID, Operation, Addr, Count, CRC
         // Response 5 bytes except data: SlaveID, Operation, Size, CRC
         auto newPollTime = std::chrono::duration_cast<std::chrono::milliseconds>(
-            reg->Device()->Port()->GetSendTime(newPduSize + 8 + 5) + deviceConfig.ResponseTimeout +
-            deviceConfig.RequestDelay + 2 * deviceConfig.FrameTimeout);
+            reg->Device()->Port()->GetSendTime(newPduSize + 8 + 5) + AverageResponseTime + deviceConfig.RequestDelay +
+            2 * deviceConfig.FrameTimeout);
 
         if (((Count != 0) && !AddingRegisterIncreasesSize(isSingleBit, extend)) || (newPollTime <= pollLimit)) {
 
@@ -308,6 +283,49 @@ namespace Modbus // modbus protocol common utilities
     PSerialDevice TModbusRegisterRange::Device() const
     {
         return RegisterList().front()->Device();
+    }
+
+    bool TModbusRegisterRange::AddingRegisterIncreasesSize(bool isSingleBit, size_t extend)
+    {
+        if (!isSingleBit) {
+            return (extend != 0);
+        }
+        if (Count % 16 == 0) {
+            return true;
+        }
+        auto maxRegsCount = ((Count / 16) + 1) * 16;
+        return (Count + extend) > maxRegsCount;
+    }
+
+    void TModbusRegisterRange::ReadRange(IModbusTraits& traits,
+                                         TPort& port,
+                                         uint8_t slaveId,
+                                         int shift,
+                                         Modbus::TRegisterCache& cache)
+    {
+        TResponse response(GetResponseSize(traits));
+        try {
+            auto request = GetRequest(traits, slaveId, shift);
+            port.SleepSinceLastInteraction(Device()->DeviceConfig()->RequestDelay);
+            port.WriteBytes(request.data(), request.size());
+            auto startTime = std::chrono::steady_clock::now();
+            auto pduSize = ReadResponse(traits, port, request, response, *Device()->DeviceConfig());
+            ResponseTime =
+                std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - startTime);
+            ParseReadResponse(traits.GetPDU(response), pduSize, *this, cache);
+        } catch (const TMalformedResponseError&) {
+            try {
+                port.SkipNoise();
+            } catch (const std::exception& e) {
+                LOG(Warn) << "SkipNoise failed: " << e.what();
+            }
+            throw;
+        }
+    }
+
+    std::chrono::microseconds TModbusRegisterRange::GetResponseTime() const
+    {
+        return ResponseTime;
     }
 
     ostream& operator<<(ostream& s, const TModbusRegisterRange& range)
@@ -778,20 +796,17 @@ namespace Modbus // modbus protocol common utilities
         }
     }
 
-    PRegisterRange CreateRegisterRange()
+    PRegisterRange CreateRegisterRange(std::chrono::microseconds averageResponseTime)
     {
-        return std::make_shared<TModbusRegisterRange>();
+        return std::make_shared<TModbusRegisterRange>(averageResponseTime);
     }
 
-    size_t ProcessRequest(IModbusTraits& traits,
-                          TPort& port,
-                          const TRequest& request,
-                          TResponse& response,
-                          const TDeviceConfig& config)
+    size_t ReadResponse(IModbusTraits& traits,
+                        TPort& port,
+                        const TRequest& request,
+                        TResponse& response,
+                        const TDeviceConfig& config)
     {
-        port.SleepSinceLastInteraction(config.RequestDelay);
-        port.WriteBytes(request.data(), request.size());
-
         auto res = traits.ReadFrame(port, config.ResponseTimeout, config.FrameTimeout, request, response);
         // PDU size must be at least 2 bytes
         if (res < 2) {
@@ -862,7 +877,9 @@ namespace Modbus // modbus protocol common utilities
 
         for (const auto& request: requests) {
             try {
-                auto pduSize = ProcessRequest(traits, port, request, response, *reg.Device()->DeviceConfig());
+                port.SleepSinceLastInteraction(reg.Device()->DeviceConfig()->RequestDelay);
+                port.WriteBytes(request.data(), request.size());
+                auto pduSize = ReadResponse(traits, port, request, response, *reg.Device()->DeviceConfig());
                 ParseWriteResponse(traits.GetPDU(response), pduSize);
             } catch (const TMalformedResponseError&) {
                 try {
@@ -875,28 +892,6 @@ namespace Modbus // modbus protocol common utilities
         }
 
         cache.insert(tmpCache.begin(), tmpCache.end());
-    }
-
-    void ReadRange(IModbusTraits& traits,
-                   TModbusRegisterRange& range,
-                   TPort& port,
-                   uint8_t slaveId,
-                   int shift,
-                   Modbus::TRegisterCache& cache)
-    {
-        TResponse response(range.GetResponseSize(traits));
-        try {
-            auto request = range.GetRequest(traits, slaveId, shift);
-            auto pduSize = ProcessRequest(traits, port, request, response, *range.Device()->DeviceConfig());
-            ParseReadResponse(traits.GetPDU(response), pduSize, range, cache);
-        } catch (const TMalformedResponseError&) {
-            try {
-                port.SkipNoise();
-            } catch (const std::exception& e) {
-                LOG(Warn) << "SkipNoise failed: " << e.what();
-            }
-            throw;
-        }
     }
 
     void ProcessRangeException(TModbusRegisterRange& range, const char* msg)
@@ -913,31 +908,27 @@ namespace Modbus // modbus protocol common utilities
     void ReadRegisterRange(IModbusTraits& traits,
                            TPort& port,
                            uint8_t slaveId,
-                           PRegisterRange range,
+                           TModbusRegisterRange& range,
                            Modbus::TRegisterCache& cache,
                            int shift)
     {
-        if (range->RegisterList().empty()) {
+        if (range.RegisterList().empty()) {
             return;
         }
-        auto modbus_range = std::dynamic_pointer_cast<Modbus::TModbusRegisterRange>(range);
-        if (!modbus_range) {
-            throw std::runtime_error("modbus range expected");
-        }
         try {
-            ReadRange(traits, *modbus_range, port, slaveId, shift, cache);
-            modbus_range->Device()->SetTransferResult(true);
+            range.ReadRange(traits, port, slaveId, shift, cache);
+            range.Device()->SetTransferResult(true);
         } catch (const TSerialDevicePermanentRegisterException& e) {
-            if (modbus_range->HasHoles()) {
-                modbus_range->Device()->SetSupportsHoles(false);
+            if (range.HasHoles()) {
+                range.Device()->SetSupportsHoles(false);
             } else {
-                for (auto& reg: modbus_range->RegisterList()) {
+                for (auto& reg: range.RegisterList()) {
                     reg->SetAvailable(TRegisterAvailability::UNAVAILABLE);
                 }
             }
-            ProcessRangeException(*modbus_range, e.what());
+            ProcessRangeException(range, e.what());
         } catch (const TSerialDeviceException& e) {
-            ProcessRangeException(*modbus_range, e.what());
+            ProcessRangeException(range, e.what());
         }
     }
 

--- a/src/running_average.h
+++ b/src/running_average.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <stdint.h>
+
+template<class ValueType, size_t WindowSize> class TRunningAverage
+{
+    ValueType Average;
+
+public:
+    TRunningAverage(const ValueType& initialValue): Average(initialValue)
+    {}
+
+    const ValueType& GetValue() const
+    {
+        return Average;
+    }
+
+    void AddValue(const ValueType& value)
+    {
+        Average = ((WindowSize - 1) * Average + value) / WindowSize;
+    }
+};
+
+template<class ValueType> class TRunningAverage<ValueType, 0>
+{
+public:
+    TRunningAverage()
+    {}
+};

--- a/test/TModbusBitmasksIntegrationTest.SingleWrite.dat
+++ b/test/TModbusBitmasksIntegrationTest.SingleWrite.dat
@@ -102,12 +102,6 @@ EnqueueU16Shift8HoldingReadResponse()
 EnqueueU8Shift0SingleBitHoldingReadResponse()
 >> 01 03 00 48 00 01 04 1C
 << 01 03 02 00 07 F9 86
-EnqueueU8Shift1SingleBitHoldingReadResponse()
->> 01 03 00 48 00 01 04 1C
-<< 01 03 02 00 07 F9 86
-EnqueueU8Shift2SingleBitHoldingReadResponse()
->> 01 03 00 48 00 01 04 1C
-<< 01 03 02 00 07 F9 86
 Close()
 Unsubscribe -- em-test: /devices/modbus-sample/controls/U8:2/on
 Publish: /devices/modbus-sample/controls/U8:2: '' (QoS 1, retained)

--- a/test/modbus_test.cpp
+++ b/test/modbus_test.cpp
@@ -707,9 +707,12 @@ TEST_F(TModbusBitmasksIntegrationTest, SingleWrite)
     PublishWaitOnValue("/devices/modbus-sample/controls/U8:1/on", "1");
 
     EnqueueU8Shift1SingleBitHoldingWriteResponse();
-    ExpectPollQueries(true);
+    EnqueueU8Shift0Bits8HoldingReadResponse();
+    EnqueueU16Shift8HoldingReadResponse(false);
+    // Read all single bit registers at once as they are located in the same modbus register
+    EnqueueU8Shift0SingleBitHoldingReadResponse(true);
     Note() << "LoopOnce()";
-    for (auto i = 0; i < 5; ++i) {
+    for (auto i = 0; i < 3; ++i) {
         SerialDriver->LoopOnce();
     }
 }


### PR DESCRIPTION
response_timeout_ms is used in calculation of register request time in a poll scheduler. Low priority registers with request time more than 100ms are polled only during bus load balancing procedure, because the scheduler have to frequently check incoming commands queue. The load balancing procedure tries to divide bus equally between high and low priority registers. If high priority registers are polled too frequently it forces low priority register poll regardless to commands queue checking. Big response_timeout_ms values and rare high priority registers polling will lead to very long periods between low priority registers requests. In most situations real devices respose much earlier. So collect average response time to use it in request time calculation instead of response_timeout_ms. This will reduce poll period for low prioty registers.