### PR TITLE
Fix average response time calculation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.85.3) stable; urgency=medium
+
+  * Fix calculation of average response time of modbus devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 18 May 2023 12:57:21 +0500
+
 wb-mqtt-serial (2.85.2) stable; urgency=medium
 
   * WB-M* templates: more description added for second press waiting time and debounce time

--- a/src/devices/curtains/dooya_device.cpp
+++ b/src/devices/curtains/dooya_device.cpp
@@ -108,10 +108,12 @@ std::vector<uint8_t> Dooya::TDevice::ExecCommand(const TRequest& request)
 {
     Port()->WriteBytes(request.Data);
     std::vector<uint8_t> respBytes(request.ResponseSize);
-    auto bytesRead = Port()->ReadFrame(respBytes.data(),
-                                       respBytes.size(),
-                                       DeviceConfig()->ResponseTimeout,
-                                       DeviceConfig()->FrameTimeout);
+    auto bytesRead = Port()
+                         ->ReadFrame(respBytes.data(),
+                                     respBytes.size(),
+                                     DeviceConfig()->ResponseTimeout,
+                                     DeviceConfig()->FrameTimeout)
+                         .Count;
     respBytes.resize(bytesRead);
     return respBytes;
 }

--- a/src/devices/curtains/somfy_sdn_device.cpp
+++ b/src/devices/curtains/somfy_sdn_device.cpp
@@ -207,11 +207,13 @@ std::vector<uint8_t> Somfy::TDevice::ExecCommand(const std::vector<uint8_t>& req
     Port()->SleepSinceLastInteraction(DeviceConfig()->FrameTimeout);
     Port()->WriteBytes(request);
     std::vector<uint8_t> respBytes(MAX_RESPONSE_SIZE);
-    auto bytesRead = Port()->ReadFrame(respBytes.data(),
-                                       respBytes.size(),
-                                       DeviceConfig()->ResponseTimeout,
-                                       DeviceConfig()->FrameTimeout,
-                                       FrameComplete);
+    auto bytesRead = Port()
+                         ->ReadFrame(respBytes.data(),
+                                     respBytes.size(),
+                                     DeviceConfig()->ResponseTimeout,
+                                     DeviceConfig()->FrameTimeout,
+                                     FrameComplete)
+                         .Count;
     respBytes.resize(bytesRead);
     FixReceivedFrame(respBytes);
     PrintDebugDump(respBytes, "Frame read: ");

--- a/src/devices/curtains/windeco_device.cpp
+++ b/src/devices/curtains/windeco_device.cpp
@@ -84,7 +84,9 @@ std::vector<uint8_t> WinDeco::TDevice::ExecCommand(const std::vector<uint8_t>& r
     Port()->WriteBytes(request);
     std::vector<uint8_t> respBytes(PACKET_SIZE);
     auto bytesRead =
-        Port()->ReadFrame(respBytes.data(), PACKET_SIZE, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
+        Port()
+            ->ReadFrame(respBytes.data(), PACKET_SIZE, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout)
+            .Count;
     respBytes.resize(bytesRead);
     return respBytes;
 }

--- a/src/devices/dlms_device.cpp
+++ b/src/devices/dlms_device.cpp
@@ -585,11 +585,13 @@ void TDlmsDevice::Read(unsigned char eop, CGXByteBuffer& reply)
     };
 
     uint8_t buf[MAX_PACKET_SIZE];
-    auto bytesRead = Port()->ReadFrame(buf,
-                                       sizeof(buf),
-                                       DeviceConfig()->ResponseTimeout,
-                                       DeviceConfig()->FrameTimeout,
-                                       frameCompleteFn);
+    auto bytesRead = Port()
+                         ->ReadFrame(buf,
+                                     sizeof(buf),
+                                     DeviceConfig()->ResponseTimeout,
+                                     DeviceConfig()->FrameTimeout,
+                                     frameCompleteFn)
+                         .Count;
     reply.Set(buf, bytesRead);
 }
 

