### PR TITLE
RPC: Get list of enabled ports

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.73.0) stable; urgency=medium
+
+  * Allow to get list of configured ports via RPC request
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 21 Oct 2022 01:01:11 +0300
+
 wb-mqtt-serial (2.72.2) stable; urgency=medium
 
   * pulsar: fix variable length array

--- a/src/port.h
+++ b/src/port.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <wblib/json/json.h>
 
 #include "serial_port_settings.h"
 
@@ -61,6 +62,8 @@ public:
     virtual std::chrono::milliseconds GetSendTime(double bytesNumber) const;
 
     virtual std::string GetDescription(bool verbose = true) const = 0;
+
+    virtual Json::Value GetConfig() const = 0;
 
     /**
      * @brief Set new byte parameters if it is a serial port.

--- a/src/rpc_handler.cpp
+++ b/src/rpc_handler.cpp
@@ -140,6 +140,7 @@ TRPCHandler::TRPCHandler(const std::string& requestSchemaFilePath,
 
     rpcServer->RegisterMethod("port", "Load", std::bind(&TRPCHandler::PortLoad, this, std::placeholders::_1));
     rpcServer->RegisterMethod("metrics", "Load", std::bind(&TRPCHandler::LoadMetrics, this, std::placeholders::_1));
+    rpcServer->RegisterMethod("ports", "Load", std::bind(&TRPCHandler::LoadPorts, this, std::placeholders::_1));
 }
 
 PRPCPortDriver TRPCHandler::FindPortDriver(const Json::Value& request) const
@@ -189,6 +190,16 @@ Json::Value TRPCHandler::PortLoad(const Json::Value& request)
 Json::Value TRPCHandler::LoadMetrics(const Json::Value& request)
 {
     return SerialDriver->LoadMetrics();
+}
+
+Json::Value TRPCHandler::LoadPorts(const Json::Value& request)
+{
+    Json::Value replyJSON(Json::arrayValue);
+    for (const auto& portDriver: PortDrivers) {
+        Json::Value item = portDriver->RPCPort->GetPort()->GetConfig();
+        replyJSON.append(std::move(item));
+    }
+    return replyJSON;
 }
 
 TRPCException::TRPCException(const std::string& message, TRPCResultCode resultCode)

--- a/src/rpc_handler.h
+++ b/src/rpc_handler.h
@@ -49,6 +49,7 @@ private:
 
     Json::Value PortLoad(const Json::Value& request);
     Json::Value LoadMetrics(const Json::Value& request);
+    Json::Value LoadPorts(const Json::Value& request);
 };
 
 typedef std::shared_ptr<TRPCHandler> PRPCHandler;

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -233,6 +233,11 @@ std::string TSerialPort::GetDescription(bool verbose) const
     return Settings.Device;
 }
 
+Json::Value TSerialPort::GetConfig() const
+{
+    return Settings.ToJson();
+}
+
 const TSerialPortSettings& TSerialPort::GetSettings() const
 {
     return Settings;
@@ -322,6 +327,11 @@ std::chrono::milliseconds TSerialPortWithIECHack::GetSendTime(double bytesNumber
 std::string TSerialPortWithIECHack::GetDescription(bool verbose) const
 {
     return Port->GetDescription(verbose);
+}
+
+Json::Value TSerialPortWithIECHack::GetConfig() const
+{
+    return Port->GetConfig();
 }
 
 void TSerialPortWithIECHack::SetSerialPortByteFormat(const TSerialPortByteFormat* params)

--- a/src/serial_port.h
+++ b/src/serial_port.h
@@ -29,6 +29,8 @@ public:
 
     std::string GetDescription(bool verbose = true) const override;
 
+    Json::Value GetConfig() const override;
+
     const TSerialPortSettings& GetSettings() const;
 
 private:
@@ -70,6 +72,8 @@ public:
     std::chrono::milliseconds GetSendTime(double bytesNumber) const override;
 
     std::string GetDescription(bool verbose = true) const override;
+
+    Json::Value GetConfig() const override;
 
     void SetSerialPortByteFormat(const TSerialPortByteFormat* params) override;
 

--- a/src/serial_port_settings.h
+++ b/src/serial_port_settings.h
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <string>
+#include <wblib/json/json.h>
 
 struct TSerialPortByteFormat
 {
@@ -33,6 +34,17 @@ struct TSerialPortSettings: public TSerialPortByteFormat
         std::ostringstream ss;
         ss << "<" << Device << " " << BaudRate << " " << DataBits << " " << Parity << " " << StopBits << ">";
         return ss.str();
+    }
+
+    Json::Value ToJson() const
+    {
+        Json::Value jsonValue;
+        jsonValue["path"] = Device;
+        jsonValue["baud_rate"] = BaudRate;
+        jsonValue["data_bits"] = DataBits;
+        jsonValue["parity"] = std::string(1, Parity);
+        jsonValue["stop_bits"] = StopBits;
+        return jsonValue;
     }
 
     std::string Device;

--- a/src/tcp_port.cpp
+++ b/src/tcp_port.cpp
@@ -141,3 +141,8 @@ std::string TTcpPort::GetDescription(bool verbose) const
     }
     return Settings.Address;
 }
+
+Json::Value TTcpPort::GetConfig() const
+{
+    return Settings.ToJson();
+}

--- a/src/tcp_port.h
+++ b/src/tcp_port.h
@@ -22,6 +22,8 @@ public:
 
     std::string GetDescription(bool verbose = true) const override;
 
+    Json::Value GetConfig() const override;
+
 private:
     void OnReadyEmptyFd() override;
 

--- a/src/tcp_port_settings.h
+++ b/src/tcp_port_settings.h
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <string>
+#include <wblib/json/json.h>
 
 struct TTcpPortSettings
 {
@@ -13,6 +14,14 @@ struct TTcpPortSettings
         std::ostringstream ss;
         ss << "<" << Address << ":" << Port << ">";
         return ss.str();
+    }
+
+    Json::Value ToJson() const
+    {
+        Json::Value jsonValue;
+        jsonValue["address"] = Address;
+        jsonValue["port"] = Port;
+        return jsonValue;
     }
 
     std::string Address;

--- a/test/fake_serial_port.cpp
+++ b/test/fake_serial_port.cpp
@@ -262,6 +262,11 @@ std::string TFakeSerialPort::GetDescription(bool verbose) const
     return "<TFakeSerialPort>";
 }
 
+Json::Value TFakeSerialPort::GetConfig() const
+{
+    return Json::Value();
+}
+
 void TSerialDeviceTest::SetUp()
 {
     RegisterProtocols(DeviceFactory);

--- a/test/fake_serial_port.h
+++ b/test/fake_serial_port.h
@@ -51,6 +51,8 @@ public:
 
     std::string GetDescription(bool verbose = true) const override;
 
+    Json::Value GetConfig() const override;
+
     void SetAllowOpen(bool allowOpen);
 
 private:

--- a/test/modbus_tcp_test.cpp
+++ b/test/modbus_tcp_test.cpp
@@ -57,6 +57,11 @@ namespace
         {
             return std::string();
         }
+
+        Json::Value GetConfig() const
+        {
+            return Json::Value();
+        }
     };
 }
 


### PR DESCRIPTION
### Test instructions
```
$ cat wb-mqtt-serial.conf
{
  "ports": [
    {
      "enabled": true,
      "path": "/dev/pts/2"
    },
    {
      "enabled": true,
      "port_type": "tcp",
      "address": "127.0.0.1",
      "port": 2000
    },
    {
      "enabled": false,
      "path": "/dev/pts/3"
    }
  ]
}
$ wb-mqtt-serial -c ./wb-mqtt-serial.conf
```

```
$ mosquitto_sub -t /rpc/v1/wb-mqtt-serial/ports/Load/client_id/reply
{"error":null,"id":1,"result":[{"baud_rate":9600,"data_bits":8,"parity":"N","path":"/dev/pts/2","stop_bits":1},{"address":"127.0.0.1","port":2000}]}
```

```
$ mosquitto_pub -t /rpc/v1/wb-mqtt-serial/ports/Load/client_id -m "{\"params\":{},\"id\":1}"
```