### PR TITLE
RPC: log IO errors at Debug log level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.78.4) stable; urgency=medium
+
+  * RPC: log IO errors at Debug log level
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 06 Feb 2023 09:12:00 +0400
+
 wb-mqtt-serial (2.78.3) stable; urgency=medium
 
   * Flush buffer before writing to port on RPC request

--- a/src/rpc_handler.cpp
+++ b/src/rpc_handler.cpp
@@ -224,7 +224,12 @@ Json::Value TRPCHandler::PortLoad(const Json::Value& request)
 
         replyJSON["response"] = responseStr;
     } catch (const TRPCException& e) {
-        LOG(Warn) << e.GetResultMessage();
+        if (e.GetResultCode() == TRPCResultCode::RPC_WRONG_IO) {
+            // Too many "request timed out" errors while scanning ports
+            LOG(Debug) << e.GetResultMessage();
+        } else {
+            LOG(Warn) << e.GetResultMessage();
+        }
         switch (e.GetResultCode()) {
             case TRPCResultCode::RPC_WRONG_TIMEOUT:
                 wb_throw(WBMQTT::TRequestTimeoutException, e.GetResultMessage());


### PR DESCRIPTION
Too many "request timed out" errors while scanning ports.