### PR TITLE
Disable events on input counters of WB-MCM8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.85.4) stable; urgency=medium
+
+  * Disable events on input counters of WB-MCM8
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 19 May 2023 18:00:26 +0500
+
 wb-mqtt-serial (2.85.3) stable; urgency=medium
 
   * WB-MAP3EV templates: fix wrong group name

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -202,7 +202,6 @@
                 "format": "u32",
                 "address": {{60 + (in_num - 1) * 2}},
                 "type": "value",
-                "sporadic": true,
                 "group": "gg_in{{in_num}}_channels"
             },
             {


### PR DESCRIPTION
Отключил события для счётчиков, т.к. они не включаются, если выбран режим работы 0 (это режим по умолчанию). Адекватного механизма задать это ограничение в wb-mqtt-serial нет. Он будет доступен после вливания https://github.com/wirenboard/wb-mqtt-serial/pull/599