### PR TITLE
Fix RPCRequestTransceive test

### DIFF
--- a/test/TSerialClientIntegrationTest.RPCRequestTransceive.dat
+++ b/test/TSerialClientIntegrationTest.RPCRequestTransceive.dat
@@ -47,13 +47,13 @@ fake_serial_device '152': prepare
 fake_serial_device '152': read address '0' value '0'
 fake_serial_device '152': transfer OK
 fake_serial_device '152': reconnected
+fake_serial_device '152': read address '7' value '0'
+Publish: /devices/RPCTest/controls/Test: '0' (QoS 1, retained)
+Publish: /devices/RPCTest/controls/White: '0' (QoS 1, retained)
 fake_serial_device '152': read address '4' value '0'
 fake_serial_device '152': read address '5' value '0'
 fake_serial_device '152': read address '6' value '0'
-fake_serial_device '152': read address '7' value '0'
-Publish: /devices/RPCTest/controls/Test: '0' (QoS 1, retained)
 Publish: /devices/RPCTest/controls/RGB: '0;0;0' (QoS 1, retained)
-Publish: /devices/RPCTest/controls/White: '0' (QoS 1, retained)
 >>> [test case] ReadFrame exception: nothing to read
 Publish: /devices/RPCTest/controls/RGB/on: '10;20;30' (QoS 0, retained)
 Publish: /devices/RPCTest/controls/White/on: '42' (QoS 0, retained)
@@ -68,6 +68,7 @@ Publish: /devices/RPCTest/controls/RGB: '10;20;30' (QoS 1, retained)
 fake_serial_device '152': write to address '7' value '42'
 Publish: /devices/RPCTest/controls/White: '42' (QoS 1, retained)
 fake_serial_device '152': end session
+SkipNoise()
 Sleep(20000)
 >> 16 05 00 0A FF 00 AF 1F
 Sleep(20000)
@@ -100,6 +101,7 @@ fake_serial_device '152': write to address '5' value '20'
 fake_serial_device '152': write to address '6' value '30'
 fake_serial_device '152': write to address '7' value '42'
 fake_serial_device '152': end session
+SkipNoise()
 Sleep(20000)
 >> 16 05 00 0A FF 00 AF 1F
 << 16 05 00 0A FF 00 AF 1F
@@ -118,6 +120,7 @@ fake_serial_device '152': write to address '5' value '20'
 fake_serial_device '152': write to address '6' value '30'
 fake_serial_device '152': write to address '7' value '42'
 fake_serial_device '152': end session
+SkipNoise()
 Sleep(20000)
 >> 16 05 00 0A FF 00 AF 1F
 Sleep(20000)


### PR DESCRIPTION
В прошлом #557 забыл обновить RPCRequestTransceive тест, из-за этого [билд на мастере](https://jenkins.wirenboard.com/view/critical-builds/job/wirenboard/job/wb-mqtt-serial/job/master/293/) не прошел и релиз  не опубликовался. Поэтому тут не обновляю версию.