### PR TITLE
Add support for RPC connection to an arbitrary port

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.72.3) stable; urgency=medium
+
+  * Add support for RPC connection to an arbitrary port
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 19 Oct 2022 14:50:42 +0300
+
 wb-mqtt-serial (2.72.2) stable; urgency=medium
 
   * pulsar: fix variable length array

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -993,14 +993,7 @@ PHandlerConfig LoadConfig(const std::string& configFileName,
                  portFactory);
     }
 
-    // check are there any devices defined
-    for (const auto& port_config: handlerConfig->PortConfigs) {
-        if (!port_config->Devices.empty()) { // found one
-            return handlerConfig;
-        }
-    }
-
-    throw TConfigParserException("no devices defined in config. Nothing to do");
+    return handlerConfig;
 }
 
 void TPortConfig::AddDevice(PSerialDevice device)

--- a/wb-mqtt-serial-rpc-request.schema.json
+++ b/wb-mqtt-serial-rpc-request.schema.json
@@ -9,7 +9,7 @@
     "response_size": {
       "description": "Expexted response size",
       "type": "integer",
-      "minimum": 0,
+      "minimum": 0
     },
     "response_timeout": {
       "description": "Timeout in milliseconds for response first byte receiving, default 500 (DefaultResponseTimeout from wb-mqtt-serial)",
@@ -44,7 +44,23 @@
       "properties": {
         "path": {
           "description": "Path to serial port",
-          "type": "string",
+          "type": "string"
+        },
+        "baud_rate": {
+          "description": "Baud rate",
+          "type": "integer"
+        },
+        "parity": {
+          "description": "Parity",
+          "type": "integer"
+        },
+        "data_bits": {
+          "description": "Data bits",
+          "type": "integer"
+        },
+        "stop_bits": {
+          "description": "Stop bits",
+          "type": "integer"
         }
       },
       "required": [
@@ -68,7 +84,7 @@
       "required": [
         "ip",
         "port"
-      ],
+      ]
     }
   ]
 }

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -1911,7 +1911,6 @@
       "type": "array",
       "title": "List of ports",
       "items": { "$ref": "#/definitions/port" },
-      "minItems": 1,
       "_format": "tabs",
       "propertyOrder": 4,
       "options" : {
@@ -1936,8 +1935,6 @@
       "propertyOrder" : 3
     }
   },
