### PR TITLE
Fix stop polling some registers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.85.3) stable; urgency=medium
+
+  * Fix stop polling some registers
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 17 May 2023 09:14:52 +0500
+
 wb-mqtt-serial (2.85.2) stable; urgency=medium
 
   * WB-M* templates: more description added for second press waiting time and debounce time

--- a/src/common_utils.cpp
+++ b/src/common_utils.cpp
@@ -29,17 +29,20 @@ std::string util::ConvertToValidMqttTopicString(const std::string& src)
     return validStr;
 }
 
-void util::TSpendTimeMeter::Start()
+util::TSpentTimeMeter::TSpentTimeMeter(util::TGetNowFn nowFn): NowFn(nowFn)
+{}
+
+void util::TSpentTimeMeter::Start()
 {
-    StartTime = std::chrono::steady_clock::now();
+    StartTime = NowFn();
 }
 
-std::chrono::steady_clock::time_point util::TSpendTimeMeter::GetStartTime() const
+std::chrono::steady_clock::time_point util::TSpentTimeMeter::GetStartTime() const
 {
     return StartTime;
 }
 
-std::chrono::microseconds util::TSpendTimeMeter::GetSpendTime() const
+std::chrono::microseconds util::TSpentTimeMeter::GetSpentTime() const
 {
-    return std::chrono::ceil<std::chrono::microseconds>(std::chrono::steady_clock::now() - StartTime);
+    return std::chrono::ceil<std::chrono::microseconds>(NowFn() - StartTime);
 }

--- a/src/common_utils.h
+++ b/src/common_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <chrono>
+#include <functional>
 #include <string>
 
 namespace util
@@ -14,14 +15,32 @@ namespace util
     /// \return modified string
     std::string ConvertToValidMqttTopicString(const std::string& src);
 
-    class TSpendTimeMeter
+    typedef std::function<std::chrono::steady_clock::time_point()> TGetNowFn;
+
+    class TSpentTimeMeter
     {
         std::chrono::steady_clock::time_point StartTime;
+        TGetNowFn NowFn;
 
     public:
+        TSpentTimeMeter(TGetNowFn nowFn);
+
         void Start();
 
         std::chrono::steady_clock::time_point GetStartTime() const;
-        std::chrono::microseconds GetSpendTime() const;
+        std::chrono::microseconds GetSpentTime() const;
+    };
+
+    /**
+     *  Classes derived from TNonCopyable cannot be copied.
+     *  The idea is taken from boost::noncopyable
+     */
+    class TNonCopyable
+    {
+    protected:
+        TNonCopyable() = default;
+        ~TNonCopyable() = default;
+        TNonCopyable(const TNonCopyable&) = delete;
+        TNonCopyable& operator=(const TNonCopyable&) = delete;
     };
 }

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -287,6 +287,10 @@ namespace ModbusExt // modbus extension protocol declarations
             throw Modbus::TMalformedResponseError("invalid slave id");
         }
 
+        if (Response[SUB_COMMAND_POS] != ENABLE_EVENTS_COMMAND) {
+            throw Modbus::TMalformedResponseError("invalid sub command");
+        }
+
         TBitIterator dataIt(Response.data() + ENABLE_EVENTS_RESPONSE_DATA_POS - 1,
                             Response[ENABLE_EVENTS_RESPONSE_DATA_SIZE_POS]);
 

--- a/src/poll_plan.h
+++ b/src/poll_plan.h
@@ -180,6 +180,11 @@ public:
     {
         TotalTime = std::chrono::milliseconds::zero();
     }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TotalTime;
+    }
 };
 
 template<class TEntry, class TComparePredicate = std::less<TEntry>> class TScheduler
@@ -294,6 +299,11 @@ public:
     bool IsEmpty() const
     {
         return LowPriorityQueue.IsEmpty() && HighPriorityQueue.IsEmpty();
+    }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TimeBalancer.GetTotalTime();
     }
 
 private:

--- a/src/poll_plan.h
+++ b/src/poll_plan.h
@@ -180,6 +180,11 @@ public:
     {
         TotalTime = std::chrono::milliseconds::zero();
     }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TotalTime;
+    }
 };
 
 template<class TEntry, class TComparePredicate = std::less<TEntry>> class TScheduler
@@ -189,7 +194,7 @@ public:
     using TItem = typename TQueue::TItem;
 
     TScheduler(std::chrono::milliseconds maxLowPriorityLag, size_t lowPriorityRateLimit)
-        : TimeBalancer(maxLowPriorityLag, 10 * maxLowPriorityLag),
+        : TimeBalancer(maxLowPriorityLag, 2 * maxLowPriorityLag),
           LowPriorityRateLimit(lowPriorityRateLimit)
     {
         ResetLoadBalancing();
@@ -233,10 +238,6 @@ public:
     template<class TAccumulator>
     TThrottlingState AccumulateNext(std::chrono::steady_clock::time_point currentTime, TAccumulator& accumulator)
     {
-        if (!LowPriorityQueue.HasReadyItems(currentTime)) {
-            ResetLoadBalancing();
-        }
-
         if (HighPriorityQueue.HasReadyItems(currentTime) &&
             (!ShouldSelectLowPriority(currentTime) || !LowPriorityQueue.HasReadyItems(currentTime)))
         {
@@ -298,6 +299,11 @@ public:
     bool IsEmpty() const
     {
         return LowPriorityQueue.IsEmpty() && HighPriorityQueue.IsEmpty();
+    }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TimeBalancer.GetTotalTime();
     }
 
 private:

--- a/src/poll_plan.h
+++ b/src/poll_plan.h
@@ -180,11 +180,6 @@ public:
     {
         TotalTime = std::chrono::milliseconds::zero();
     }
-
-    std::chrono::milliseconds GetTotalTime() const
-    {
-        return TotalTime;
-    }
 };
 
 template<class TEntry, class TComparePredicate = std::less<TEntry>> class TScheduler
@@ -299,11 +294,6 @@ public:
     bool IsEmpty() const
     {
         return LowPriorityQueue.IsEmpty() && HighPriorityQueue.IsEmpty();
-    }
-
-    std::chrono::milliseconds GetTotalTime() const
-    {
-        return TimeBalancer.GetTotalTime();
     }
 
 private:

--- a/src/port.h
+++ b/src/port.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common_utils.h"
 #include "definitions.h"
 
 #include <chrono>
@@ -94,7 +95,7 @@ public:
         std::chrono::milliseconds ReopenTimeout = std::chrono::milliseconds(5000);
     };
 
-    TPortOpenCloseLogic(const TPortOpenCloseLogic::TSettings& settings);
+    TPortOpenCloseLogic(const TPortOpenCloseLogic::TSettings& settings, util::TGetNowFn nowFn);
 
     void OpenIfAllowed(PPort port);
     void CloseIfNeeded(PPort port, bool allPreviousDataExchangeWasFailed);
@@ -104,4 +105,5 @@ private:
     std::chrono::steady_clock::time_point LastSuccessfulCycle;
     size_t RemainingFailCycles;
     std::chrono::steady_clock::time_point NextOpenTryTime;
+    util::TGetNowFn NowFn;
 };

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -36,32 +36,24 @@ namespace
     }
 };
 
