### PR TITLE
Fix tests build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.72.1) stable; urgency=medium
+
+  * Fix tests build.
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 17 Oct 2022 06:48:50 -0400
+
 wb-mqtt-serial (2.72.0) stable; urgency=medium
 
   * Master switch action is added to WB-LED and WB-MRGBW-D templates

--- a/test/serial_config_test.cpp
+++ b/test/serial_config_test.cpp
@@ -68,7 +68,7 @@ protected:
                         TTestLogIndent indent(*this);
                         Emit() << "------";
                         Emit() << "Name: " << device_channel->GetName();
-                        for (const auto it: device_channel->GetTitles()) {
+                        for (const auto& it: device_channel->GetTitles()) {
                             if (it.first != "en") {
                                 Emit() << "Name " << it.first << ": " << it.second;
                             }


### PR DESCRIPTION
Build failed:
```
test/serial_config_test.cpp: In member function 'void TConfigParserTest::PrintConfig(PHandlerConfig)':
test/serial_config_test.cpp:71:41: error: loop variable 'it' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wrange-loop-construct-Werror=range-loop-construct8;;]
   71 |                         for (const auto it: device_channel->GetTitles()) {
      |                                         ^~
test/serial_config_test.cpp:71:41: note: use reference type to prevent copying
   71 |                         for (const auto it: device_channel->GetTitles()) {
      |                                         ^~
      |                                         &
cc1plus: all warnings being treated as errors
```