### PR TITLE
Fix compiler warnings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.77.4) stable; urgency=medium
+
+  * Fix compiler warnings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 30 Nov 2022 10:30:05 +0400
+
 wb-mqtt-serial (2.77.3) stable; urgency=medium
 
   * WB-MR templates update for version 1.19.0 - debounce and input frequency measure mode when disabled

--- a/src/devices/lls_device.cpp
+++ b/src/devices/lls_device.cpp
@@ -66,7 +66,7 @@ namespace
     const size_t REQUEST_LEN = 4;
     const ptrdiff_t HEADER_SZ = 3;
     const uint8_t REQUEST_PREFIX = 0x31;
-    // const uint8_t RESPONSE_PREFIX = 0x3E;
+    const uint8_t RESPONSE_PREFIX = 0x3E;
 }
 
 std::vector<uint8_t> TLLSDevice::ExecCommand(uint8_t cmd)
@@ -88,7 +88,7 @@ std::vector<uint8_t> TLLSDevice::ExecCommand(uint8_t cmd)
     Port()->SleepSinceLastInteraction(DeviceConfig()->FrameTimeout);
 
     int len = Port()->ReadFrame(buf, RESPONSE_BUF_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
-    if (buf[0] != 0x3e) {
+    if (buf[0] != RESPONSE_PREFIX) {
         throw TSerialDeviceTransientErrorException("invalid response prefix");
     }
     if (buf[1] != SlaveId) {

--- a/src/devices/lls_device.cpp
+++ b/src/devices/lls_device.cpp
@@ -66,7 +66,7 @@ namespace
     const size_t REQUEST_LEN = 4;
     const ptrdiff_t HEADER_SZ = 3;
     const uint8_t REQUEST_PREFIX = 0x31;
-    const uint8_t RESPONSE_PREFIX = 0x3E;
+    //const uint8_t RESPONSE_PREFIX = 0x3E;
 }
 
 std::vector<uint8_t> TLLSDevice::ExecCommand(uint8_t cmd)

--- a/src/devices/lls_device.cpp
+++ b/src/devices/lls_device.cpp
@@ -66,7 +66,7 @@ namespace
     const size_t REQUEST_LEN = 4;
     const ptrdiff_t HEADER_SZ = 3;
     const uint8_t REQUEST_PREFIX = 0x31;
-    //const uint8_t RESPONSE_PREFIX = 0x3E;
+    // const uint8_t RESPONSE_PREFIX = 0x3E;
 }
 
 std::vector<uint8_t> TLLSDevice::ExecCommand(uint8_t cmd)

--- a/src/devices/mercury230_device.h
+++ b/src/devices/mercury230_device.h
@@ -33,8 +33,8 @@ public:
     TRegisterValue ReadRegisterImpl(PRegister reg) override;
 
 protected:
-    bool ConnectionSetup();
-    ErrorType CheckForException(uint8_t* frame, int len, const char** message);
+    bool ConnectionSetup() override;
+    ErrorType CheckForException(uint8_t* frame, int len, const char** message) override;
 
 private:
     struct TValueArray

--- a/src/devices/milur_device.h
+++ b/src/devices/milur_device.h
@@ -28,8 +28,8 @@ public:
 
 protected:
     void PrepareImpl() override;
-    bool ConnectionSetup();
-    ErrorType CheckForException(uint8_t* frame, int len, const char** message);
+    bool ConnectionSetup() override;
+    ErrorType CheckForException(uint8_t* frame, int len, const char** message) override;
     uint64_t BuildIntVal(uint8_t* p, int sz) const;
     uint64_t BuildBCB32(uint8_t* psrc) const;
     int GetExpectedSize(int type) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,7 @@ namespace
 
     pair<shared_ptr<Json::Value>, shared_ptr<TTemplateMap>> LoadTemplates()
     {
-        auto configSchema = make_shared<Json::Value>(std::move(LoadConfigSchema(CONFIG_JSON_SCHEMA_FULL_FILE_PATH)));
+        auto configSchema = make_shared<Json::Value>(LoadConfigSchema(CONFIG_JSON_SCHEMA_FULL_FILE_PATH));
         auto templates =
             make_shared<TTemplateMap>(TEMPLATES_DIR,
                                       LoadConfigTemplatesSchema(TEMPLATES_JSON_SCHEMA_FULL_FILE_PATH, *configSchema));

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -22,11 +22,11 @@ typedef uint16_t TRegisterWord;
 namespace Modbus // modbus protocol declarations
 {
     const int MAX_READ_BITS = 2000;
-    const int MAX_WRITE_BITS = 1968;
+    //const int MAX_WRITE_BITS = 1968;
 
     const int MAX_READ_REGISTERS = 125;
-    const int MAX_WRITE_REGISTERS = 123;
-    const int MAX_RW_WRITE_REGISTERS = 121;
+    //const int MAX_WRITE_REGISTERS = 123;
+    //const int MAX_RW_WRITE_REGISTERS = 121;
 
     const size_t EXCEPTION_RESPONSE_PDU_SIZE = 2;
     const size_t WRITE_RESPONSE_PDU_SIZE = 5;

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -22,11 +22,8 @@ typedef uint16_t TRegisterWord;
 namespace Modbus // modbus protocol declarations
 {
     const int MAX_READ_BITS = 2000;
-    // const int MAX_WRITE_BITS = 1968;
 
     const int MAX_READ_REGISTERS = 125;
-    // const int MAX_WRITE_REGISTERS = 123;
-    // const int MAX_RW_WRITE_REGISTERS = 121;
 
     const size_t EXCEPTION_RESPONSE_PDU_SIZE = 2;
     const size_t WRITE_RESPONSE_PDU_SIZE = 5;

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -22,11 +22,11 @@ typedef uint16_t TRegisterWord;
 namespace Modbus // modbus protocol declarations
 {
     const int MAX_READ_BITS = 2000;
-    //const int MAX_WRITE_BITS = 1968;
+    // const int MAX_WRITE_BITS = 1968;
 
     const int MAX_READ_REGISTERS = 125;
-    //const int MAX_WRITE_REGISTERS = 123;
-    //const int MAX_RW_WRITE_REGISTERS = 121;
+    // const int MAX_WRITE_REGISTERS = 123;
+    // const int MAX_RW_WRITE_REGISTERS = 121;
 
     const size_t EXCEPTION_RESPONSE_PDU_SIZE = 2;
     const size_t WRITE_RESPONSE_PDU_SIZE = 5;

--- a/src/modbus_common.h
+++ b/src/modbus_common.h
@@ -66,8 +66,8 @@ namespace Modbus // modbus protocol common utilities
                          const TRequest& req,
                          TResponse& resp) const override;
 
-        uint8_t* GetPDU(std::vector<uint8_t>& frame) const;
-        const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const;
+        uint8_t* GetPDU(std::vector<uint8_t>& frame) const override;
+        const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const override;
     };
 
     class TModbusTCPTraits: public IModbusTraits
@@ -92,8 +92,8 @@ namespace Modbus // modbus protocol common utilities
                          const TRequest& req,
                          TResponse& resp) const override;
 
-        uint8_t* GetPDU(std::vector<uint8_t>& frame) const;
-        const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const;
+        uint8_t* GetPDU(std::vector<uint8_t>& frame) const override;
+        const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const override;
     };
 
     class IModbusTraitsFactory

--- a/src/register.h
+++ b/src/register.h
@@ -91,7 +91,7 @@ public:
 
 typedef std::shared_ptr<TRegisterTypeMap> PRegisterTypeMap;
 
-struct TRegisterConfig;
+class TRegisterConfig;
 typedef std::shared_ptr<TRegisterConfig> PRegisterConfig;
 
 class TSerialDevice;

--- a/src/register_handler.cpp
+++ b/src/register_handler.cpp
@@ -7,7 +7,7 @@ using namespace std::chrono;
 
 namespace
 {
-    //const size_t MAX_WRITE_FAILS = 10;
+    // const size_t MAX_WRITE_FAILS = 10;
     const seconds MAX_WRITE_FAIL_TIME(600); // 10 minutes
 }
 

--- a/src/register_handler.cpp
+++ b/src/register_handler.cpp
@@ -7,7 +7,6 @@ using namespace std::chrono;
 
 namespace
 {
-    // const size_t MAX_WRITE_FAILS = 10;
     const seconds MAX_WRITE_FAIL_TIME(600); // 10 minutes
 }
 

--- a/src/register_handler.cpp
+++ b/src/register_handler.cpp
@@ -7,7 +7,7 @@ using namespace std::chrono;
 
 namespace
 {
-    const size_t MAX_WRITE_FAILS = 10;
+    //const size_t MAX_WRITE_FAILS = 10;
     const seconds MAX_WRITE_FAIL_TIME(600); // 10 minutes
 }
 

--- a/src/rpc_handler.cpp
+++ b/src/rpc_handler.cpp
@@ -169,11 +169,10 @@ TRPCHandler::TRPCHandler(const std::string& requestSchemaFilePath,
     for (auto serialPortDriver: serialPortDrivers) {
         PPort port = serialPortDriver->GetSerialClient()->GetPort();
 
-        auto findedPortDriver = std::find_if(PortDrivers.begin(),
-                                             PortDrivers.end(),
-                                             [&port](PRPCPortDriver rpcPortDriver) {
-                                                 return port == rpcPortDriver->RPCPort->GetPort();
-                                             });
+        auto findedPortDriver =
+            std::find_if(PortDrivers.begin(), PortDrivers.end(), [&port](PRPCPortDriver rpcPortDriver) {
+                return port == rpcPortDriver->RPCPort->GetPort();
+            });
 
         if (findedPortDriver != PortDrivers.end()) {
             findedPortDriver->get()->SerialClient = serialPortDriver->GetSerialClient();

--- a/src/rpc_handler.cpp
+++ b/src/rpc_handler.cpp
@@ -171,7 +171,7 @@ TRPCHandler::TRPCHandler(const std::string& requestSchemaFilePath,
 
         auto findedPortDriver = std::find_if(PortDrivers.begin(),
                                              PortDrivers.end(),
-                                             [&serialPortDriver, &port](PRPCPortDriver rpcPortDriver) {
+                                             [&port](PRPCPortDriver rpcPortDriver) {
                                                  return port == rpcPortDriver->RPCPort->GetPort();
                                              });
 

--- a/src/rpc_port.h
+++ b/src/rpc_port.h
@@ -6,6 +6,7 @@ class TRPCPort
 {
 public:
     TRPCPort(PPort Port);
+    virtual ~TRPCPort() = default;
     PPort GetPort();
     virtual bool Match(const Json::Value& Request) const = 0;
 
@@ -19,7 +20,6 @@ class TRPCSerialPort: public TRPCPort
 {
 public:
     TRPCSerialPort(PPort Port, const std::string& Path);
-    virtual ~TRPCSerialPort() = default;
     bool Match(const Json::Value& Request) const;
 
 protected:
@@ -31,7 +31,6 @@ class TRPCTCPPort: public TRPCPort
 {
 public:
     TRPCTCPPort(PPort Port, const std::string& Ip, uint16_t PortNumber);
-    virtual ~TRPCTCPPort() = default;
     bool Match(const Json::Value& Request) const;
 
 protected:

--- a/src/rpc_port.h
+++ b/src/rpc_port.h
@@ -15,7 +15,7 @@ protected:
 
 typedef std::shared_ptr<TRPCPort> PRPCPort;
 
-class TRPCSerialPort final : public TRPCPort
+class TRPCSerialPort final: public TRPCPort
 {
 public:
     TRPCSerialPort(PPort Port, const std::string& Path);
@@ -26,7 +26,7 @@ protected:
 };
 typedef std::shared_ptr<TRPCSerialPort> PRPCSerialPort;
 
-class TRPCTCPPort final : public TRPCPort
+class TRPCTCPPort final: public TRPCPort
 {
 public:
     TRPCTCPPort(PPort Port, const std::string& Ip, uint16_t PortNumber);

--- a/src/rpc_port.h
+++ b/src/rpc_port.h
@@ -15,10 +15,11 @@ protected:
 
 typedef std::shared_ptr<TRPCPort> PRPCPort;
 
-class TRPCSerialPort final: public TRPCPort
+class TRPCSerialPort: public TRPCPort
 {
 public:
     TRPCSerialPort(PPort Port, const std::string& Path);
+    virtual ~TRPCSerialPort() = default;
     bool Match(const Json::Value& Request) const;
 
 protected:
@@ -26,10 +27,11 @@ protected:
 };
 typedef std::shared_ptr<TRPCSerialPort> PRPCSerialPort;
 
-class TRPCTCPPort final: public TRPCPort
+class TRPCTCPPort: public TRPCPort
 {
 public:
     TRPCTCPPort(PPort Port, const std::string& Ip, uint16_t PortNumber);
+    virtual ~TRPCTCPPort() = default;
     bool Match(const Json::Value& Request) const;
 
 protected:

--- a/src/rpc_port.h
+++ b/src/rpc_port.h
@@ -15,7 +15,7 @@ protected:
 
 typedef std::shared_ptr<TRPCPort> PRPCPort;
 
-class TRPCSerialPort: public TRPCPort
+class TRPCSerialPort final : public TRPCPort
 {
 public:
     TRPCSerialPort(PPort Port, const std::string& Path);
@@ -26,7 +26,7 @@ protected:
 };
 typedef std::shared_ptr<TRPCSerialPort> PRPCSerialPort;
 
-class TRPCTCPPort: public TRPCPort
+class TRPCTCPPort final : public TRPCPort
 {
 public:
     TRPCTCPPort(PPort Port, const std::string& Ip, uint16_t PortNumber);

--- a/test/dlms_test.cpp
+++ b/test/dlms_test.cpp
@@ -51,8 +51,8 @@ protected:
 class TDlmsIntegrationTest: public TSerialDeviceIntegrationTest, public TDlmsDeviceExpectations
 {
 protected:
-    void TearDown();
-    const char* ConfigPath() const
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-dlms-test.json";
     }

--- a/test/em_integration.cpp
+++ b/test/em_integration.cpp
@@ -8,9 +8,9 @@
 class TEMIntegrationTest: public TSerialDeviceIntegrationTest, public TMilurExpectations, public TMercury230Expectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-em-test.json";
     }

--- a/test/energomera_ce102m_test.cpp
+++ b/test/energomera_ce102m_test.cpp
@@ -71,7 +71,7 @@ namespace
     class TEnergomeraCe102MIntegrationTest: public TSerialDeviceIntegrationTest, public TEnergomeraCe102MExpectations
     {
     protected:
-        const char* ConfigPath() const
+        const char* ConfigPath() const override
         {
             return "configs/config-energomera-ce102m-test.json";
         }

--- a/test/energomera_test.cpp
+++ b/test/energomera_test.cpp
@@ -7,7 +7,7 @@ namespace
     class TEnergomeraIntegrationTest: public TSerialDeviceIntegrationTest, public virtual TExpectorProvider
     {
     protected:
-        const char* ConfigPath() const
+        const char* ConfigPath() const override
         {
             return "configs/config-energomera-test.json";
         }

--- a/test/fake_serial_port.h
+++ b/test/fake_serial_port.h
@@ -27,24 +27,24 @@ public:
     TFakeSerialPort(WBMQTT::Testing::TLoggedFixture& fixture);
 
     void SetExpectedFrameTimeout(const std::chrono::microseconds& timeout);
-    void CheckPortOpen() const;
-    void Open();
-    void Close();
-    bool IsOpen() const;
-    void WriteBytes(const uint8_t* buf, int count);
-    uint8_t ReadByte(const std::chrono::microseconds& timeout);
+    void CheckPortOpen() const override;
+    void Open() override;
+    void Close() override;
+    bool IsOpen() const override;
+    void WriteBytes(const uint8_t* buf, int count) override;
+    uint8_t ReadByte(const std::chrono::microseconds& timeout) override;
     size_t ReadFrame(uint8_t* buf,
                      size_t count,
                      const std::chrono::microseconds& responseTimeout = std::chrono::microseconds(-1),
                      const std::chrono::microseconds& frameTimeout = std::chrono::microseconds(-1),
-                     TFrameCompletePred frame_complete = 0);
-    void SkipNoise();
+                     TFrameCompletePred frame_complete = 0) override;
+    void SkipNoise() override;
 
     void SleepSinceLastInteraction(const std::chrono::microseconds& us) override;
 
     std::chrono::milliseconds GetSendTime(double bytesNumber) const override;
 
-    void Expect(const std::vector<int>& request, const std::vector<int>& response, const char* func = 0);
+    void Expect(const std::vector<int>& request, const std::vector<int>& response, const char* func = 0) override;
     void DumpWhatWasRead();
     void SimulateDisconnect(TDisconnectType simulate);
     WBMQTT::Testing::TLoggedFixture& GetFixture();

--- a/test/lls_test.cpp
+++ b/test/lls_test.cpp
@@ -5,9 +5,9 @@
 class TLLSIntegrationTest: public TSerialDeviceIntegrationTest
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-lls-test.json";
     }

--- a/test/mercury200_test.cpp
+++ b/test/mercury200_test.cpp
@@ -103,9 +103,9 @@ TEST_F(TMercury200Test, BatteryVoltageQuery)
 class TMercury200IntegrationTest: public TSerialDeviceIntegrationTest, public TMercury200Expectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-mercury200-test.json";
     }

--- a/test/mercury230_test.cpp
+++ b/test/mercury230_test.cpp
@@ -239,9 +239,9 @@ TEST_F(TMercury230CustomPasswordTest, Test)
 class TMercury230IntegrationTest: public TSerialDeviceIntegrationTest, public TMercury230Expectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-mercury230-test.json";
     }

--- a/test/milur_test.cpp
+++ b/test/milur_test.cpp
@@ -149,9 +149,9 @@ TEST_F(TMilurCustomPasswordTest, Test)
 class TMilurIntegrationTest: public TSerialDeviceIntegrationTest, public TMilurExpectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-milur-test.json";
     }

--- a/test/modbus_io_test.cpp
+++ b/test/modbus_io_test.cpp
@@ -7,8 +7,8 @@ using namespace std;
 class TModbusIOIntegrationTest: public TSerialDeviceIntegrationTest, public TModbusIOExpectations
 {
 protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
+    void TearDown() override;
     const char* ConfigPath() const override
     {
         return "configs/config-modbus-io-test.json";

--- a/test/modbus_tcp_test.cpp
+++ b/test/modbus_tcp_test.cpp
@@ -16,17 +16,17 @@ namespace
         {}
         void Close() override
         {}
-        bool IsOpen() const
+        bool IsOpen() const override
         {
             return false;
         }
-        void CheckPortOpen() const
+        void CheckPortOpen() const override
         {}
 
-        void WriteBytes(const uint8_t* buf, int count)
+        void WriteBytes(const uint8_t* buf, int count) override
         {}
 
-        uint8_t ReadByte(const std::chrono::microseconds& timeout)
+        uint8_t ReadByte(const std::chrono::microseconds& timeout) override
         {
             return 0;
         }
@@ -35,7 +35,7 @@ namespace
                          size_t count,
                          const std::chrono::microseconds& responseTimeout,
                          const std::chrono::microseconds& frameTimeout,
-                         TFrameCompletePred frame_complete = 0)
+                         TFrameCompletePred frame_complete = 0) override
         {
             if (Pointer == Stream.size()) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(15));
@@ -47,13 +47,13 @@ namespace
             return l;
         }
 
-        void SkipNoise()
+        void SkipNoise() override
         {}
 
-        void SleepSinceLastInteraction(const std::chrono::microseconds& us)
+        void SleepSinceLastInteraction(const std::chrono::microseconds& us) override
         {}
 
-        std::string GetDescription(bool verbose) const
+        std::string GetDescription(bool verbose) const override
         {
             return std::string();
         }

--- a/test/modbus_test.cpp
+++ b/test/modbus_test.cpp
@@ -420,8 +420,8 @@ protected:
         TEST_MAX_READ_REGISTERS_FIRST_CYCLE,
     };
 
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
+    void TearDown() override;
     const char* ConfigPath() const override
     {
         return "configs/config-modbus-test.json";
@@ -737,14 +737,14 @@ TEST_F(TModbusBitmasksIntegrationTest, SingleWrite)
 class TModbusUnavailableRegistersIntegrationTest: public TSerialDeviceIntegrationTest, public TModbusExpectations
 {
 protected:
-    void SetUp()
+    void SetUp() override
     {
         SelectModbusType(MODBUS_RTU);
         TSerialDeviceIntegrationTest::SetUp();
         ASSERT_TRUE(!!SerialPort);
     }
 
-    void TearDown()
+    void TearDown() override
     {
         SerialPort->Close();
         TSerialDeviceIntegrationTest::TearDown();
@@ -812,14 +812,14 @@ class TModbusUnavailableRegistersAndHolesIntegrationTest: public TSerialDeviceIn
                                                           public TModbusExpectations
 {
 protected:
-    void SetUp()
+    void SetUp() override
     {
         SelectModbusType(MODBUS_RTU);
         TSerialDeviceIntegrationTest::SetUp();
         ASSERT_TRUE(!!SerialPort);
     }
 
-    void TearDown()
+    void TearDown() override
     {
         SerialPort->Close();
         TSerialDeviceIntegrationTest::TearDown();

--- a/test/neva_test.cpp
+++ b/test/neva_test.cpp
@@ -106,7 +106,7 @@ namespace
     class TNevaIntegrationTest: public TSerialDeviceIntegrationTest, public TNevaExpectations
     {
     protected:
-        const char* ConfigPath() const
+        const char* ConfigPath() const override
         {
             return "configs/config-neva-test.json";
         }

--- a/test/s2k_test.cpp
+++ b/test/s2k_test.cpp
@@ -53,9 +53,9 @@ TEST_F(TS2KDeviceTest, TestSetRelayState)
 class TS2KIntegrationTest: public TSerialDeviceIntegrationTest, public TS2KDeviceExpectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-s2k-test.json";
     }

--- a/test/uniel_test.cpp
+++ b/test/uniel_test.cpp
@@ -92,9 +92,9 @@ TEST_F(TUnielDeviceTest, TestSetBrightness)
 class TUnielIntegrationTest: public TSerialDeviceIntegrationTest, public TUnielDeviceExpectations
 {
 protected:
-    void SetUp();
-    void TearDown();
-    const char* ConfigPath() const
+    void SetUp() override;
+    void TearDown() override;
+    const char* ConfigPath() const override
     {
         return "configs/config-uniel-test.json";
     }


### PR DESCRIPTION
```sh
wb-mqtt-serial> src/register.h:192:1: error: 'TRegisterConfig' defined as a class here but previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
<...>
wb-mqtt-serial> src/devices/mercury230_device.h:36:10: error: 'ConnectionSetup' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
<...>
wb-mqtt-serial> src/devices/mercury230_device.h:37:15: error: 'CheckForException' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
<...>
wb-mqtt-serial> src/modbus_common.h:69:18: error: 'GetPDU' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
<...>
wb-mqtt-serial> src/devices/lls_device.cpp:69:19: error: unused variable 'RESPONSE_PREFIX' [-Werror,-Wunused-const-variable]
<...>
wb-mqtt-serial> src/devices/milur_device.h:31:10: error: 'ConnectionSetup' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
<...>
wb-mqtt-serial> src/devices/milur_device.h:32:15: error: 'CheckForException' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
<...>
wb-mqtt-serial> /nix/store/1gf2flfqnpqbr1b4p4qz2f72y42bs56r-gcc-11.3.0/include/c++/11.3.0/ext/new_allocator.h:168:4: error: destructor called on non-final 'TRPCSerialPort' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
<...>
wb-mqtt-serial> /nix/store/1gf2flfqnpqbr1b4p4qz2f72y42bs56r-gcc-11.3.0/include/c++/11.3.0/ext/new_allocator.h:168:4: error: destructor called on non-final 'TRPCTCPPort' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
<...>
wb-mqtt-serial> src/rpc_handler.cpp:174:48: error: lambda capture 'serialPortDriver' is not used [-Werror,-Wunused-lambda-capture]
<...>
wb-mqtt-serial> src/modbus_common.cpp:25:15: error: unused variable 'MAX_WRITE_BITS' [-Werror,-Wunused-const-variable]
<...>
wb-mqtt-serial> src/modbus_common.cpp:28:15: error: unused variable 'MAX_WRITE_REGISTERS' [-Werror,-Wunused-const-variable]
<...>
wb-mqtt-serial> src/modbus_common.cpp:29:15: error: unused variable 'MAX_RW_WRITE_REGISTERS' [-Werror,-Wunused-const-variable]
<...>
wb-mqtt-serial> src/register_handler.cpp:10:18: error: unused variable 'MAX_WRITE_FAILS' [-Werror,-Wunused-const-variable]
<...>
wb-mqtt-serial> src/main.cpp:99:54: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
wb-mqtt-serial>         auto configSchema = make_shared<Json::Value>(std::move(LoadConfigSchema(CONFIG_JSON_SCHEMA_FULL_FILE_PATH)));
wb-mqtt-serial>                                                      ^
wb-mqtt-serial> src/main.cpp:99:54: note: remove std::move call here
wb-mqtt-serial>         auto configSchema = make_shared<Json::Value>(std::move(LoadConfigSchema(CONFIG_JSON_SCHEMA_FULL_FILE_PATH)));
wb-mqtt-serial>                                                      ^~~~~~~~~~                                                   ~
wb-mqtt-serial> 1 error generated.
<...and other similar...>
```