### PR TITLE
Set WB-LED and WB-MRGBWD default input actions to none

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.76.2) stable; urgency=medium
+
+  * Set WB-LED and WB-MRGBWD default input actions to none
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 18 Nov 2022 11:55:42 +0500
+
 wb-mqtt-serial (2.76.1) stable; urgency=medium
 
   * Remove minimal time limits for RPC wb-mqtt-serial/port/Load

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -1981,7 +1981,7 @@
                 "order": 1,
                 "address": {{1000 + in_num - 1}},
                 "reg_type": "holding",
-                "default": 12294,
+                "default": 0,
                 "condition": "(dimmer_mode==512)",
                 "enum": [0, 16384, 4102, 8198, 12294, 36870, 40966],
                 "enum_titles": [
@@ -2001,7 +2001,7 @@
                 "order": 2,
                 "address": {{1020 + in_num - 1}},
                 "reg_type": "holding",
-                "default": 45062,
+                "default": 0,
                 "condition": "(dimmer_mode==512)",
                 "enum": [0, 16384, 4102, 8198, 12294, 36870, 40966, 45062],
                 "enum_titles": [

--- a/templates/config-wb-mrgbw-d-fw3.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw3.json.jinja
@@ -1981,7 +1981,7 @@
                 "order": 1,
                 "address": {{1000 + in_num - 1}},
                 "reg_type": "holding",
-                "default": 12294,
+                "default": 0,
                 "condition": "(dimmer_mode==512)",
                 "enum": [0, 16384, 4102, 8198, 12294, 36870, 40966],
                 "enum_titles": [
@@ -2001,7 +2001,7 @@
                 "order": 2,
                 "address": {{1020 + in_num - 1}},
                 "reg_type": "holding",
-                "default": 45062,
+                "default": 0,
                 "condition": "(dimmer_mode==512)",
                 "enum": [0, 16384, 4102, 8198, 12294, 36870, 40966, 45062],
                 "enum_titles": [


### PR DESCRIPTION
Везде по умолчанию "нет действия", а тут какие-то значения