### PR TITLE
change scale for SPL low-pass filter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.76.4) stable; urgency=medium
+
+  * Change scale for SPL low-pass filter
+
+ -- Alexander Karpin <alexander.karpin@wirenboard.ru>  Mon, 21 Nov 2022 11:53:00 +0300
+
 wb-mqtt-serial (2.76.3) stable; urgency=medium
 
   * Set WB-LED and WB-MRGBWD default input actions to none

--- a/templates/config-wb-msw_v3.json
+++ b/templates/config-wb-msw_v3.json
@@ -126,7 +126,7 @@
                 "title": "Low-pass Filter Time Constant (ms)",
                 "address": 91,
                 "reg_type": "holding",
-                "scale": 0.1,
+                "scale": 10,
                 "default": 20,
                 "group": "sound_level",
                 "order": 1


### PR DESCRIPTION
шаблон умножал значение HOLD_REG_SPL_RC на 10, а должен делить