-TSerialClient::TSerialClient(const std::vector<PSerialDevice>& devices,
-                             PPort port,
+TSerialClient::TSerialClient(PPort port,
                              const TPortOpenCloseLogic::TSettings& openCloseSettings,
+                             util::TGetNowFn nowFn,
                              size_t lowPriorityRateLimit)
     : Port(port),
-      Active(false),
-      OpenCloseLogic(openCloseSettings),
+      OpenCloseLogic(openCloseSettings, nowFn),
       ConnectLogger(PORT_OPEN_ERROR_NOTIFICATION_INTERVAL, "[serial client] "),
-      EventsReader(MAX_EVENT_READ_ERRORS),
-      RegisterPoller(lowPriorityRateLimit),
-      LastAccessedDevice(EventsReader),
-      TimeBalancer(BALANCING_THRESHOLD, 0),
-      LastCycleWasTooSmallToPoll(false)
+      NowFn(nowFn),
+      LowPriorityRateLimit(lowPriorityRateLimit)
 {
     FlushNeeded = std::make_shared<TBinarySemaphore>();
     RPCRequestHandler = std::make_shared<TRPCRequestHandler>();
     RegisterUpdateSignal = FlushNeeded->MakeSignal();
     RPCSignal = FlushNeeded->MakeSignal();
-    RegisterPoller.SetDeviceDisconnectedCallback(
-        [this](PSerialDevice device) { EventsReader.DeviceDisconnected(device); });
-    ReadEventsPeriod = GetReadEventsPeriod(*Port);
 }
 
 TSerialClient::~TSerialClient()
 {
-    Active = false;
     if (Port->IsOpen()) {
         Port->Close();
     }
@@ -69,26 +61,23 @@ TSerialClient::~TSerialClient()
 
 void TSerialClient::AddRegister(PRegister reg)
 {
-    if (Active)
+    if (RegHandler)
         throw TSerialDeviceException("can't add registers to the active client");
     if (Handlers.find(reg) != Handlers.end())
         throw TSerialDeviceException("duplicate register");
     auto handler = Handlers[reg] = std::make_shared<TRegisterHandler>(reg->Device(), reg);
     RegList.push_back(reg);
-    EventsReader.AddRegister(reg);
     LOG(Debug) << "AddRegister: " << reg;
 }
 
 void TSerialClient::Activate()
 {
-    if (!Active) {
-        Active = true;
-        auto now = steady_clock::now();
-        RegisterPoller.PrepareRegisterRanges(RegList, now);
-        if (EventsReader.HasRegisters()) {
-            TimeBalancer.AddEntry(TClientTaskType::EVENTS, now, TPriority::High);
-        }
-        TimeBalancer.AddEntry(TClientTaskType::POLLING, now, TPriority::Low);
+    if (!RegHandler) {
+        RegHandler = std::make_unique<TSerialClientRegisterAndEventsReader>(RegList,
+                                                                            GetReadEventsPeriod(*Port),
+                                                                            NowFn,
+                                                                            LowPriorityRateLimit);
+        LastAccessedDevice = std::make_unique<TSerialClientDeviceAccessHandler>(RegHandler->GetEventsReader());
     }
 }
 
@@ -103,7 +92,7 @@ void TSerialClient::DoFlush()
         auto handler = Handlers[reg];
         if (!handler->NeedToFlush())
             continue;
-        if (LastAccessedDevice.PrepareToAccess(handler->Device())) {
+        if (LastAccessedDevice->PrepareToAccess(handler->Device())) {
             handler->Flush();
         } else {
             reg->SetError(TRegister::TError::WriteError);
@@ -120,26 +109,26 @@ void TSerialClient::DoFlush()
     }
 }
 
-void TSerialClient::WaitForPollAndFlush(steady_clock::time_point now, steady_clock::time_point waitUntil)
+void TSerialClient::WaitForPollAndFlush(steady_clock::time_point currentTime, steady_clock::time_point waitUntil)
 {
-    if (now > waitUntil) {
-        waitUntil = now;
+    if (currentTime > waitUntil) {
+        waitUntil = currentTime;
     }
 
     if (Debug.IsEnabled()) {
-        LOG(Debug) << Port->GetDescription() << duration_cast<milliseconds>(now.time_since_epoch()).count()
+        LOG(Debug) << Port->GetDescription() << duration_cast<milliseconds>(currentTime.time_since_epoch()).count()
                    << ": Wait until " << duration_cast<milliseconds>(waitUntil.time_since_epoch()).count();
     }
 
     // Limit waiting time to be responsive
-    waitUntil = std::min(waitUntil, now + MAX_POLL_TIME);
+    waitUntil = std::min(waitUntil, currentTime + MAX_POLL_TIME);
     while (FlushNeeded->Wait(waitUntil)) {
         if (FlushNeeded->GetSignalValue(RegisterUpdateSignal)) {
             DoFlush();
         }
         if (FlushNeeded->GetSignalValue(RPCSignal)) {
             // End session with current device to make bus clean for RPC
-            LastAccessedDevice.PrepareToAccess(nullptr);
+            LastAccessedDevice->PrepareToAccess(nullptr);
             RPCRequestHandler->RPCRequestHandling(Port);
         }
     }
@@ -189,7 +178,7 @@ void TSerialClient::Cycle()
 
 void TSerialClient::ClosedPortCycle()
 {
-    auto wait_until = std::chrono::steady_clock::now() + CLOSED_PORT_CYCLE_TIME;
+    auto wait_until = NowFn() + CLOSED_PORT_CYCLE_TIME;
 
     while (FlushNeeded->Wait(wait_until)) {
         if (FlushNeeded->GetSignalValue(RegisterUpdateSignal)) {
@@ -208,8 +197,7 @@ void TSerialClient::ClosedPortCycle()
         }
     }
 
-    EventsReader.SetReadErrors([this](PRegister reg) { ProcessPolledRegister(reg); });
-    RegisterPoller.ClosedPortCycle(wait_until);
+    RegHandler->ClosedPortCycle(wait_until, [this](PRegister reg) { ProcessPolledRegister(reg); });
 }
 
 void TSerialClient::SetTextValue(PRegister reg, const std::string& value)
@@ -221,13 +209,11 @@ void TSerialClient::SetTextValue(PRegister reg, const std::string& value)
 void TSerialClient::SetReadCallback(const TSerialClient::TCallback& callback)
 {
     ReadCallback = callback;
-    RegisterPoller.SetReadCallback(callback);
 }
 
 void TSerialClient::SetErrorCallback(const TSerialClient::TCallback& callback)
 {
     ErrorCallback = callback;
-    RegisterPoller.SetErrorCallback(callback);
 }
 
 PRegisterHandler TSerialClient::GetHandler(PRegister reg) const
@@ -236,6 +222,65 @@ PRegisterHandler TSerialClient::GetHandler(PRegister reg) const
     if (it == Handlers.end())
         throw TSerialDeviceException("register not found");
     return it->second;
+}
+
+void TSerialClient::OpenPortCycle()
+{
+    UpdateFlushNeeded();
+    auto currentTime = NowFn();
+    WaitForPollAndFlush(currentTime, RegHandler->GetDeadline(currentTime));
+
+    auto device = RegHandler->OpenPortCycle(
+        *Port,
+        [this](PRegister reg) { ProcessPolledRegister(reg); },
+        *LastAccessedDevice);
+
+    if (device) {
+        OpenCloseLogic.CloseIfNeeded(Port, device->GetIsDisconnected());
+    }
+}
+
+PPort TSerialClient::GetPort()
+{
+    return Port;
+}
+
+void TSerialClient::RPCTransceive(PRPCRequest request) const
+{
+    RPCRequestHandler->RPCTransceive(request, FlushNeeded, RPCSignal);
+}
+
+TSerialClientRegisterAndEventsReader::TSerialClientRegisterAndEventsReader(const std::list<PRegister>& regList,
+                                                                           std::chrono::milliseconds readEventsPeriod,
+                                                                           util::TGetNowFn nowFn,
+                                                                           size_t lowPriorityRateLimit)
+    : EventsReader(MAX_EVENT_READ_ERRORS),
+      RegisterPoller(lowPriorityRateLimit),
+      TimeBalancer(BALANCING_THRESHOLD, 0),
+      ReadEventsPeriod(readEventsPeriod),
+      SpentTime(nowFn),
+      LastCycleWasTooSmallToPoll(false),
+      NowFn(nowFn)
+{
+    auto currentTime = NowFn();
+    RegisterPoller.SetDeviceDisconnectedCallback(
+        [this](PSerialDevice device) { EventsReader.DeviceDisconnected(device); });
+    RegisterPoller.PrepareRegisterRanges(regList, currentTime);
+    for (const auto& reg: regList) {
+        EventsReader.AddRegister(reg);
+    }
+
+    if (EventsReader.HasRegisters()) {
+        TimeBalancer.AddEntry(TClientTaskType::EVENTS, currentTime, TPriority::High);
+    }
+    TimeBalancer.AddEntry(TClientTaskType::POLLING, currentTime, TPriority::Low);
+}
+
+void TSerialClientRegisterAndEventsReader::ClosedPortCycle(std::chrono::steady_clock::time_point currentTime,
+                                                           TCallback regCallback)
+{
+    EventsReader.SetReadErrors(regCallback);
+    RegisterPoller.ClosedPortCycle(currentTime, regCallback);
 }
 
 class TSerialClientTaskHandler
@@ -256,71 +301,73 @@ public:
     }
 };
 
-void TSerialClient::OpenPortCycle()
+PSerialDevice TSerialClientRegisterAndEventsReader::OpenPortCycle(TPort& port,
+                                                                  TCallback regCallback,
+                                                                  TSerialClientDeviceAccessHandler& lastAccessedDevice)
 {
-    UpdateFlushNeeded();
-    auto now = steady_clock::now();
-    WaitForPollAndFlush(now, TimeBalancer.GetDeadline(now));
-
     // Count idle time as high priority task time to faster reach time balancing threshold
     if (LastCycleWasTooSmallToPoll) {
-        TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpendTime.GetSpendTime()), TPriority::High);
+        TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpentTime.GetSpentTime()), TPriority::High);
     }
 
