### PR TITLE
Fix safety timeout editing in wb-mqtt-homeui

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.80.2) stable; urgency=medium
+
+  * Fix safety timeout editing in wb-mqtt-homeui
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 13 Mar 2023 10:34:38 +0500
+
 wb-mqtt-serial (2.80.1) stable; urgency=medium
 
   * Fix missing l1, l2, l3 groups in MAP12E template

--- a/templates/config-wb-mr6cv3.json.jinja
+++ b/templates/config-wb-mr6cv3.json.jinja
@@ -390,7 +390,7 @@
                 "order": 2,
                 "reg_type": "holding",
                 "min": 1,
-                "condition" : "safety_mode_source!=2",
+                "condition" : "safety_mode_source!=1",
                 "max": 65534,
                 "default": 10
             }


### PR DESCRIPTION
Safety timeout is not used if safety mode trigger != 1