### PR TITLE
Fix config reading in wb-mqtt-homeui

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.80.3) stable; urgency=medium
+
+  * Fix reading of config with custom Modbus devices in wb-mqtt-homeui
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 15 Mar 2023 16:38:14 +0500
+
 wb-mqtt-serial (2.80.2) stable; urgency=medium
 
   * Fix safety timeout editing in wb-mqtt-homeui

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -889,8 +889,7 @@
           "disable_panel": true
         },
         "disable_collapse": true
-      },
-      "_format": "wb-multiple"
+      }
     },
     "channelSettings": {
       "type": "object",


### PR DESCRIPTION
Fix reading of config with custom Modbus devices in wb-mqtt-homeui


Клиент делает произвольный составной канал в модбас устройстве, сохраняет, жмёт F5 и получает такую ошибку.
![image](https://user-images.githubusercontent.com/86825564/225308112-489043ff-fe7b-45ee-ada5-104d98faea84.png)

Для редактирования каналов использовали редактор `wb-multiple`. Он предназначен для схем с `oneOf`, но имеет оптимизацию. Каждая подсхема `oneOf` должна иметь первый текстовый параметр в `required` с только одним значением. Это работает хорошо для выбора типа устройства и т.п. В нашем же случае для выбора подсхемы надо делать полную валидацию. В результате homeui показывал вместо составного канала канал из одного регистра и писал ошибку.