-    SpendTime.Start();
+    SpentTime.Start();
     TSerialClientTaskHandler handler;
-    TimeBalancer.AccumulateNext(SpendTime.GetStartTime(), handler);
+    TimeBalancer.AccumulateNext(SpentTime.GetStartTime(), handler);
     if (handler.NotReady) {
-        return;
+        return nullptr;
     }
 
     if (handler.TaskType == TClientTaskType::EVENTS) {
         if (EventsReader.HasDevicesWithEnabledEvents()) {
-            LastAccessedDevice.PrepareToAccess(nullptr);
+            lastAccessedDevice.PrepareToAccess(nullptr);
             EventsReader.ReadEvents(
-                *Port,
+                port,
                 MAX_POLL_TIME,
-                [this](PRegister reg) { ProcessPolledRegister(reg); },
+                regCallback,
                 [this](PSerialDevice device) {
                     device->SetDisconnected();
-                    RegisterPoller.DeviceDisconnected(device);
-                });
-            TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpendTime.GetSpendTime()), TPriority::High);
+                    RegisterPoller.DeviceDisconnected(device, NowFn());
+                },
+                NowFn);
+            TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpentTime.GetSpentTime()), TPriority::High);
         }
-        TimeBalancer.AddEntry(TClientTaskType::EVENTS, SpendTime.GetStartTime() + ReadEventsPeriod, TPriority::High);
-    } else {
-        // Some registers can have theoretical read time more than poll limit.
-        // Define special cases when reading can exceed poll limit to read the registers:
-        // 1. TimeBalancer can force reading of such registers.
-        // 2. If there are not devices with enabled events, the only limiting timeout is MAX_POLL_TIME.
-        //    We can miss it and read at least one register.
-        const bool readAtLeastOneRegister =
-            (handler.Policy == TItemAccumulationPolicy::Force) || !EventsReader.HasDevicesWithEnabledEvents();
-        auto res = RegisterPoller.OpenPortCycle(*Port,
-                                                SpendTime.GetStartTime(),
-                                                std::min(handler.PollLimit, MAX_POLL_TIME),
-                                                readAtLeastOneRegister,
-                                                LastAccessedDevice);
-        TimeBalancer.AddEntry(TClientTaskType::POLLING, res.Deadline, TPriority::Low);
-        if (res.NotEnoughTime) {
-            LastCycleWasTooSmallToPoll = true;
-        } else {
-            LastCycleWasTooSmallToPoll = false;
-            TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpendTime.GetSpendTime()), TPriority::Low);
-        }
-        if (res.Device) {
-            OpenCloseLogic.CloseIfNeeded(Port, res.Device->GetIsDisconnected());
-        }
+        TimeBalancer.AddEntry(TClientTaskType::EVENTS, SpentTime.GetStartTime() + ReadEventsPeriod, TPriority::High);
+        SpentTime.Start();
+        return nullptr;
     }
-    SpendTime.Start();
+
+    // Some registers can have theoretical read time more than poll limit.
+    // Define special cases when reading can exceed poll limit to read the registers:
+    // 1. TimeBalancer can force reading of such registers.
+    // 2. If there are not devices with enabled events, the only limiting timeout is MAX_POLL_TIME.
+    //    We can miss it and read at least one register.
+    const bool readAtLeastOneRegister =
+        (handler.Policy == TItemAccumulationPolicy::Force) || !EventsReader.HasDevicesWithEnabledEvents();
+
+    auto res = RegisterPoller.OpenPortCycle(port,
+                                            SpentTime,
+                                            std::min(handler.PollLimit, MAX_POLL_TIME),
+                                            readAtLeastOneRegister,
+                                            lastAccessedDevice,
+                                            regCallback);
+    TimeBalancer.AddEntry(TClientTaskType::POLLING, res.Deadline, TPriority::Low);
+    if (res.NotEnoughTime) {
+        LastCycleWasTooSmallToPoll = true;
+    } else {
+        LastCycleWasTooSmallToPoll = false;
+        TimeBalancer.UpdateSelectionTime(ceil<milliseconds>(SpentTime.GetSpentTime()), TPriority::Low);
+    }
+    SpentTime.Start();
+    return res.Device;
 }
 
-PPort TSerialClient::GetPort()
+std::chrono::steady_clock::time_point TSerialClientRegisterAndEventsReader::GetDeadline(
+    std::chrono::steady_clock::time_point currentTime) const
 {
-    return Port;
+    return TimeBalancer.GetDeadline(currentTime);
 }
 
-void TSerialClient::RPCTransceive(PRPCRequest request) const
+TSerialClientEventsReader& TSerialClientRegisterAndEventsReader::GetEventsReader()
 {
-    RPCRequestHandler->RPCTransceive(request, FlushNeeded, RPCSignal);
+    return EventsReader;
 }

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -274,8 +274,6 @@ void TSerialClient::OpenPortCycle()
         return;
     }
 