--- a/src/devices/em_device.cpp
+++ b/src/devices/em_device.cpp
@@ -33,7 +33,9 @@ bool TEMDevice::ReadResponse(int expectedByte1, uint8_t* payload, int len, TPort
 {
     uint8_t buf[MAX_LEN], *p = buf;
     int nread =
-        Port()->ReadFrame(buf, MAX_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout, frame_complete);
+        Port()
+            ->ReadFrame(buf, MAX_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout, frame_complete)
+            .Count;
     if (nread < 3 + SlaveIdWidth)
         throw TSerialDeviceTransientErrorException("frame too short");
 

--- a/src/devices/ivtm_device.cpp
+++ b/src/devices/ivtm_device.cpp
@@ -82,11 +82,13 @@ void TIVTMDevice::ReadResponse(uint16_t addr, uint8_t* payload, uint16_t len)
 {
     uint8_t buf[MAX_LEN];
 
-    int nread = Port()->ReadFrame(buf,
-                                  MAX_LEN,
-                                  DeviceConfig()->ResponseTimeout,
-                                  DeviceConfig()->FrameTimeout,
-                                  [](uint8_t* buf, int size) { return size > 0 && buf[size - 1] == '\r'; });
+    int nread = Port()
+                    ->ReadFrame(buf,
+                                MAX_LEN,
+                                DeviceConfig()->ResponseTimeout,
+                                DeviceConfig()->FrameTimeout,
+                                [](uint8_t* buf, int size) { return size > 0 && buf[size - 1] == '\r'; })
+                    .Count;
     if (nread < 10)
         throw TSerialDeviceTransientErrorException("frame too short");
 

--- a/src/devices/ivtm_device.cpp
+++ b/src/devices/ivtm_device.cpp
@@ -82,7 +82,7 @@ void TIVTMDevice::ReadResponse(uint16_t addr, uint8_t* payload, uint16_t len)
 {
     uint8_t buf[MAX_LEN];
 
-    int nread = Port()
+    auto nread = Port()
                     ->ReadFrame(buf,
                                 MAX_LEN,
                                 DeviceConfig()->ResponseTimeout,

--- a/src/devices/ivtm_device.cpp
+++ b/src/devices/ivtm_device.cpp
@@ -83,12 +83,12 @@ void TIVTMDevice::ReadResponse(uint16_t addr, uint8_t* payload, uint16_t len)
     uint8_t buf[MAX_LEN];
 
     auto nread = Port()
-                    ->ReadFrame(buf,
-                                MAX_LEN,
-                                DeviceConfig()->ResponseTimeout,
-                                DeviceConfig()->FrameTimeout,
-                                [](uint8_t* buf, int size) { return size > 0 && buf[size - 1] == '\r'; })
-                    .Count;
+                     ->ReadFrame(buf,
+                                 MAX_LEN,
+                                 DeviceConfig()->ResponseTimeout,
+                                 DeviceConfig()->FrameTimeout,
+                                 [](uint8_t* buf, int size) { return size > 0 && buf[size - 1] == '\r'; })
+                     .Count;
     if (nread < 10)
         throw TSerialDeviceTransientErrorException("frame too short");
 

--- a/src/devices/lls_device.cpp
+++ b/src/devices/lls_device.cpp
@@ -88,7 +88,8 @@ std::vector<uint8_t> TLLSDevice::ExecCommand(uint8_t cmd)
     Port()->WriteBytes(buf, REQUEST_LEN);
     Port()->SleepSinceLastInteraction(DeviceConfig()->FrameTimeout);
 
-    int len = Port()->ReadFrame(buf, RESPONSE_BUF_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
+    int len =
+        Port()->ReadFrame(buf, RESPONSE_BUF_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout).Count;
     if (buf[0] != RESPONSE_PREFIX) {
         throw TSerialDeviceTransientErrorException("invalid response prefix");
     }

--- a/src/devices/mercury200_device.cpp
+++ b/src/devices/mercury200_device.cpp
@@ -106,7 +106,9 @@ int TMercury200Device::RequestResponse(uint32_t slave, uint8_t cmd, uint8_t* res
     uint8_t request[REQUEST_LEN];
     FillCommand(request, slave, cmd);
     Port()->WriteBytes(request, REQUEST_LEN);
-    return Port()->ReadFrame(response, RESPONSE_BUF_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
+    return Port()
+        ->ReadFrame(response, RESPONSE_BUF_LEN, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout)
+        .Count;
 }
 
 void TMercury200Device::FillCommand(uint8_t* buf, uint32_t id, uint8_t cmd) const

--- a/src/devices/pulsar_device.cpp
+++ b/src/devices/pulsar_device.cpp
@@ -150,11 +150,13 @@ void TPulsarDevice::ReadResponse(uint32_t addr, uint8_t* payload, size_t size, u
     const int exp_size = size + 10; /* payload size + service bytes */
     std::vector<uint8_t> response(exp_size);
 
-    int nread = Port()->ReadFrame(response.data(),
-                                  response.size(),
-                                  DeviceConfig()->ResponseTimeout,
-                                  DeviceConfig()->FrameTimeout,
-                                  [](uint8_t* buf, int size) { return size >= 6 && size == buf[5]; });
+    int nread = Port()
+                    ->ReadFrame(response.data(),
+                                response.size(),
+                                DeviceConfig()->ResponseTimeout,
+                                DeviceConfig()->FrameTimeout,
+                                [](uint8_t* buf, int size) { return size >= 6 && size == buf[5]; })
+                    .Count;
 
     /* check size */
     if (nread < 6)

--- a/src/devices/s2k_device.cpp
+++ b/src/devices/s2k_device.cpp
@@ -92,7 +92,7 @@ void TS2KDevice::WriteRegisterImpl(PRegister reg, const TRegisterValue& value)
     command[6] = CrcS2K(command, 6);
     Port()->WriteBytes(command, 7);
     uint8_t response[256];
-    int size = Port()->ReadFrame(response, 256, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
+    int size = Port()->ReadFrame(response, 256, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout).Count;
     if (size != 6 || response[0] != (uint8_t)SlaveId || response[1] != 5 || response[2] != 0x16) {
         throw TSerialDeviceTransientErrorException("incorrect response for 0x15 command");
     }
@@ -127,7 +127,8 @@ TRegisterValue TS2KDevice::ReadRegisterImpl(PRegister reg)
             command[6] = CrcS2K(command, 6);
             Port()->WriteBytes(command, 7);
             uint8_t response[256];
-            int size = Port()->ReadFrame(response, 256, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout);
+            int size =
+                Port()->ReadFrame(response, 256, DeviceConfig()->ResponseTimeout, DeviceConfig()->FrameTimeout).Count;
             if (size != 6 || response[0] != (uint8_t)SlaveId || response[1] != 0x5 || response[2] != 0x6) {
                 throw TSerialDeviceTransientErrorException("incorrect response for 0x5 command");
             }

--- a/src/file_descriptor_port.cpp
+++ b/src/file_descriptor_port.cpp
@@ -1,5 +1,6 @@
 #include "file_descriptor_port.h"
 #include "binary_semaphore.h"
+#include "common_utils.h"
 #include "serial_exc.h"
 
 #include <iomanip>
@@ -149,30 +150,32 @@ size_t TFileDescriptorPort::ReadAvailableData(uint8_t* buf, size_t max_read)
 }
 
 // Reading becomes unstable when using timeout less than default because of bufferization
-size_t TFileDescriptorPort::ReadFrame(uint8_t* buf,
-                                      size_t size,
-                                      const std::chrono::microseconds& responseTimeout,
-                                      const std::chrono::microseconds& frameTimeout,
-                                      TFrameCompletePred frame_complete)
+TReadFrameResult TFileDescriptorPort::ReadFrame(uint8_t* buf,
+                                                size_t size,
+                                                const std::chrono::microseconds& responseTimeout,
+                                                const std::chrono::microseconds& frameTimeout,
+                                                TFrameCompletePred frame_complete)
 {
     CheckPortOpen();
-    size_t nread = 0;
+    TReadFrameResult res;
 
     if (!size) {
-        return 0;
+        return res;
     }
+
+    util::TSpendTimeMeter spendTime;
 
     // Will wait first byte up to responseTimeout us
     auto selectTimeout = responseTimeout;
-    while (nread < size) {
-        if (frame_complete && frame_complete(buf, nread)) {
+    while (res.Count < size) {
+        if (frame_complete && frame_complete(buf, res.Count)) {
             break;
         }
 
         if (!Select(selectTimeout))
             break; // end of the frame
 
-        size_t nb = ReadAvailableData(buf + nread, size - nread);
+        size_t nb = ReadAvailableData(buf + res.Count, size - res.Count);
 
         // Got Fd as ready for read from select, but no actual data to read
         if (nb == 0) {
@@ -182,20 +185,23 @@ size_t TFileDescriptorPort::ReadFrame(uint8_t* buf,
         // Got something, switch to frameTimeout to detect frame boundary
         // Delay between bytes in one message can't be more than frameTimeout
         selectTimeout = frameTimeout;
-        nread += nb;
+        if (res.Count == 0) {
+            res.ResponseTime = spendTime.GetSpendTime();
+        }
+        res.Count += nb;
     }
 
-    if (!nread) {
+    if (!res.Count) {
         throw TSerialDeviceTransientErrorException("request timed out");
     }
 
     LastInteraction = std::chrono::steady_clock::now();
 
     if (::Debug.IsEnabled()) {
-        LOG(Debug) << GetDescription(false) << ": ReadFrame: " << WBMQTT::HexDump(buf, nread);
+        LOG(Debug) << GetDescription(false) << ": ReadFrame: " << WBMQTT::HexDump(buf, res.Count);
     }
 
-    return nread;
+    return res;
 }
 
 void TFileDescriptorPort::SkipNoise()

--- a/src/file_descriptor_port.h
+++ b/src/file_descriptor_port.h
@@ -13,11 +13,11 @@ public:
 
     void WriteBytes(const uint8_t* buf, int count) override;
     uint8_t ReadByte(const std::chrono::microseconds& timeout) override;
-    size_t ReadFrame(uint8_t* buf,
-                     size_t count,
-                     const std::chrono::microseconds& responseTimeout,
-                     const std::chrono::microseconds& frameTimeout,
-                     TFrameCompletePred frame_complete = 0) override;
+    TReadFrameResult ReadFrame(uint8_t* buf,
+                               size_t count,
+                               const std::chrono::microseconds& responseTimeout,
+                               const std::chrono::microseconds& frameTimeout,
+                               TFrameCompletePred frame_complete = 0) override;
     void SkipNoise() override;
     void Close() override;
     void CheckPortOpen() const override;

--- a/src/iec_common.cpp
+++ b/src/iec_common.cpp
@@ -107,7 +107,7 @@ namespace IEC
                      TPort::TFrameCompletePred frame_complete,
                      const std::string& logPrefix)
     {
-        size_t nread = port.ReadFrame(buf, count, responseTimeout, frameTimeout, frame_complete);
+        size_t nread = port.ReadFrame(buf, count, responseTimeout, frameTimeout, frame_complete).Count;
         if (Debug.IsEnabled()) {
             Debug.Log() << logPrefix << "ReadFrame: " << ToString(buf, nread);
         }

--- a/src/modbus_common.h
+++ b/src/modbus_common.h
@@ -39,11 +39,11 @@ namespace Modbus // modbus protocol common utilities
          *
          * @return size_t PDU size in bytes
          */
-        virtual size_t ReadFrame(TPort& port,
-                                 const std::chrono::milliseconds& responseTimeout,
-                                 const std::chrono::milliseconds& frameTimeout,
-                                 const TRequest& req,
-                                 TResponse& resp) const = 0;
+        virtual TReadFrameResult ReadFrame(TPort& port,
+                                           const std::chrono::milliseconds& responseTimeout,
+                                           const std::chrono::milliseconds& frameTimeout,
+                                           const TRequest& req,
+                                           TResponse& resp) const = 0;
 
         virtual uint8_t* GetPDU(std::vector<uint8_t>& frame) const = 0;
         virtual const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const = 0;
@@ -60,11 +60,11 @@ namespace Modbus // modbus protocol common utilities
 
         void FinalizeRequest(TRequest& request, uint8_t slaveId) override;
 
-        size_t ReadFrame(TPort& port,
-                         const std::chrono::milliseconds& responseTimeout,
-                         const std::chrono::milliseconds& frameTimeout,
-                         const TRequest& req,
-                         TResponse& resp) const override;
+        TReadFrameResult ReadFrame(TPort& port,
+                                   const std::chrono::milliseconds& responseTimeout,
+                                   const std::chrono::milliseconds& frameTimeout,
+                                   const TRequest& req,
+                                   TResponse& resp) const override;
 
         uint8_t* GetPDU(std::vector<uint8_t>& frame) const override;
         const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const override;
@@ -86,11 +86,11 @@ namespace Modbus // modbus protocol common utilities
 
         void FinalizeRequest(TRequest& request, uint8_t slaveId) override;
 
-        size_t ReadFrame(TPort& port,
-                         const std::chrono::milliseconds& responseTimeout,
-                         const std::chrono::milliseconds& frameTimeout,
-                         const TRequest& req,
-                         TResponse& resp) const override;
+        TReadFrameResult ReadFrame(TPort& port,
+                                   const std::chrono::milliseconds& responseTimeout,
+                                   const std::chrono::milliseconds& frameTimeout,
+                                   const TRequest& req,
+                                   TResponse& resp) const override;
 
         uint8_t* GetPDU(std::vector<uint8_t>& frame) const override;
         const uint8_t* GetPDU(const std::vector<uint8_t>& frame) const override;

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -187,7 +187,7 @@ namespace ModbusExt // modbus extension protocol declarations
 
         const auto timeout = GetTimeout(port);
         std::array<uint8_t, MAX_PACKET_SIZE + ARBITRATION_HEADER_MAX_BYTES> res;
-        auto rc = port.ReadFrame(res.data(), res.size(), timeout, timeout, ExpectEvents());
+        auto rc = port.ReadFrame(res.data(), res.size(), timeout, timeout, ExpectEvents()).Count;
         port.SleepSinceLastInteraction(port.GetSendTimeBytes(3.5));
 
         auto start = GetPacketStart(res.data(), res.size());
@@ -269,7 +269,7 @@ namespace ModbusExt // modbus extension protocol declarations
         Port.WriteBytes(Request);
 
         // Use response timeout from MR6C template
-        auto rc = Port.ReadFrame(Response.data(), Request.size(), 8ms, FrameTimeout);
+        auto rc = Port.ReadFrame(Response.data(), Request.size(), 8ms, FrameTimeout).Count;
 
         CheckCRC16(Response.data(), rc);
 

--- a/src/port.h
+++ b/src/port.h
@@ -9,6 +9,15 @@
 
 #include "serial_port_settings.h"
 
+struct TReadFrameResult
+{
+    //! Received byte count
+    size_t Count = 0;
+
+    //! Time to first byte
+    std::chrono::microseconds ResponseTime = std::chrono::microseconds::zero();
+};
+
 class TPort: public std::enable_shared_from_this<TPort>
 {
 public:
@@ -41,13 +50,12 @@ public:
      * @param responseTimeout maximum waiting timeout before first byte of frame
      * @param frameTimeout minimum inter-frame delay
      * @param frame_complete
-     * @return size_t received byte count
      */
-    virtual size_t ReadFrame(uint8_t* buf,
-                             size_t count,
-                             const std::chrono::microseconds& responseTimeout,
-                             const std::chrono::microseconds& frameTimeout,
-                             TFrameCompletePred frame_complete = 0) = 0;
+    virtual TReadFrameResult ReadFrame(uint8_t* buf,
+                                       size_t count,
+                                       const std::chrono::microseconds& responseTimeout,
+                                       const std::chrono::microseconds& frameTimeout,
+                                       TFrameCompletePred frame_complete = 0) = 0;
 
     virtual void SkipNoise() = 0;
 

--- a/src/rpc_handler.cpp
+++ b/src/rpc_handler.cpp
@@ -129,7 +129,8 @@ namespace
         auto actualSize = port->ReadFrame(response.data(),
                                           rpcRequest->ResponseSize,
                                           rpcRequest->ResponseTimeout,
-                                          rpcRequest->FrameTimeout);
+                                          rpcRequest->FrameTimeout)
+                              .Count;
         response.resize(actualSize);
 
         return response;

--- a/src/rpc_request_handler.cpp
+++ b/src/rpc_request_handler.cpp
@@ -36,10 +36,9 @@ void TRPCRequestHandler::RPCRequestHandling(PPort port)
             port->WriteBytes(Request->Message);
 
             std::vector<uint8_t> response(Request->ResponseSize);
-            size_t actualSize = port->ReadFrame(response.data(),
-                                                Request->ResponseSize,
-                                                Request->ResponseTimeout,
-                                                Request->FrameTimeout);
+            size_t actualSize =
+                port->ReadFrame(response.data(), Request->ResponseSize, Request->ResponseTimeout, Request->FrameTimeout)
+                    .Count;
 
             response.resize(actualSize);
             if (Request->OnResult) {

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -225,11 +225,11 @@ uint8_t TSerialPort::ReadByte(const std::chrono::microseconds& timeout)
     return Base::ReadByte(timeout + GetLinuxLag(Settings.BaudRate));
 }
 
-size_t TSerialPort::ReadFrame(uint8_t* buf,
-                              size_t count,
-                              const std::chrono::microseconds& responseTimeout,
-                              const std::chrono::microseconds& frameTimeout,
-                              TFrameCompletePred frameComplete)
+TReadFrameResult TSerialPort::ReadFrame(uint8_t* buf,
+                                        size_t count,
+                                        const std::chrono::microseconds& responseTimeout,
+                                        const std::chrono::microseconds& frameTimeout,
+                                        TFrameCompletePred frameComplete)
 {
     return Base::ReadFrame(buf,
                            count,

--- a/src/serial_port.h
+++ b/src/serial_port.h
@@ -23,11 +23,11 @@ public:
     void WriteBytes(const uint8_t* buf, int count) override;
 
     uint8_t ReadByte(const std::chrono::microseconds& timeout) override;
-    size_t ReadFrame(uint8_t* buf,
-                     size_t count,
-                     const std::chrono::microseconds& responseTimeout,
-                     const std::chrono::microseconds& frameTimeout,
-                     TFrameCompletePred frameComplete = 0) override;
+    TReadFrameResult ReadFrame(uint8_t* buf,
+                               size_t count,
+                               const std::chrono::microseconds& responseTimeout,
+                               const std::chrono::microseconds& frameTimeout,
+                               TFrameCompletePred frameComplete = 0) override;
 
     std::chrono::microseconds GetSendTimeBytes(double bytesNumber) const override;
     std::chrono::microseconds GetSendTimeBits(size_t bitsNumber) const override;

--- a/src/tcp_port.cpp
+++ b/src/tcp_port.cpp
@@ -117,11 +117,11 @@ uint8_t TTcpPort::ReadByte(const std::chrono::microseconds& timeout)
     return Base::ReadByte(timeout + ResponseTCPLag);
 }
 
-size_t TTcpPort::ReadFrame(uint8_t* buf,
-                           size_t count,
-                           const std::chrono::microseconds& responseTimeout,
-                           const std::chrono::microseconds& frameTimeout,
-                           TFrameCompletePred frame_complete)
+TReadFrameResult TTcpPort::ReadFrame(uint8_t* buf,
+                                     size_t count,
+                                     const std::chrono::microseconds& responseTimeout,
+                                     const std::chrono::microseconds& frameTimeout,
+                                     TFrameCompletePred frame_complete)
 {
     if (IsOpen()) {
         return Base::ReadFrame(buf,
@@ -131,7 +131,7 @@ size_t TTcpPort::ReadFrame(uint8_t* buf,
                                frame_complete);
     }
     LOG(Debug) << "Attempt to read from not open port";
-    return 0;
+    return TReadFrameResult();
 }
 
 std::string TTcpPort::GetDescription(bool verbose) const

--- a/src/tcp_port.h
+++ b/src/tcp_port.h
@@ -14,11 +14,11 @@ public:
     void Open() override;
     void WriteBytes(const uint8_t* buf, int count) override;
     uint8_t ReadByte(const std::chrono::microseconds& timeout) override;
-    size_t ReadFrame(uint8_t* buf,
-                     size_t count,
-                     const std::chrono::microseconds& responseTimeout,
-                     const std::chrono::microseconds& frameTimeout,
-                     TFrameCompletePred frame_complete = 0) override;
+    TReadFrameResult ReadFrame(uint8_t* buf,
+                               size_t count,
+                               const std::chrono::microseconds& responseTimeout,
+                               const std::chrono::microseconds& frameTimeout,
+                               TFrameCompletePred frame_complete = 0) override;
 
     std::string GetDescription(bool verbose = true) const override;
 

--- a/test/fake_serial_port.h
+++ b/test/fake_serial_port.h
@@ -33,11 +33,11 @@ public:
     bool IsOpen() const override;
     void WriteBytes(const uint8_t* buf, int count) override;
     uint8_t ReadByte(const std::chrono::microseconds& timeout) override;
-    size_t ReadFrame(uint8_t* buf,
-                     size_t count,
-                     const std::chrono::microseconds& responseTimeout = std::chrono::microseconds(-1),
-                     const std::chrono::microseconds& frameTimeout = std::chrono::microseconds(-1),
-                     TFrameCompletePred frame_complete = 0) override;
+    TReadFrameResult ReadFrame(uint8_t* buf,
+                               size_t count,
+                               const std::chrono::microseconds& responseTimeout = std::chrono::microseconds(-1),
+                               const std::chrono::microseconds& frameTimeout = std::chrono::microseconds(-1),
+                               TFrameCompletePred frame_complete = 0) override;
     void SkipNoise() override;
 
     void SleepSinceLastInteraction(const std::chrono::microseconds& us) override;

--- a/test/modbus_ext_common_test.cpp
+++ b/test/modbus_ext_common_test.cpp
@@ -37,14 +37,16 @@ namespace
             return 0;
         }
 
-        size_t ReadFrame(uint8_t* buf,
-                         size_t count,
-                         const std::chrono::microseconds& responseTimeout,
-                         const std::chrono::microseconds& frameTimeout,
-                         TFrameCompletePred frame_complete = 0) override
+        TReadFrameResult ReadFrame(uint8_t* buf,
+                                   size_t count,
+                                   const std::chrono::microseconds& responseTimeout,
+                                   const std::chrono::microseconds& frameTimeout,
+                                   TFrameCompletePred frame_complete = 0) override
         {
+            TReadFrameResult res;
+            res.Count = Response.size();
             memcpy(buf, Response.data(), Response.size());
-            return Response.size();
+            return res;
         }
 
         void SkipNoise() override


### PR DESCRIPTION
Average response time must be counted till first received byte, but it was counted till last received byte