-
-  "required": ["ports"],
 
   "options": {
     "disable_edit_json": true


### PR DESCRIPTION
## Test instructions
* Terminal 1 (mosquitto):
```
$ nix shell nixpkgs#mosquitto
$ mosquitto -p 1884 -v
...
1666211956: Received DISCONNECT from test-123474310
1666211956: Client test-123474310 disconnected.
1666211958: New connection from ::1:38620 on port 1884.
1666211958: New client connected from ::1:38620 as test-123474406 (p2, c1, k60).
1666211958: No will message specified.
1666211958: Sending CONNACK to test-123474406 (0, 0)
1666211958: Received SUBSCRIBE from test-123474406
1666211958: 	/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply (QoS 0)
1666211958: test-123474406 0 /rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply
1666211958: Sending SUBACK to test-123474406
1666211965: New connection from ::1:33280 on port 1884.
1666211965: New client connected from ::1:33280 as test-123474408 (p2, c1, k60).
1666211965: No will message specified.
1666211965: Sending CONNACK to test-123474408 (0, 0)
1666211965: Received PUBLISH from test-123474408 (d0, q1, r0, m1, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234', ... (110 bytes))
1666211965: Sending PUBLISH to wb-modbus (d0, q0, r0, m0, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234', ... (110 bytes))
1666211965: Sending PUBACK to test-123474408 (m1, rc0)
1666211965: Received DISCONNECT from test-123474408
1666211965: Client test-123474408 disconnected.
1666211965: Received PUBLISH from wb-modbus (d0, q2, r0, m17, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply', ... (59 bytes))
1666211965: Sending PUBREC to wb-modbus (m17, rc0)
1666211965: Received PUBREL from wb-modbus (Mid: 17)
1666211965: Sending PUBLISH to test-123474406 (d0, q0, r0, m0, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply', ... (59 bytes))
1666211965: Sending PUBCOMP to wb-modbus (m17)
...
1666211985: New connection from ::1:48338 on port 1884.
1666211985: New client connected from ::1:48338 as test-123474423 (p2, c1, k60).
1666211985: No will message specified.
1666211985: Sending CONNACK to test-123474423 (0, 0)
1666211985: Received PUBLISH from test-123474423 (d0, q1, r0, m1, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234', ... (122 bytes))
1666211985: Sending PUBLISH to wb-modbus (d0, q0, r0, m0, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234', ... (122 bytes))
1666211985: Sending PUBACK to test-123474423 (m1, rc0)
1666211985: Received DISCONNECT from test-123474423
1666211985: Client test-123474423 disconnected.
1666211985: Received PUBLISH from wb-modbus (d0, q2, r0, m18, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply', ... (56 bytes))
1666211985: Sending PUBREC to wb-modbus (m18, rc0)
1666211985: Received PUBREL from wb-modbus (Mid: 18)
1666211985: Sending PUBLISH to test-123474406 (d0, q0, r0, m0, '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply', ... (56 bytes))
1666211985: Sending PUBCOMP to wb-modbus (m18)
```
* Terminal 2 (wb-mqtt-serial):
```
$ echo '{"debug": true}' > wb-mqtt-serial.conf
$ wb-mqtt-serial -c wb-mqtt-serial.conf -p 1884 -d 3
...
<7>DEBUG: [mqtt rpc] handle message topic: /rpc/v1/wb-mqtt-serial/port/Load/test-1234 payload: {
  "params": {
    "path": "/dev/pts/5",
    "msg": "Hello Serial!",
    "response_size": 13
  },
  "id": 1
}
<7>DEBUG: [RPC] Create serial port: /dev/pts/5
<7>DEBUG: [port] Write: 48 65 6c 6c 6f 20 53 65 72 69 61 6c 21
<7>DEBUG: [port] Sleep 14000 us
<7>DEBUG: [port] ReadFrame: 48 65 6c 6c 6f 20 53 65 72 69 61 6c 21
<7>DEBUG: [mqtt] Publish '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply' payload: '{"error":null,"id":1,"result":{"response":"Hello Serial!"}}'
<7>DEBUG: [mqtt rpc] handle message topic: /rpc/v1/wb-mqtt-serial/port/Load/test-1234 payload: {
  "params": {
    "ip": "127.0.0.1",
    "port": 2000,
    "msg": "Hello TCP!",
    "response_size": 10
  },
  "id": 1
}
<7>DEBUG: [RPC] Create tcp port: 127.0.0.1:2000
<7>DEBUG: [port] Write: 48 65 6c 6c 6f 20 54 43 50 21
<7>DEBUG: [port] ReadFrame: 48 65 6c 6c 6f 20 54 43 50 21
<7>DEBUG: [mqtt] Publish '/rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply' payload: '{"error":null,"id":1,"result":{"response":"Hello TCP!"}}'
```
* Terminal 3 (virtual serial echo port & tcp echo server):
```
$ nix shell nixpkgs#socat
$ socat -d -d -v pty,rawer,link=ttyNSC0 EXEC:cat,pty,rawer
...
> 2022/10/19 16:39:25.000396788  length=13 from=0 to=12
Hello Serial!< 2022/10/19 16:39:25.000398365  length=13 from=0 to=12
Hello Serial!
$ socat -v TCP4-LISTEN:2000,fork EXEC:cat
...
> 2022/10/19 16:39:45.000153526  length=10 from=0 to=9
Hello TCP!< 2022/10/19 16:39:45.000163285  length=10 from=0 to=9
Hello TCP!
```
* Terminal 4 (mosquitto_sub):
```
$ nix shell nixpkgs#mosquitto
$ mosquitto_sub -p 1884 -I test-1234 -t /rpc/v1/wb-mqtt-serial/port/Load/test-1234/reply
{"error":null,"id":1,"result":{"response":"Hello Serial!"}}
{"error":null,"id":1,"result":{"response":"Hello TCP!"}}
```
* Terminal 5 (mosquitto_pub):
```
$ nix shell nixpkgs#mosquitto
$ cat > req-serial.json << EOF
{
  "params": {
    "path": "/dev/pts/5",
    "msg": "Hello Serial!",
    "response_size": 13
  },
  "id": 1
}
EOF
$ mosquitto_pub -p 1884 -I test-1234 -t /rpc/v1/wb-mqtt-serial/port/Load/test-1234 -m "$(cat req-serial.json)" -q 1
$ cat > req-tcp.json << EOF
{
  "params": {
    "ip": "127.0.0.1",
    "port": 2000,
    "msg": "Hello TCP!",
    "response_size": 10
  },
  "id": 1
}
EOF
$ mosquitto_pub -p 1884 -I test-1234 -t /rpc/v1/wb-mqtt-serial/port/Load/test-1234 -m "$(cat req-tcp.json)" -q 1
```