-    std::cout << TimeBalancer.GetTotalTime().count() << std::endl;
-
     if (handler.TaskType == TClientTaskType::EVENTS) {
         if (EventsReader.HasDevicesWithEnabledEvents()) {
             LastAccessedDevice.PrepareToAccess(nullptr);

--- a/src/serial_client.h
+++ b/src/serial_client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binary_semaphore.h"
+#include "common_utils.h"
 #include "log.h"
 #include "modbus_ext_common.h"
 #include "poll_plan.h"
@@ -76,6 +77,9 @@ private:
     TSerialClientDeviceAccessHandler LastAccessedDevice;
     TScheduler<TClientTaskType> TimeBalancer;
     std::chrono::milliseconds ReadEventsPeriod;
+
+    util::TSpendTimeMeter SpendTime;
+    bool LastCycleWasTooSmallToPoll;
 };
 
 typedef std::shared_ptr<TSerialClient> PSerialClient;

--- a/src/serial_client.h
+++ b/src/serial_client.h
@@ -18,6 +18,12 @@
 class TSerialDevice;
 typedef std::shared_ptr<TSerialDevice> PSerialDevice;
 
+enum TClientTaskType
+{
+    POLLING,
+    EVENTS
+};
+
 class TSerialClientRegisterAndEventsReader: public util::TNonCopyable
 {
 public:
@@ -46,12 +52,6 @@ private:
     util::TSpentTimeMeter SpentTime;
     bool LastCycleWasTooSmallToPoll;
     util::TGetNowFn NowFn;
-};
-
-enum TClientTaskType
-{
-    POLLING,
-    EVENTS
 };
 
 class TSerialClient: public std::enable_shared_from_this<TSerialClient>, util::TNonCopyable
@@ -100,7 +100,7 @@ private:
     PRPCRequestHandler RPCRequestHandler;
 
     std::unique_ptr<TSerialClientDeviceAccessHandler> LastAccessedDevice;
-    std::unique_ptr<TSerialClientRegisterAndEventsReader> RegHandler;
+    std::unique_ptr<TSerialClientRegisterAndEventsReader> RegReader;
 
     util::TGetNowFn NowFn;
 

--- a/src/serial_client_events_reader.cpp
+++ b/src/serial_client_events_reader.cpp
@@ -210,14 +210,11 @@ TSerialClientEventsReader::TSerialClientEventsReader(size_t maxReadErrors)
       ClearErrorsOnSuccessfulRead(false)
 {}
 
-bool TSerialClientEventsReader::ReadEvents(TPort& port,
+void TSerialClientEventsReader::ReadEvents(TPort& port,
                                            milliseconds maxReadingTime,
                                            TRegisterCallback registerCallback,
                                            TDeviceCallback deviceRestartedHandler)
 {
-    if (DevicesWithEnabledEvents.empty()) {
-        return false;
-    }
     TModbusExtEventsVisitor visitor(Regs, DevicesWithEnabledEvents, registerCallback, deviceRestartedHandler);
     util::TSpendTimeMeter spendTimeMeter;
     spendTimeMeter.Start();
@@ -248,7 +245,6 @@ bool TSerialClientEventsReader::ReadEvents(TPort& port,
         }
     }
     DisableEventsFromRegs(port, visitor.GetRegsToDisable());
-    return true;
 }
 
 void TSerialClientEventsReader::EnableEvents(PSerialDevice device, TPort& port)

--- a/src/serial_client_events_reader.cpp
+++ b/src/serial_client_events_reader.cpp
@@ -358,11 +358,6 @@ void TSerialClientEventsReader::ClearReadErrors(TRegisterCallback callback)
     }
 }
 
-bool TSerialClientEventsReader::HasRegisters() const
-{
-    return !Regs.empty();
-}
-
 bool TSerialClientEventsReader::HasDevicesWithEnabledEvents() const
 {
     return !DevicesWithEnabledEvents.empty();

--- a/src/serial_client_events_reader.h
+++ b/src/serial_client_events_reader.h
@@ -4,6 +4,7 @@
 
 #include <unordered_map>
 
+#include "common_utils.h"
 #include "devices/modbus_device.h"
 #include "modbus_ext_common.h"
 #include "port.h"
@@ -45,7 +46,8 @@ public:
     void ReadEvents(TPort& port,
                     std::chrono::milliseconds maxReadingTime,
                     TRegisterCallback registerCallback,
-                    TDeviceCallback deviceRestartedHandler);
+                    TDeviceCallback deviceRestartedHandler,
+                    util::TGetNowFn nowFn);
 
     void DeviceDisconnected(PSerialDevice device);
     void SetReadErrors(TRegisterCallback callback);

--- a/src/serial_client_events_reader.h
+++ b/src/serial_client_events_reader.h
@@ -42,7 +42,7 @@ public:
 
     void EnableEvents(PSerialDevice device, TPort& port);
 
-    bool ReadEvents(TPort& port,
+    void ReadEvents(TPort& port,
                     std::chrono::milliseconds maxReadingTime,
                     TRegisterCallback registerCallback,
                     TDeviceCallback deviceRestartedHandler);

--- a/src/serial_client_events_reader.h
+++ b/src/serial_client_events_reader.h
@@ -52,7 +52,6 @@ public:
     void DeviceDisconnected(PSerialDevice device);
     void SetReadErrors(TRegisterCallback callback);
 
-    bool HasRegisters() const;
     bool HasDevicesWithEnabledEvents() const;
 
 private:

--- a/src/serial_client_register_poller.cpp
+++ b/src/serial_client_register_poller.cpp
@@ -40,7 +40,10 @@ namespace
                 return false;
             }
             if (ReadAtLeastOneRegister) {
-                return RegisterRange->Add(reg, milliseconds::max());
+                if (policy == TItemAccumulationPolicy::Force) {
+                    return RegisterRange->Add(reg, milliseconds::max());
+                }
+                return RegisterRange->Add(reg, pollLimit);
             }
             if (policy == TItemAccumulationPolicy::Force) {
                 return RegisterRange->Add(reg, MaxPollTime);
@@ -98,27 +101,6 @@ void TSerialClientRegisterPoller::PrepareRegisterRanges(const std::list<PRegiste
     }
 }
 
-void TSerialClientRegisterPoller::SetReadError(PRegister reg)
-{
-    reg->SetError(TRegister::TError::ReadError);
-    if (ErrorCallback) {
-        ErrorCallback(reg);
-    }
-}
-
-void TSerialClientRegisterPoller::ProcessPolledRegister(PRegister reg)
-{
-    if (reg->GetErrorState().test(TRegister::ReadError) || reg->GetErrorState().test(TRegister::WriteError)) {
-        if (ErrorCallback) {
-            ErrorCallback(reg);
-        }
-    } else {
-        if (ReadCallback) {
-            ReadCallback(reg);
-        }
-    }
-}
-
 void TSerialClientRegisterPoller::ScheduleNextPoll(PRegister reg, steady_clock::time_point pollStartTime)
 {
     if (reg->IsExcludedFromPolling()) {
@@ -137,7 +119,7 @@ void TSerialClientRegisterPoller::ScheduleNextPoll(PRegister reg, steady_clock::
     Scheduler.AddEntry(reg, pollStartTime + 1us, TPriority::Low);
 }
 
-void TSerialClientRegisterPoller::ClosedPortCycle(steady_clock::time_point currentTime)
+void TSerialClientRegisterPoller::ClosedPortCycle(steady_clock::time_point currentTime, TRegisterCallback callback)
 {
     Scheduler.ResetLoadBalancing();
 
@@ -146,34 +128,28 @@ void TSerialClientRegisterPoller::ClosedPortCycle(steady_clock::time_point curre
         reader.ClearRegisters();
         Scheduler.AccumulateNext(currentTime, reader);
         for (auto& reg: reader.GetRegisters()) {
-            SetReadError(reg);
+            reg->SetError(TRegister::TError::ReadError);
+            if (callback) {
+                callback(reg);
+            }
             ScheduleNextPoll(reg, currentTime);
             reg->Device()->SetTransferResult(false);
         }
     } while (!reader.GetRegisters().empty());
 }
 
-void TSerialClientRegisterPoller::SetReadCallback(TRegisterCallback callback)
-{
-    ReadCallback = std::move(callback);
-}
-
-void TSerialClientRegisterPoller::SetErrorCallback(TRegisterCallback callback)
-{
-    ErrorCallback = std::move(callback);
-}
-
 TPollResult TSerialClientRegisterPoller::OpenPortCycle(TPort& port,
-                                                       std::chrono::steady_clock::time_point currentTime,
+                                                       const util::TSpentTimeMeter& spentTime,
                                                        std::chrono::milliseconds maxPollingTime,
                                                        bool readAtLeastOneRegister,
-                                                       TSerialClientDeviceAccessHandler& lastAccessedDevice)
+                                                       TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                                       TRegisterCallback callback)
 {
     TPollResult res;
 
     TRegisterReader reader(maxPollingTime, readAtLeastOneRegister);
 
-    auto throttlingState = Scheduler.AccumulateNext(currentTime, reader);
+    auto throttlingState = Scheduler.AccumulateNext(spentTime.GetStartTime(), reader);
     auto throttlingMsg = ThrottlingStateLogger.GetMessage(throttlingState);
     if (!throttlingMsg.empty()) {
         LOG(Warn) << port.GetDescription() << " " << throttlingMsg;
@@ -182,7 +158,8 @@ TPollResult TSerialClientRegisterPoller::OpenPortCycle(TPort& port,
 
     if (!range) {
         // Nothing to read
-        res.Deadline = Scheduler.IsEmpty() ? currentTime + 1s : Scheduler.GetDeadline(currentTime);
+        res.Deadline =
+            Scheduler.IsEmpty() ? spentTime.GetStartTime() + 1s : Scheduler.GetDeadline(spentTime.GetStartTime());
         return res;
     }
 
@@ -191,46 +168,50 @@ TPollResult TSerialClientRegisterPoller::OpenPortCycle(TPort& port,
         res.NotEnoughTime = true;
         if (reader.GetPriority() == TPriority::High) {
             // High priority registers are limited by maxPollingTime
-            res.Deadline = currentTime + maxPollingTime;
+            res.Deadline = spentTime.GetStartTime() + maxPollingTime;
         } else {
             // Low priority registers are limited by high priority and maxPollingTime
-            res.Deadline = std::min(Scheduler.GetHighPriorityDeadline(), currentTime + maxPollingTime);
+            res.Deadline = std::min(Scheduler.GetHighPriorityDeadline(), spentTime.GetStartTime() + maxPollingTime);
         }
         return res;
     }
 
     auto device = range->RegisterList().front()->Device();
     bool deviceWasConnected = !device->GetIsDisconnected();
+
+    bool readOk = false;
     if (lastAccessedDevice.PrepareToAccess(device)) {
         device->ReadRegisterRange(range);
-        for (auto& reg: range->RegisterList()) {
-            reg->SetLastPollTime(currentTime);
-            ProcessPolledRegister(reg);
-            ScheduleNextPoll(reg, currentTime);
+        readOk = true;
+    }
+
+    for (auto& reg: range->RegisterList()) {
+        reg->SetLastPollTime(spentTime.GetStartTime());
+        if (!readOk) {
+            reg->SetError(TRegister::TError::ReadError);
         }
-    } else {
-        for (auto& reg: range->RegisterList()) {
-            reg->SetLastPollTime(currentTime);
-            ScheduleNextPoll(reg, currentTime);
-            SetReadError(reg);
+        if (callback) {
+            callback(reg);
         }
+        ScheduleNextPoll(reg, spentTime.GetStartTime());
     }
 
     if (deviceWasConnected && device->GetIsDisconnected()) {
-        DeviceDisconnected(device);
+        DeviceDisconnected(device, spentTime.GetStartTime());
         if (DeviceDisconnectedCallback) {
             DeviceDisconnectedCallback(device);
         }
     }
 
-    Scheduler.UpdateSelectionTime(ceil<milliseconds>(steady_clock::now() - currentTime), reader.GetPriority());
-    res.Deadline = Scheduler.IsEmpty() ? currentTime + 1s : Scheduler.GetDeadline(currentTime);
+    Scheduler.UpdateSelectionTime(ceil<milliseconds>(spentTime.GetSpentTime()), reader.GetPriority());
+    res.Deadline =
+        Scheduler.IsEmpty() ? spentTime.GetStartTime() + 1s : Scheduler.GetDeadline(spentTime.GetStartTime());
     return res;
 }
 
-void TSerialClientRegisterPoller::DeviceDisconnected(PSerialDevice device)
+void TSerialClientRegisterPoller::DeviceDisconnected(PSerialDevice device,
+                                                     std::chrono::steady_clock::time_point currentTime)
 {
-    auto currentTime = std::chrono::steady_clock::now();
     for (auto& reg: RegList) {
         if (reg->Device() == device) {
             bool wasExcludedFromPolling = reg->IsExcludedFromPolling();

--- a/src/serial_client_register_poller.h
+++ b/src/serial_client_register_poller.h
@@ -39,27 +39,21 @@ public:
     TSerialClientRegisterPoller(size_t lowPriorityRateLimit = std::numeric_limits<size_t>::max());
 
     void PrepareRegisterRanges(const std::list<PRegister>& regList, std::chrono::steady_clock::time_point currentTime);
-    void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime);
+    void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime, TRegisterCallback callback);
     TPollResult OpenPortCycle(TPort& port,
-                              std::chrono::steady_clock::time_point currentTime,
+                              const util::TSpentTimeMeter& spentTime,
                               std::chrono::milliseconds maxPollingTime,
                               bool readAtLeastOneRegister,
-                              TSerialClientDeviceAccessHandler& lastAccessedDevice);
-    void SetReadCallback(TRegisterCallback callback);
-    void SetErrorCallback(TRegisterCallback callback);
+                              TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                              TRegisterCallback callback);
     void SetDeviceDisconnectedCallback(TDeviceCallback callback);
-    void DeviceDisconnected(PSerialDevice device);
+    void DeviceDisconnected(PSerialDevice device, std::chrono::steady_clock::time_point currentTime);
 
 private:
-    void ProcessPolledRegister(PRegister reg);
-    void SetReadError(PRegister reg);
     void ScheduleNextPoll(PRegister reg, std::chrono::steady_clock::time_point pollStartTime);
-    void SetDeadline(std::chrono::steady_clock::time_point deadline);
 
     std::list<PRegister> RegList;
 
-    TRegisterCallback ReadCallback;
-    TRegisterCallback ErrorCallback;
     TDeviceCallback DeviceDisconnectedCallback;
 
     TScheduler<PRegister, TRegisterComparePredicate> Scheduler;

--- a/src/serial_client_register_poller.h
+++ b/src/serial_client_register_poller.h
@@ -23,6 +23,13 @@ public:
     std::string GetMessage(TThrottlingState state);
 };
 
+struct TPollResult
+{
+    PSerialDevice Device;
+    bool NotEnoughTime = false;
+    std::chrono::steady_clock::time_point Deadline;
+};
+
 class TSerialClientRegisterPoller
 {
 public:
@@ -33,17 +40,15 @@ public:
 
     void PrepareRegisterRanges(const std::list<PRegister>& regList, std::chrono::steady_clock::time_point currentTime);
     void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime);
-    PSerialDevice OpenPortCycle(TPort& port,
-                                std::chrono::steady_clock::time_point currentTime,
-                                std::chrono::milliseconds maxPollingTime,
-                                bool readAtLeastOneRegister,
-                                TSerialClientDeviceAccessHandler& lastAccessedDevice);
+    TPollResult OpenPortCycle(TPort& port,
+                              std::chrono::steady_clock::time_point currentTime,
+                              std::chrono::milliseconds maxPollingTime,
+                              bool readAtLeastOneRegister,
+                              TSerialClientDeviceAccessHandler& lastAccessedDevice);
     void SetReadCallback(TRegisterCallback callback);
     void SetErrorCallback(TRegisterCallback callback);
     void SetDeviceDisconnectedCallback(TDeviceCallback callback);
     void DeviceDisconnected(PSerialDevice device);
-
-    std::chrono::steady_clock::time_point GetDeadline() const;
 
 private:
     void ProcessPolledRegister(PRegister reg);
@@ -60,6 +65,4 @@ private:
     TScheduler<PRegister, TRegisterComparePredicate> Scheduler;
 
     TThrottlingStateLogger ThrottlingStateLogger;
-
-    std::chrono::steady_clock::time_point Deadline;
 };

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -25,8 +25,10 @@ TSerialPortDriver::TSerialPortDriver(WBMQTT::PDeviceDriver mqttDriver,
       PublishPolicy(publishPolicy)
 {
     Description = Config->Port->GetDescription(false);
-    SerialClient = PSerialClient(
-        new TSerialClient(Config->Devices, Config->Port, Config->OpenCloseSettings, lowPriorityRateLimit));
+    SerialClient = PSerialClient(new TSerialClient(Config->Port,
+                                                   Config->OpenCloseSettings,
+                                                   std::chrono::steady_clock::now,
+                                                   lowPriorityRateLimit));
 }
 
 const std::string& TSerialPortDriver::GetShortDescription() const

--- a/test/TPollTest.SingleDeviceEnableEventsError.dat
+++ b/test/TPollTest.SingleDeviceEnableEventsError.dat
@@ -1,0 +1,102 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 14 02 01 00 2D A5
+11000: <modbus:1:(type 0): 1>
+11000: Cycle end
+
+11000: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 00 00 2F 65
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+42000: <modbus:1:(type 0): 1>
+42000: Cycle end
+
+42000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+62000: <modbus:1:(type 0): 1>
+62000: Cycle end
+
+62000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+82000: <modbus:1:(type 0): 1>
+82000: Cycle end
+
+82000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+102000: <modbus:1:(type 0): 1>
+102000: Cycle end
+
+102000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+122000: <modbus:1:(type 0): 1>
+122000: Cycle end
+
+122000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+142000: <modbus:1:(type 0): 1>
+142000: Cycle end
+
+142000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+162000: <modbus:1:(type 0): 1>
+162000: Cycle end
+
+162000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+182000: <modbus:1:(type 0): 1>
+182000: Cycle end
+
+182000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+202000: <modbus:1:(type 0): 1>
+202000: Cycle end
+
+202000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+222000: <modbus:1:(type 0): 1>
+222000: Cycle end
+
+222000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+242000: <modbus:1:(type 0): 1>
+242000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceEventsAndBigReadTime.dat
+++ b/test/TPollTest.SingleDeviceEventsAndBigReadTime.dat
@@ -1,0 +1,252 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+121000: <modbus:1:(type 0): 1>
+121000: Cycle end
+
+121000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+125670: Cycle end
+
+125670: Cycle
+171000: Cycle end
+
+171000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+175670: Cycle end
+
+175670: Cycle
+221000: Cycle end
+
+221000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+225670: Cycle end
+
+225670: Cycle
+271000: Cycle end
+
+271000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+275670: Cycle end
+
+275670: Cycle
+321000: Cycle end
+
+321000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+325670: Cycle end
+
+325670: Cycle
+371000: Cycle end
+
+371000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+375670: Cycle end
+
+375670: Cycle
+421000: Cycle end
+
+421000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+425670: Cycle end
+
+425670: Cycle
+471000: Cycle end
+
+471000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+475670: Cycle end
+
+475670: Cycle
+521000: Cycle end
+
+521000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+525670: Cycle end
+
+525670: Cycle
+571000: Cycle end
+
+571000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+575670: Cycle end
+
+575670: Cycle
+621000: Cycle end
+
+621000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+625670: Cycle end
+
+625670: Cycle
+671000: Cycle end
+
+671000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+675670: Cycle end
+
+675670: Cycle
+721000: Cycle end
+
+721000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+725670: Cycle end
+
+725670: Cycle
+771000: Cycle end
+
+771000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+775670: Cycle end
+
+775670: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+886670: <modbus:1:(type 0): 2>
+886670: Cycle end
+
+886670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+891340: Cycle end
+
+891340: Cycle
+936670: Cycle end
+
+936670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+941340: Cycle end
+
+941340: Cycle
+986670: Cycle end
+
+986670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+991340: Cycle end
+
+991340: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+1102340: <modbus:1:(type 0): 2>
+1102340: Cycle end
+
+1102340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1107010: Cycle end
+
+1107010: Cycle
+1152340: Cycle end
+
+1152340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1157010: Cycle end
+
+1157010: Cycle
+1202340: Cycle end
+
+1202340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1207010: Cycle end
+
+1207010: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+1318010: <modbus:1:(type 0): 2>
+1318010: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSeveralRegisters.dat
+++ b/test/TPollTest.SingleDeviceSeveralRegisters.dat
@@ -1,0 +1,193 @@
+Open()
+0: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+21000: <modbus:1:(type 0): 2>
+21000: Cycle end
+
+21000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+41000: <modbus:1:(type 0): 1>
+41000: Cycle end
+
+41000: Cycle
+50000: Cycle end
+
+50000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+70000: <modbus:1:(type 0): 2>
+70000: Cycle end
+
+70000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+90000: <modbus:1:(type 0): 1>
+90000: Cycle end
+
+90000: Cycle
+100000: Cycle end
+
+100000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+120000: <modbus:1:(type 0): 2>
+120000: Cycle end
+
+120000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+140000: <modbus:1:(type 0): 1>
+140000: Cycle end
+
+140000: Cycle
+150000: Cycle end
+
+150000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+170000: <modbus:1:(type 0): 2>
+170000: Cycle end
+
+170000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+190000: <modbus:1:(type 0): 1>
+190000: Cycle end
+
+190000: Cycle
+200000: Cycle end
+
+200000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+220000: <modbus:1:(type 0): 2>
+220000: Cycle end
+
+220000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+240000: <modbus:1:(type 0): 1>
+240000: Cycle end
+
+240000: Cycle
+250000: Cycle end
+
+250000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+270000: <modbus:1:(type 0): 2>
+270000: Cycle end
+
+270000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+290000: <modbus:1:(type 0): 1>
+290000: Cycle end
+
+290000: Cycle
+300000: Cycle end
+
+300000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+320000: <modbus:1:(type 0): 2>
+320000: Cycle end
+
+320000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+340000: <modbus:1:(type 0): 1>
+340000: Cycle end
+
+340000: Cycle
+350000: Cycle end
+
+350000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+370000: <modbus:1:(type 0): 2>
+370000: Cycle end
+
+370000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+390000: <modbus:1:(type 0): 1>
+390000: Cycle end
+
+390000: Cycle
+400000: Cycle end
+
+400000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+420000: <modbus:1:(type 0): 2>
+420000: Cycle end
+
+420000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+440000: <modbus:1:(type 0): 1>
+440000: Cycle end
+
+440000: Cycle
+450000: Cycle end
+
+450000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+470000: <modbus:1:(type 0): 2>
+470000: Cycle end
+
+470000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+490000: <modbus:1:(type 0): 1>
+490000: Cycle end
+
+490000: Cycle
+500000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegister.dat
+++ b/test/TPollTest.SingleDeviceSingleRegister.dat
@@ -1,0 +1,73 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+31000: Cycle end
+
+31000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+61000: <modbus:1:(type 0): 1>
+61000: Cycle end
+
+61000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+91000: <modbus:1:(type 0): 1>
+91000: Cycle end
+
+91000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+121000: <modbus:1:(type 0): 1>
+121000: Cycle end
+
+121000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+151000: <modbus:1:(type 0): 1>
+151000: Cycle end
+
+151000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+181000: <modbus:1:(type 0): 1>
+181000: Cycle end
+
+181000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+211000: <modbus:1:(type 0): 1>
+211000: Cycle end
+
+211000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+241000: <modbus:1:(type 0): 1>
+241000: Cycle end
+
+241000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+271000: <modbus:1:(type 0): 1>
+271000: Cycle end
+
+271000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+301000: <modbus:1:(type 0): 1>
+301000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithBigReadTime.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithBigReadTime.dat
@@ -1,0 +1,83 @@
+Open()
+0: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+131000: <modbus:1:(type 0): 1>
+131000: Cycle end
+
+131000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+261000: <modbus:1:(type 0): 1>
+261000: Cycle end
+
+261000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+391000: <modbus:1:(type 0): 1>
+391000: Cycle end
+
+391000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+521000: <modbus:1:(type 0): 1>
+521000: Cycle end
+
+521000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+651000: <modbus:1:(type 0): 1>
+651000: Cycle end
+
+651000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+781000: <modbus:1:(type 0): 1>
+781000: Cycle end
+
+781000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+911000: <modbus:1:(type 0): 1>
+911000: Cycle end
+
+911000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1041000: <modbus:1:(type 0): 1>
+1041000: Cycle end
+
+1041000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1171000: <modbus:1:(type 0): 1>
+1171000: Cycle end
+
+1171000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1301000: <modbus:1:(type 0): 1>
+1301000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEvents.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEvents.dat
@@ -1,0 +1,94 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+50000: Cycle end
+
+50000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+100000: Cycle end
+
+100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+150000: Cycle end
+
+150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+200000: Cycle end
+
+200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+250000: Cycle end
+
+250000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+300000: Cycle end
+
+300000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+350000: Cycle end
+
+350000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+400000: Cycle end
+
+400000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+450000: Cycle end
+
+450000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+500000: Cycle end
+
+500000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+550000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndErrors.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndErrors.dat
@@ -1,0 +1,108 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+50000: Cycle end
+
+50000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+100000: Cycle end
+
+100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+150000: Cycle end
+
+150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+200000: Cycle end
+
+200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+317680: Cycle end
+
+317680: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+435360: Cycle end
+
+435360: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+527370: <modbus:1:(type 0): 1>
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+553040: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPolling.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPolling.dat
@@ -1,0 +1,106 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+31000: Cycle end
+
+31000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+51000: <modbus:1:(type 0): 2>
+51000: Cycle end
+
+51000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+55670: Cycle end
+
+55670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+76670: <modbus:1:(type 0): 2>
+76670: Cycle end
+
+76670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+96670: <modbus:1:(type 0): 2>
+96670: Cycle end
+
+96670: Cycle
+101000: Cycle end
+
+101000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+105670: Cycle end
+
+105670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+126670: <modbus:1:(type 0): 2>
+126670: Cycle end
+
+126670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+146670: <modbus:1:(type 0): 2>
+146670: Cycle end
+
+146670: Cycle
+151000: Cycle end
+
+151000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+155670: Cycle end
+
+155670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+176670: <modbus:1:(type 0): 2>
+176670: Cycle end
+
+176670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+196670: <modbus:1:(type 0): 2>
+196670: Cycle end
+
+196670: Cycle
+201000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod.dat
@@ -1,0 +1,126 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 2>
+31000: Cycle end
+
+31000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+51000: <modbus:1:(type 0): 1>
+51000: Cycle end
+
+51000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+55670: Cycle end
+
+55670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+76670: <modbus:1:(type 0): 3>
+76670: Cycle end
+
+76670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+96670: <modbus:1:(type 0): 3>
+96670: Cycle end
+
+96670: Cycle
+100000: Cycle end
+
+100000: Cycle
+101000: Cycle end
+
+101000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+105670: Cycle end
+
+105670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+126670: <modbus:1:(type 0): 2>
+126670: Cycle end
+
+126670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+146670: <modbus:1:(type 0): 3>
+146670: Cycle end
+
+146670: Cycle
+151000: Cycle end
+
+151000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+155670: Cycle end
+
+155670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+176670: <modbus:1:(type 0): 3>
+176670: Cycle end
+
+176670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+196670: <modbus:1:(type 0): 3>
+196670: Cycle end
+
+196670: Cycle
+201000: Cycle end
+
+201000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+205670: Cycle end
+
+205670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+226670: <modbus:1:(type 0): 2>
+226670: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithReadPeriod.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithReadPeriod.dat
@@ -1,0 +1,73 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+100000: Cycle end
+
+100000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+130000: <modbus:1:(type 0): 1>
+200000: Cycle end
+
+200000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+230000: <modbus:1:(type 0): 1>
+300000: Cycle end
+
+300000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+330000: <modbus:1:(type 0): 1>
+400000: Cycle end
+
+400000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+430000: <modbus:1:(type 0): 1>
+500000: Cycle end
+
+500000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+530000: <modbus:1:(type 0): 1>
+600000: Cycle end
+
+600000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+630000: <modbus:1:(type 0): 1>
+700000: Cycle end
+
+700000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+730000: <modbus:1:(type 0): 1>
+800000: Cycle end
+
+800000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+830000: <modbus:1:(type 0): 1>
+900000: Cycle end
+
+900000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+930000: <modbus:1:(type 0): 1>
+1000000: Cycle end
+
+Close()

--- a/test/poll_test.cpp
+++ b/test/poll_test.cpp
@@ -1,0 +1,611 @@
+
+#include "fake_serial_port.h"
+#include "log.h"
+#include "modbus_expectations_base.h"
+#include "serial_driver.h"
+
+using namespace std::chrono_literals;
+using namespace std::chrono;
+
+namespace
+{
+    class TTimeMock
+    {
+        steady_clock::time_point Time;
+
+    public:
+        void Reset()
+        {
+            Time = steady_clock::time_point();
+        }
+
+        steady_clock::time_point GetTime() const
+        {
+            return Time;
+        }
+
+        void AddTime(microseconds intervalToAdd)
+        {
+            Time += intervalToAdd;
+        }
+    };
+
+    class TFakeSerialPortWithTime: public TFakeSerialPort
+    {
+        std::deque<microseconds> FrameReadTimes;
+        TTimeMock& TimeMock;
+
+    public:
+        TFakeSerialPortWithTime(WBMQTT::Testing::TLoggedFixture& fixture, TTimeMock& timeMock)
+            : TFakeSerialPort(fixture),
+              TimeMock(timeMock)
+        {}
+
+        void Expect(const std::vector<int>& request,
+                    const std::vector<int>& response,
+                    const char* func,
+                    microseconds frameReadTime)
+        {
+            TFakeSerialPort::Expect(request, response, func);
+            FrameReadTimes.push_back(frameReadTime);
+        }
+
+        size_t ReadFrame(uint8_t* buf,
+                         size_t count,
+                         const microseconds& responseTimeout = -1ms,
+                         const microseconds& frameTimeout = -1ms,
+                         TFrameCompletePred frame_complete = 0) override
+        {
+            if (!FrameReadTimes.empty()) {
+                TimeMock.AddTime(FrameReadTimes.front());
+                FrameReadTimes.pop_front();
+            }
+            return TFakeSerialPort::ReadFrame(buf, count, responseTimeout, frameTimeout, frame_complete);
+        }
+
+        void SleepSinceLastInteraction(const std::chrono::microseconds& us) override
+        {
+            TFakeSerialPort::SleepSinceLastInteraction(us);
+            TimeMock.AddTime(us);
+        }
+    };
+}
+
+class TPollTest: public TLoggedFixture, public TModbusExpectationsBase
+{
+public:
+    void SetUp()
+    {
+        TLoggedFixture::SetUp();
+        TimeMock.Reset();
+        Port = std::make_shared<TFakeSerialPortWithTime>(*this, TimeMock);
+        TModbusDevice::Register(DeviceFactory);
+        Port->Open();
+    }
+
+    void TearDown()
+    {
+        Port->Close();
+        TLoggedFixture::TearDown();
+    }
+
+    void Cycle(TSerialClientRegisterAndEventsReader& serialClient, TSerialClientDeviceAccessHandler& lastAccessedDevice)
+    {
+        Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": Cycle";
+        serialClient.OpenPortCycle(
+            *Port,
+            [this](PRegister reg) {
+                Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": " << reg->ToString();
+            },
+            lastAccessedDevice);
+        auto deadline = serialClient.GetDeadline(TimeMock.GetTime());
+        if (deadline > TimeMock.GetTime()) {
+            TimeMock.AddTime(ceil<microseconds>(deadline - TimeMock.GetTime()));
+        }
+        Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": Cycle end\n";
+    }
+
+    void EnqueueReadHolding(uint8_t slaveId, uint16_t addr, uint16_t count, microseconds readTime)
+    {
+        SetModbusRTUSlaveId(slaveId);
+        std::vector<int> response = {0x03, count * 2};
+        for (auto i = 0; i < count; ++i) {
+            response.push_back((i >> 8) & 0xFF);
+            response.push_back(i & 0xFF);
+        }
+        Port->Expect(WrapPDU({
+                         0x03,                // function code
+                         (addr >> 8) & 0xFF,  // starting address Hi
+                         addr & 0xFF,         // starting address Lo
+                         (count >> 8) & 0xFF, // quantity Hi
+                         count & 0xFF         // quantity Lo
+                     }),
+                     WrapPDU(response),
+                     __func__,
+                     readTime);
+    }
+
+    void EnqueueReadEvents(microseconds readTime, bool error = false, uint8_t responseSize = 0xF8)
+    {
+        SetModbusRTUSlaveId(0xFD);
+        Port->Expect(WrapPDU({
+                         0x46,         // function code
+                         0x10,         // subcommand
+                         0x00,         // staring slaveId
+                         responseSize, // max response size
+                         0x00,         //
+                         0x00          //
+                     }),
+                     WrapPDU({
+                         0x46,               // function code
+                         error ? 0x14 : 0x12 // subcommand, no events
+                     }),
+                     __func__,
+                     readTime);
+    }
+
+    void EnqueueEnableEvents(uint8_t slaveId,
+                             uint16_t addr,
+                             microseconds readTime,
+                             uint8_t res = 0x01,
+                             bool error = false)
+    {
+        SetModbusRTUSlaveId(slaveId);
+        Port->Expect(WrapPDU({
+                         0x46,               // function code
+                         0x18,               // subcommand
+                         0x0A,               // data size
+                         0x03,               // holding
+                         (addr >> 8) & 0xFF, // address Hi
+                         addr & 0xFF,        // address Lo
+                         0x01,               // count
+                         0x01,               // enable
+                         0x0F,               // disable reset event
+                         0x00,               //
+                         0x00,               //
+                         0x01,               //
+                         0x00                //
+                     }),
+                     WrapPDU({
+                         0x46,                // function code
+                         error ? 0x14 : 0x18, // subcommand
+                         0x02,                // data size
+                         res,                 //
+                         0x00                 //
+                     }),
+                     __func__,
+                     readTime);
+    }
+
+    PExpector Expector() const override
+    {
+        return Port;
+    }
+
+    TModbusDeviceConfig MakeDeviceConfig(const std::string& name, const std::string& addr)
+    {
+        TModbusDeviceConfig config;
+        config.CommonConfig = std::make_shared<TDeviceConfig>(name, addr, "modbus");
+        config.CommonConfig->FrameTimeout = 0ms;
+        return config;
+    }
+
+    PDeviceChannelConfig MakeChannelConfig(
+        const std::string& deviceName,
+        uint16_t addr,
+        milliseconds readPeriod = 0ms,
+        TRegisterConfig::TSporadicMode sporadicMode = TRegisterConfig::TSporadicMode::DISABLED)
+    {
+        auto channel = std::make_shared<TDeviceChannelConfig>("value", deviceName);
+        channel->RegisterConfigs.push_back(TRegister::Create(Modbus::REG_HOLDING, addr));
+        if (readPeriod != 0ms) {
+            channel->RegisterConfigs[0]->ReadPeriod = readPeriod;
+        }
+        channel->RegisterConfigs[0]->SporadicMode = sporadicMode;
+        return channel;
+    }
+
+    std::shared_ptr<TModbusDevice> MakeDevice(const TModbusDeviceConfig& config)
+    {
+        return std::make_shared<TModbusDevice>(std::make_unique<Modbus::TModbusRTUTraits>(),
+                                               config,
+                                               Port,
+                                               DeviceFactory.GetProtocol("modbus"));
+    }
+
+    std::list<PRegister> GetRegList(PSerialDevice device)
+    {
+        std::list<PRegister> regList;
+        for (const auto& channelConfig: device->DeviceConfig()->DeviceChannelConfigs) {
+            auto channel = std::make_shared<TDeviceChannel>(device, channelConfig);
+            for (const auto& reg: channel->Registers) {
+                regList.push_back(reg);
+            }
+        }
+        return regList;
+    }
+
+    std::shared_ptr<TFakeSerialPortWithTime> Port;
+    TTimeMock TimeMock;
+    TSerialDeviceFactory DeviceFactory;
+};
+
+TEST_F(TPollTest, SingleDeviceSingleRegister)
+{
+    // One register without fixed read period
+    // Check what poller reads it as soon as possible
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithReadPeriod)
+{
+    // One register with fixed read period
+    // Check what read period is preserved
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 100ms));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSeveralRegisters)
+{
+    // One register with fixed read period and one without it
+    // Check what read period is preserved and poller wait for the first register,
+    // if there are not enough time to read the second register
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2, 50ms));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 1, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEvents)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Only read events
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndPolling)
+{
+    // One register with events and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register without read period must be polled during free time
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Enable events and read first register
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        // Not enough time for polling
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod)
+{
+    // One register with events, one with read period and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register with read period must be polled during free time as much close to read period as possible
+    // 5. Register without read period must be polled during free time
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2, 100ms));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 3));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Enable events and read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before reading register with read period
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before events reading
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register with read period
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before reading register with read period
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before events reading
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register with read period
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+}
+
+TEST_F(TPollTest, SingleDeviceEventsAndBigReadTime)
+{
+    // One register with events, one with read period and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register without read period must be polled after some time of event reads because of time balancing
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 100ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Enable events and read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 13; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+
+        // Calculated read time is too big
+        Cycle(serialClient, lastAccessedDevice);
+    }
+
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
+            EnqueueReadEvents(4ms);
+            Cycle(serialClient, lastAccessedDevice);
+
+            // Calculated read time is too big
+            Cycle(serialClient, lastAccessedDevice);
+        }
+
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+
+        // Read register
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithBigReadTime)
+{
+    // One register without fixed read period but with big read time
+    // Check what poller reads it as soon as possible
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 100ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndErrors)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Some read requests have errors
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Only read events
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(25ms, true, 0x40);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceEnableEventsError)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Some read requests have errors
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read events, but nothing configured
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms, 0x01, true);
+    Cycle(serialClient, lastAccessedDevice);
+
+    EnqueueEnableEvents(1, 1, 10ms, 0x00);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadHolding(1, 1, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -146,12 +146,7 @@ void TSerialClientTest::SetUp()
     config->FrameTimeout = std::chrono::milliseconds(100);
     Device = std::make_shared<TFakeSerialDevice>(config, Port, DeviceFactory.GetProtocol("fake"));
     Device->InitSetupItems();
-    std::vector<PSerialDevice> devices;
-    devices.push_back(Device);
-    SerialClient = std::make_shared<TSerialClient>(devices, Port, PortOpenCloseSettings);
-#if 0
-    SerialClient->SetModbusDebug(true);
-#endif
+    SerialClient = std::make_shared<TSerialClient>(Port, PortOpenCloseSettings, std::chrono::steady_clock::now);
     SerialClient->SetReadCallback([this](PRegister reg) {
         if (reg->GetErrorState().count()) {
             EmitErrorMsg(reg);


### PR DESCRIPTION
* Read at least one register every cycle if there are not devices with enabled events even if read time is bigger than MAX_POLL_TIME
* Fix calculation of total events read time. Unexpected zeroing of total read time lead to stop polling registers with big response-request times

Исправил 2 бага:
1. Когда нет устройств с включенными событиями, периодическое чтение ограничено по времени 100мс. Это нужно для оперативной реакции на команды из mqtt. Ошибка была в том, что регистры с теоретически длинным временем опроса (более 100мс) не запрашивались из-за ограничения по времени. Принудительный опрос не включался, т.к. не было событий, и общее время опроса событий вегда было 0. Принудительный опрос включается, когда общее время опроса событий больше 500мс.
2. Есть устройства с событиями, тогда ограничение опроса по времени на скорости 115200 - 50мс. Ситуация повторяется, регистры с теоретически длинным временем опроса блокируют очередь. Баг был в том, что общее время опроса событий сбрасывалось, и не вызывался принудительный опрос регистров.