### PR TITLE
Fix stop polling some registers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.86.1) stable; urgency=medium
+
+  * Fix stop polling some registers
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 30 May 2023 12:08:03 +0500
+
 wb-mqtt-serial (2.86.0) stable; urgency=medium
 
   * Add mao4 actions configuration

--- a/src/common_utils.cpp
+++ b/src/common_utils.cpp
@@ -29,17 +29,20 @@ std::string util::ConvertToValidMqttTopicString(const std::string& src)
     return validStr;
 }
 
-void util::TSpendTimeMeter::Start()
+util::TSpentTimeMeter::TSpentTimeMeter(util::TGetNowFn nowFn): NowFn(nowFn)
+{}
+
+void util::TSpentTimeMeter::Start()
 {
-    StartTime = std::chrono::steady_clock::now();
+    StartTime = NowFn();
 }
 
-std::chrono::steady_clock::time_point util::TSpendTimeMeter::GetStartTime() const
+std::chrono::steady_clock::time_point util::TSpentTimeMeter::GetStartTime() const
 {
     return StartTime;
 }
 
-std::chrono::microseconds util::TSpendTimeMeter::GetSpendTime() const
+std::chrono::microseconds util::TSpentTimeMeter::GetSpentTime() const
 {
-    return std::chrono::ceil<std::chrono::microseconds>(std::chrono::steady_clock::now() - StartTime);
+    return std::chrono::ceil<std::chrono::microseconds>(NowFn() - StartTime);
 }

--- a/src/common_utils.h
+++ b/src/common_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <chrono>
+#include <functional>
 #include <string>
 
 namespace util
@@ -14,14 +15,32 @@ namespace util
     /// \return modified string
     std::string ConvertToValidMqttTopicString(const std::string& src);
 
-    class TSpendTimeMeter
+    typedef std::function<std::chrono::steady_clock::time_point()> TGetNowFn;
+
+    class TSpentTimeMeter
     {
         std::chrono::steady_clock::time_point StartTime;
+        TGetNowFn NowFn;
 
     public:
+        TSpentTimeMeter(TGetNowFn nowFn);
+
         void Start();
 
         std::chrono::steady_clock::time_point GetStartTime() const;
-        std::chrono::microseconds GetSpendTime() const;
+        std::chrono::microseconds GetSpentTime() const;
+    };
+
+    /**
+     *  Classes derived from TNonCopyable cannot be copied.
+     *  The idea is taken from boost::noncopyable
+     */
+    class TNonCopyable
+    {
+    protected:
+        TNonCopyable() = default;
+        ~TNonCopyable() = default;
+        TNonCopyable(const TNonCopyable&) = delete;
+        TNonCopyable& operator=(const TNonCopyable&) = delete;
     };
 }

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -287,19 +287,25 @@ namespace ModbusExt // modbus extension protocol declarations
             throw Modbus::TMalformedResponseError("invalid slave id");
         }
 
+        if (Response[SUB_COMMAND_POS] != ENABLE_EVENTS_COMMAND) {
+            throw Modbus::TMalformedResponseError("invalid sub command");
+        }
+
         TBitIterator dataIt(Response.data() + ENABLE_EVENTS_RESPONSE_DATA_POS - 1,
                             Response[ENABLE_EVENTS_RESPONSE_DATA_SIZE_POS]);
 
         TEventType lastType = TEventType::REBOOT;
         uint16_t lastRegAddr = 0;
         uint16_t lastDataAddr = 0;
+        bool firstRegister = true;
 
         for (auto regIt = SettingsStart; regIt != SettingsEnd; ++regIt) {
-            if (lastType != regIt->Type || lastRegAddr + MaxRegDistance < regIt->Addr) {
+            if (firstRegister || (lastType != regIt->Type) || (lastRegAddr + MaxRegDistance < regIt->Addr)) {
                 dataIt.NextByte();
                 lastDataAddr = regIt->Addr;
                 lastType = regIt->Type;
                 Visitor(lastType, lastDataAddr, dataIt.GetBit());
+                firstRegister = false;
             } else {
                 do {
                     dataIt.NextBit();
@@ -348,14 +354,16 @@ namespace ModbusExt // modbus extension protocol declarations
         uint16_t lastAddr = 0;
         auto regIt = SettingsEnd;
         size_t regCountPos;
+        bool firstRegister = true;
         for (; HasSpaceForEnableEventRecord(Request) && regIt != Settings.cend(); ++regIt) {
-            if (lastType != regIt->Type || lastAddr + MaxRegDistance < regIt->Addr) {
+            if (firstRegister || (lastType != regIt->Type) || (lastAddr + MaxRegDistance < regIt->Addr)) {
                 Append(requestBack, static_cast<uint8_t>(regIt->Type));
                 AppendBigEndian(requestBack, regIt->Addr);
                 Append(requestBack, static_cast<uint8_t>(1));
                 regCountPos = Request.size() - 1;
                 Append(requestBack, static_cast<uint8_t>(regIt->Priority));
                 Request[ENABLE_EVENTS_RESPONSE_DATA_SIZE_POS] += MIN_ENABLE_EVENTS_REC_SIZE;
+                firstRegister = false;
             } else {
                 const auto nRegs = static_cast<size_t>(regIt->Addr - lastAddr);
                 Request[regCountPos] += nRegs;

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -87,7 +87,7 @@ namespace ModbusExt // modbus extension protocol declarations
         if (timePerByte.count() == 0) {
             return EVENTS_REQUEST_MAX_BYTES;
         }
-        auto maxBytes = std::chrono::duration_cast<std::chrono::microseconds>(maxTime).count() / timePerByte.count();
+        size_t maxBytes = std::chrono::duration_cast<std::chrono::microseconds>(maxTime).count() / timePerByte.count();
         if (maxBytes > MAX_PACKET_SIZE) {
             maxBytes = MAX_PACKET_SIZE;
         }

--- a/src/poll_plan.h
+++ b/src/poll_plan.h
@@ -180,6 +180,11 @@ public:
     {
         TotalTime = std::chrono::milliseconds::zero();
     }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TotalTime;
+    }
 };
 
 template<class TEntry, class TComparePredicate = std::less<TEntry>> class TScheduler
@@ -189,7 +194,7 @@ public:
     using TItem = typename TQueue::TItem;
 
     TScheduler(std::chrono::milliseconds maxLowPriorityLag, size_t lowPriorityRateLimit)
-        : TimeBalancer(maxLowPriorityLag, 10 * maxLowPriorityLag),
+        : TimeBalancer(maxLowPriorityLag, 2 * maxLowPriorityLag),
           LowPriorityRateLimit(lowPriorityRateLimit)
     {
         ResetLoadBalancing();
@@ -233,10 +238,6 @@ public:
     template<class TAccumulator>
     TThrottlingState AccumulateNext(std::chrono::steady_clock::time_point currentTime, TAccumulator& accumulator)
     {
-        if (!LowPriorityQueue.HasReadyItems(currentTime)) {
-            ResetLoadBalancing();
-        }
-
         if (HighPriorityQueue.HasReadyItems(currentTime) &&
             (!ShouldSelectLowPriority(currentTime) || !LowPriorityQueue.HasReadyItems(currentTime)))
         {
@@ -298,6 +299,11 @@ public:
     bool IsEmpty() const
     {
         return LowPriorityQueue.IsEmpty() && HighPriorityQueue.IsEmpty();
+    }
+
+    std::chrono::milliseconds GetTotalTime() const
+    {
+        return TimeBalancer.GetTotalTime();
     }
 
 private:

--- a/src/port.h
+++ b/src/port.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common_utils.h"
 #include "definitions.h"
 
 #include <chrono>
@@ -94,7 +95,7 @@ public:
         std::chrono::milliseconds ReopenTimeout = std::chrono::milliseconds(5000);
     };
 
-    TPortOpenCloseLogic(const TPortOpenCloseLogic::TSettings& settings);
+    TPortOpenCloseLogic(const TPortOpenCloseLogic::TSettings& settings, util::TGetNowFn nowFn);
 
     void OpenIfAllowed(PPort port);
     void CloseIfNeeded(PPort port, bool allPreviousDataExchangeWasFailed);
@@ -104,4 +105,5 @@ private:
     std::chrono::steady_clock::time_point LastSuccessfulCycle;
     size_t RemainingFailCycles;
     std::chrono::steady_clock::time_point NextOpenTryTime;
+    util::TGetNowFn NowFn;
 };

--- a/src/serial_client.h
+++ b/src/serial_client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binary_semaphore.h"
+#include "common_utils.h"
 #include "log.h"
 #include "modbus_ext_common.h"
 #include "poll_plan.h"
@@ -23,17 +24,45 @@ enum TClientTaskType
     EVENTS
 };
 
-class TSerialClient: public std::enable_shared_from_this<TSerialClient>
+class TSerialClientRegisterAndEventsReader: public util::TNonCopyable
 {
 public:
     typedef std::function<void(PRegister reg)> TCallback;
 
-    TSerialClient(const std::vector<PSerialDevice>& devices,
-                  PPort port,
+    TSerialClientRegisterAndEventsReader(const std::list<PRegister>& regList,
+                                         std::chrono::milliseconds readEventsPeriod,
+                                         util::TGetNowFn nowFn,
+                                         size_t lowPriorityRateLimit = std::numeric_limits<size_t>::max());
+
+    void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime, TCallback regCallback);
+    PSerialDevice OpenPortCycle(TPort& port,
+                                TCallback regCallback,
+                                TSerialClientDeviceAccessHandler& lastAccessedDevice);
+
+    std::chrono::steady_clock::time_point GetDeadline(std::chrono::steady_clock::time_point currentTime) const;
+
+    TSerialClientEventsReader& GetEventsReader();
+
+private:
+    TSerialClientEventsReader EventsReader;
+    TSerialClientRegisterPoller RegisterPoller;
+    TScheduler<TClientTaskType> TimeBalancer;
+    std::chrono::milliseconds ReadEventsPeriod;
+
+    util::TSpentTimeMeter SpentTime;
+    bool LastCycleWasTooSmallToPoll;
+    util::TGetNowFn NowFn;
+};
+
+class TSerialClient: public std::enable_shared_from_this<TSerialClient>, util::TNonCopyable
+{
+public:
+    typedef std::function<void(PRegister reg)> TCallback;
+
+    TSerialClient(PPort port,
                   const TPortOpenCloseLogic::TSettings& openCloseSettings,
+                  util::TGetNowFn nowFn,
                   size_t lowPriorityRateLimit = std::numeric_limits<size_t>::max());
-    TSerialClient(const TSerialClient& client) = delete;
-    TSerialClient& operator=(const TSerialClient&) = delete;
     ~TSerialClient();
 
     void AddRegister(PRegister reg);
@@ -43,7 +72,6 @@ public:
     void SetErrorCallback(const TCallback& callback);
     PPort GetPort();
     void RPCTransceive(PRPCRequest request) const;
-    void ProcessPolledRegister(PRegister reg);
 
 private:
     void Activate();
@@ -55,12 +83,12 @@ private:
     void ClosedPortCycle();
     void OpenPortCycle();
     void UpdateFlushNeeded();
+    void ProcessPolledRegister(PRegister reg);
 
     PPort Port;
     std::list<PRegister> RegList;
     std::unordered_map<PRegister, PRegisterHandler> Handlers;
 
-    bool Active;
     TCallback ReadCallback;
     TCallback ErrorCallback;
     PBinarySemaphore FlushNeeded;
@@ -71,11 +99,12 @@ private:
 
     PRPCRequestHandler RPCRequestHandler;
 
-    TSerialClientEventsReader EventsReader;
-    TSerialClientRegisterPoller RegisterPoller;
-    TSerialClientDeviceAccessHandler LastAccessedDevice;
-    TScheduler<TClientTaskType> TimeBalancer;
-    std::chrono::milliseconds ReadEventsPeriod;
+    std::unique_ptr<TSerialClientDeviceAccessHandler> LastAccessedDevice;
+    std::unique_ptr<TSerialClientRegisterAndEventsReader> RegReader;
+
+    util::TGetNowFn NowFn;
+
+    size_t LowPriorityRateLimit;
 };
 
 typedef std::shared_ptr<TSerialClient> PSerialClient;

--- a/src/serial_client_events_reader.h
+++ b/src/serial_client_events_reader.h
@@ -4,6 +4,7 @@
 
 #include <unordered_map>
 
+#include "common_utils.h"
 #include "devices/modbus_device.h"
 #include "modbus_ext_common.h"
 #include "port.h"
@@ -42,15 +43,15 @@ public:
 
     void EnableEvents(PSerialDevice device, TPort& port);
 
-    bool ReadEvents(TPort& port,
+    void ReadEvents(TPort& port,
                     std::chrono::milliseconds maxReadingTime,
                     TRegisterCallback registerCallback,
-                    TDeviceCallback deviceRestartedHandler);
+                    TDeviceCallback deviceRestartedHandler,
+                    util::TGetNowFn nowFn);
 
     void DeviceDisconnected(PSerialDevice device);
     void SetReadErrors(TRegisterCallback callback);
 
-    bool HasRegisters() const;
     bool HasDevicesWithEnabledEvents() const;
 
 private:

--- a/src/serial_client_register_poller.h
+++ b/src/serial_client_register_poller.h
@@ -23,6 +23,13 @@ public:
     std::string GetMessage(TThrottlingState state);
 };
 
+struct TPollResult
+{
+    PSerialDevice Device;
+    bool NotEnoughTime = false;
+    std::chrono::steady_clock::time_point Deadline;
+};
+
 class TSerialClientRegisterPoller
 {
 public:
@@ -32,34 +39,24 @@ public:
     TSerialClientRegisterPoller(size_t lowPriorityRateLimit = std::numeric_limits<size_t>::max());
 
     void PrepareRegisterRanges(const std::list<PRegister>& regList, std::chrono::steady_clock::time_point currentTime);
-    void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime);
-    PSerialDevice OpenPortCycle(TPort& port,
-                                std::chrono::steady_clock::time_point currentTime,
-                                std::chrono::milliseconds maxPollingTime,
-                                bool readAtLeastOneRegister,
-                                TSerialClientDeviceAccessHandler& lastAccessedDevice);
-    void SetReadCallback(TRegisterCallback callback);
-    void SetErrorCallback(TRegisterCallback callback);
+    void ClosedPortCycle(std::chrono::steady_clock::time_point currentTime, TRegisterCallback callback);
+    TPollResult OpenPortCycle(TPort& port,
+                              const util::TSpentTimeMeter& spentTime,
+                              std::chrono::milliseconds maxPollingTime,
+                              bool readAtLeastOneRegister,
+                              TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                              TRegisterCallback callback);
     void SetDeviceDisconnectedCallback(TDeviceCallback callback);
-    void DeviceDisconnected(PSerialDevice device);
-
-    std::chrono::steady_clock::time_point GetDeadline() const;
+    void DeviceDisconnected(PSerialDevice device, std::chrono::steady_clock::time_point currentTime);
 
 private:
-    void ProcessPolledRegister(PRegister reg);
-    void SetReadError(PRegister reg);
     void ScheduleNextPoll(PRegister reg, std::chrono::steady_clock::time_point pollStartTime);
-    void SetDeadline(std::chrono::steady_clock::time_point deadline);
 
     std::list<PRegister> RegList;
 
-    TRegisterCallback ReadCallback;
-    TRegisterCallback ErrorCallback;
     TDeviceCallback DeviceDisconnectedCallback;
 
     TScheduler<PRegister, TRegisterComparePredicate> Scheduler;
 
     TThrottlingStateLogger ThrottlingStateLogger;
-
-    std::chrono::steady_clock::time_point Deadline;
 };

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -25,8 +25,10 @@ TSerialPortDriver::TSerialPortDriver(WBMQTT::PDeviceDriver mqttDriver,
       PublishPolicy(publishPolicy)
 {
     Description = Config->Port->GetDescription(false);
-    SerialClient = PSerialClient(
-        new TSerialClient(Config->Devices, Config->Port, Config->OpenCloseSettings, lowPriorityRateLimit));
+    SerialClient = PSerialClient(new TSerialClient(Config->Port,
+                                                   Config->OpenCloseSettings,
+                                                   std::chrono::steady_clock::now,
+                                                   lowPriorityRateLimit));
 }
 
 const std::string& TSerialPortDriver::GetShortDescription() const

--- a/test/TPollTest.SingleDeviceEnableEventsError.dat
+++ b/test/TPollTest.SingleDeviceEnableEventsError.dat
@@ -1,0 +1,102 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 14 02 01 00 2D A5
+11000: <modbus:1:(type 0): 1>
+11000: Cycle end
+
+11000: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 00 00 2F 65
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+42000: <modbus:1:(type 0): 1>
+42000: Cycle end
+
+42000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+62000: <modbus:1:(type 0): 1>
+62000: Cycle end
+
+62000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+82000: <modbus:1:(type 0): 1>
+82000: Cycle end
+
+82000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+102000: <modbus:1:(type 0): 1>
+102000: Cycle end
+
+102000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+122000: <modbus:1:(type 0): 1>
+122000: Cycle end
+
+122000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+142000: <modbus:1:(type 0): 1>
+142000: Cycle end
+
+142000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+162000: <modbus:1:(type 0): 1>
+162000: Cycle end
+
+162000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+182000: <modbus:1:(type 0): 1>
+182000: Cycle end
+
+182000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+202000: <modbus:1:(type 0): 1>
+202000: Cycle end
+
+202000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+222000: <modbus:1:(type 0): 1>
+222000: Cycle end
+
+222000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+242000: <modbus:1:(type 0): 1>
+242000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceEventsAndBigReadTime.dat
+++ b/test/TPollTest.SingleDeviceEventsAndBigReadTime.dat
@@ -1,0 +1,252 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+121000: <modbus:1:(type 0): 1>
+121000: Cycle end
+
+121000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+125670: Cycle end
+
+125670: Cycle
+171000: Cycle end
+
+171000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+175670: Cycle end
+
+175670: Cycle
+221000: Cycle end
+
+221000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+225670: Cycle end
+
+225670: Cycle
+271000: Cycle end
+
+271000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+275670: Cycle end
+
+275670: Cycle
+321000: Cycle end
+
+321000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+325670: Cycle end
+
+325670: Cycle
+371000: Cycle end
+
+371000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+375670: Cycle end
+
+375670: Cycle
+421000: Cycle end
+
+421000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+425670: Cycle end
+
+425670: Cycle
+471000: Cycle end
+
+471000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+475670: Cycle end
+
+475670: Cycle
+521000: Cycle end
+
+521000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+525670: Cycle end
+
+525670: Cycle
+571000: Cycle end
+
+571000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+575670: Cycle end
+
+575670: Cycle
+621000: Cycle end
+
+621000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+625670: Cycle end
+
+625670: Cycle
+671000: Cycle end
+
+671000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+675670: Cycle end
+
+675670: Cycle
+721000: Cycle end
+
+721000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+725670: Cycle end
+
+725670: Cycle
+771000: Cycle end
+
+771000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+775670: Cycle end
+
+775670: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+886670: <modbus:1:(type 0): 2>
+886670: Cycle end
+
+886670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+891340: Cycle end
+
+891340: Cycle
+936670: Cycle end
+
+936670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+941340: Cycle end
+
+941340: Cycle
+986670: Cycle end
+
+986670: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+991340: Cycle end
+
+991340: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+1102340: <modbus:1:(type 0): 2>
+1102340: Cycle end
+
+1102340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1107010: Cycle end
+
+1107010: Cycle
+1152340: Cycle end
+
+1152340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1157010: Cycle end
+
+1157010: Cycle
+1202340: Cycle end
+
+1202340: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1207010: Cycle end
+
+1207010: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+1318010: <modbus:1:(type 0): 2>
+1318010: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSeveralRegisters.dat
+++ b/test/TPollTest.SingleDeviceSeveralRegisters.dat
@@ -1,0 +1,193 @@
+Open()
+0: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+21000: <modbus:1:(type 0): 2>
+21000: Cycle end
+
+21000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+41000: <modbus:1:(type 0): 1>
+41000: Cycle end
+
+41000: Cycle
+50000: Cycle end
+
+50000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+70000: <modbus:1:(type 0): 2>
+70000: Cycle end
+
+70000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+90000: <modbus:1:(type 0): 1>
+90000: Cycle end
+
+90000: Cycle
+100000: Cycle end
+
+100000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+120000: <modbus:1:(type 0): 2>
+120000: Cycle end
+
+120000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+140000: <modbus:1:(type 0): 1>
+140000: Cycle end
+
+140000: Cycle
+150000: Cycle end
+
+150000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+170000: <modbus:1:(type 0): 2>
+170000: Cycle end
+
+170000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+190000: <modbus:1:(type 0): 1>
+190000: Cycle end
+
+190000: Cycle
+200000: Cycle end
+
+200000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+220000: <modbus:1:(type 0): 2>
+220000: Cycle end
+
+220000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+240000: <modbus:1:(type 0): 1>
+240000: Cycle end
+
+240000: Cycle
+250000: Cycle end
+
+250000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+270000: <modbus:1:(type 0): 2>
+270000: Cycle end
+
+270000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+290000: <modbus:1:(type 0): 1>
+290000: Cycle end
+
+290000: Cycle
+300000: Cycle end
+
+300000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+320000: <modbus:1:(type 0): 2>
+320000: Cycle end
+
+320000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+340000: <modbus:1:(type 0): 1>
+340000: Cycle end
+
+340000: Cycle
+350000: Cycle end
+
+350000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+370000: <modbus:1:(type 0): 2>
+370000: Cycle end
+
+370000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+390000: <modbus:1:(type 0): 1>
+390000: Cycle end
+
+390000: Cycle
+400000: Cycle end
+
+400000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+420000: <modbus:1:(type 0): 2>
+420000: Cycle end
+
+420000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+440000: <modbus:1:(type 0): 1>
+440000: Cycle end
+
+440000: Cycle
+450000: Cycle end
+
+450000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+470000: <modbus:1:(type 0): 2>
+470000: Cycle end
+
+470000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+490000: <modbus:1:(type 0): 1>
+490000: Cycle end
+
+490000: Cycle
+500000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegister.dat
+++ b/test/TPollTest.SingleDeviceSingleRegister.dat
@@ -1,0 +1,73 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+31000: Cycle end
+
+31000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+61000: <modbus:1:(type 0): 1>
+61000: Cycle end
+
+61000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+91000: <modbus:1:(type 0): 1>
+91000: Cycle end
+
+91000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+121000: <modbus:1:(type 0): 1>
+121000: Cycle end
+
+121000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+151000: <modbus:1:(type 0): 1>
+151000: Cycle end
+
+151000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+181000: <modbus:1:(type 0): 1>
+181000: Cycle end
+
+181000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+211000: <modbus:1:(type 0): 1>
+211000: Cycle end
+
+211000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+241000: <modbus:1:(type 0): 1>
+241000: Cycle end
+
+241000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+271000: <modbus:1:(type 0): 1>
+271000: Cycle end
+
+271000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+301000: <modbus:1:(type 0): 1>
+301000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithBigReadTime.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithBigReadTime.dat
@@ -1,0 +1,83 @@
+Open()
+0: Cycle
+Sleep(1000)
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+131000: <modbus:1:(type 0): 1>
+131000: Cycle end
+
+131000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+261000: <modbus:1:(type 0): 1>
+261000: Cycle end
+
+261000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+391000: <modbus:1:(type 0): 1>
+391000: Cycle end
+
+391000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+521000: <modbus:1:(type 0): 1>
+521000: Cycle end
+
+521000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+651000: <modbus:1:(type 0): 1>
+651000: Cycle end
+
+651000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+781000: <modbus:1:(type 0): 1>
+781000: Cycle end
+
+781000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+911000: <modbus:1:(type 0): 1>
+911000: Cycle end
+
+911000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1041000: <modbus:1:(type 0): 1>
+1041000: Cycle end
+
+1041000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1171000: <modbus:1:(type 0): 1>
+1171000: Cycle end
+
+1171000: Cycle
+Sleep(100000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1301000: <modbus:1:(type 0): 1>
+1301000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEvents.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEvents.dat
@@ -1,0 +1,94 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+50000: Cycle end
+
+50000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+100000: Cycle end
+
+100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+150000: Cycle end
+
+150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+200000: Cycle end
+
+200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+250000: Cycle end
+
+250000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+300000: Cycle end
+
+300000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+350000: Cycle end
+
+350000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+400000: Cycle end
+
+400000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+450000: Cycle end
+
+450000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+500000: Cycle end
+
+500000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+550000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndErrors.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndErrors.dat
@@ -1,0 +1,108 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+50000: Cycle end
+
+50000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+100000: Cycle end
+
+100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+150000: Cycle end
+
+150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+200000: Cycle end
+
+200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+317680: Cycle end
+
+317680: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+435360: Cycle end
+
+435360: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 14 D2 5F
+Sleep(335)
+527370: <modbus:1:(type 0): 1>
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 40 00 00 F9 7E
+<< FD 46 14 D2 5F
+Sleep(335)
+553040: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPolling.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPolling.dat
@@ -1,0 +1,106 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+31000: Cycle end
+
+31000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+51000: <modbus:1:(type 0): 2>
+51000: Cycle end
+
+51000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+55670: Cycle end
+
+55670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+76670: <modbus:1:(type 0): 2>
+76670: Cycle end
+
+76670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+96670: <modbus:1:(type 0): 2>
+96670: Cycle end
+
+96670: Cycle
+101000: Cycle end
+
+101000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+105670: Cycle end
+
+105670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+126670: <modbus:1:(type 0): 2>
+126670: Cycle end
+
+126670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+146670: <modbus:1:(type 0): 2>
+146670: Cycle end
+
+146670: Cycle
+151000: Cycle end
+
+151000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+155670: Cycle end
+
+155670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+176670: <modbus:1:(type 0): 2>
+176670: Cycle end
+
+176670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+196670: <modbus:1:(type 0): 2>
+196670: Cycle end
+
+196670: Cycle
+201000: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod.dat
@@ -1,0 +1,126 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 2>
+31000: Cycle end
+
+31000: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+51000: <modbus:1:(type 0): 1>
+51000: Cycle end
+
+51000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+55670: Cycle end
+
+55670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+76670: <modbus:1:(type 0): 3>
+76670: Cycle end
+
+76670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+96670: <modbus:1:(type 0): 3>
+96670: Cycle end
+
+96670: Cycle
+100000: Cycle end
+
+100000: Cycle
+101000: Cycle end
+
+101000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+105670: Cycle end
+
+105670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+126670: <modbus:1:(type 0): 2>
+126670: Cycle end
+
+126670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+146670: <modbus:1:(type 0): 3>
+146670: Cycle end
+
+146670: Cycle
+151000: Cycle end
+
+151000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+155670: Cycle end
+
+155670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+176670: <modbus:1:(type 0): 3>
+176670: Cycle end
+
+176670: Cycle
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 03 00 01 74 0A
+<< 01 03 02 00 00 B8 44
+196670: <modbus:1:(type 0): 3>
+196670: Cycle end
+
+196670: Cycle
+201000: Cycle end
+
+201000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+205670: Cycle end
+
+205670: Cycle
+Sleep(1000)
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 02 00 01 25 CA
+<< 01 03 02 00 00 B8 44
+226670: <modbus:1:(type 0): 2>
+226670: Cycle end
+
+Close()

--- a/test/TPollTest.SingleDeviceSingleRegisterWithReadPeriod.dat
+++ b/test/TPollTest.SingleDeviceSingleRegisterWithReadPeriod.dat
@@ -1,0 +1,73 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+100000: Cycle end
+
+100000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+130000: <modbus:1:(type 0): 1>
+200000: Cycle end
+
+200000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+230000: <modbus:1:(type 0): 1>
+300000: Cycle end
+
+300000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+330000: <modbus:1:(type 0): 1>
+400000: Cycle end
+
+400000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+430000: <modbus:1:(type 0): 1>
+500000: Cycle end
+
+500000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+530000: <modbus:1:(type 0): 1>
+600000: Cycle end
+
+600000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+630000: <modbus:1:(type 0): 1>
+700000: Cycle end
+
+700000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+730000: <modbus:1:(type 0): 1>
+800000: Cycle end
+
+800000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+830000: <modbus:1:(type 0): 1>
+900000: Cycle end
+
+900000: Cycle
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+930000: <modbus:1:(type 0): 1>
+1000000: Cycle end
+
+Close()

--- a/test/poll_test.cpp
+++ b/test/poll_test.cpp
@@ -1,0 +1,596 @@
+
+#include "fake_serial_port.h"
+#include "log.h"
+#include "modbus_expectations_base.h"
+#include "serial_driver.h"
+
+using namespace std::chrono_literals;
+using namespace std::chrono;
+
+namespace
+{
+    class TTimeMock
+    {
+        steady_clock::time_point Time;
+
+    public:
+        void Reset()
+        {
+            Time = steady_clock::time_point();
+        }
+
+        steady_clock::time_point GetTime() const
+        {
+            return Time;
+        }
+
+        void AddTime(microseconds intervalToAdd)
+        {
+            Time += intervalToAdd;
+        }
+    };
+
+    class TFakeSerialPortWithTime: public TFakeSerialPort
+    {
+        std::deque<microseconds> FrameReadTimes;
+        TTimeMock& TimeMock;
+
+    public:
+        TFakeSerialPortWithTime(WBMQTT::Testing::TLoggedFixture& fixture, TTimeMock& timeMock)
+            : TFakeSerialPort(fixture),
+              TimeMock(timeMock)
+        {}
+
+        void Expect(const std::vector<int>& request,
+                    const std::vector<int>& response,
+                    const char* func,
+                    microseconds frameReadTime)
+        {
+            TFakeSerialPort::Expect(request, response, func);
+            FrameReadTimes.push_back(frameReadTime);
+        }
+
+        size_t ReadFrame(uint8_t* buf,
+                         size_t count,
+                         const microseconds& responseTimeout = -1ms,
+                         const microseconds& frameTimeout = -1ms,
+                         TFrameCompletePred frame_complete = 0) override
+        {
+            if (!FrameReadTimes.empty()) {
+                TimeMock.AddTime(FrameReadTimes.front());
+                FrameReadTimes.pop_front();
+            }
+            return TFakeSerialPort::ReadFrame(buf, count, responseTimeout, frameTimeout, frame_complete);
+        }
+
+        void SleepSinceLastInteraction(const std::chrono::microseconds& us) override
+        {
+            TFakeSerialPort::SleepSinceLastInteraction(us);
+            TimeMock.AddTime(us);
+        }
+    };
+}
+
+class TPollTest: public TLoggedFixture, public TModbusExpectationsBase
+{
+public:
+    void SetUp()
+    {
+        TLoggedFixture::SetUp();
+        TimeMock.Reset();
+        Port = std::make_shared<TFakeSerialPortWithTime>(*this, TimeMock);
+        TModbusDevice::Register(DeviceFactory);
+        Port->Open();
+    }
+
+    void TearDown()
+    {
+        Port->Close();
+        TLoggedFixture::TearDown();
+    }
+
+    void Cycle(TSerialClientRegisterAndEventsReader& serialClient, TSerialClientDeviceAccessHandler& lastAccessedDevice)
+    {
+        Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": Cycle";
+        serialClient.OpenPortCycle(
+            *Port,
+            [this](PRegister reg) {
+                Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": " << reg->ToString();
+            },
+            lastAccessedDevice);
+        auto deadline = serialClient.GetDeadline(TimeMock.GetTime());
+        if (deadline > TimeMock.GetTime()) {
+            TimeMock.AddTime(ceil<microseconds>(deadline - TimeMock.GetTime()));
+        }
+        Emit() << ceil<microseconds>(TimeMock.GetTime().time_since_epoch()).count() << ": Cycle end\n";
+    }
+
+    void EnqueueReadHolding(uint8_t slaveId, uint16_t addr, uint16_t count, microseconds readTime)
+    {
+        SetModbusRTUSlaveId(slaveId);
+        std::vector<int> response = {0x03, count * 2};
+        for (auto i = 0; i < count; ++i) {
+            response.push_back((i >> 8) & 0xFF);
+            response.push_back(i & 0xFF);
+        }
+        Port->Expect(WrapPDU({
+                         0x03,                // function code
+                         (addr >> 8) & 0xFF,  // starting address Hi
+                         addr & 0xFF,         // starting address Lo
+                         (count >> 8) & 0xFF, // quantity Hi
+                         count & 0xFF         // quantity Lo
+                     }),
+                     WrapPDU(response),
+                     __func__,
+                     readTime);
+    }
+
+    void EnqueueReadEvents(microseconds readTime, bool error = false, uint8_t responseSize = 0xF8)
+    {
+        SetModbusRTUSlaveId(0xFD);
+        Port->Expect(WrapPDU({
+                         0x46,         // function code
+                         0x10,         // subcommand
+                         0x00,         // staring slaveId
+                         responseSize, // max response size
+                         0x00,         //
+                         0x00          //
+                     }),
+                     WrapPDU({
+                         0x46,               // function code
+                         error ? 0x14 : 0x12 // subcommand, no events
+                     }),
+                     __func__,
+                     readTime);
+    }
+
+    void EnqueueEnableEvents(uint8_t slaveId,
+                             uint16_t addr,
+                             microseconds readTime,
+                             uint8_t res = 0x01,
+                             bool error = false)
+    {
+        SetModbusRTUSlaveId(slaveId);
+        Port->Expect(WrapPDU({
+                         0x46,               // function code
+                         0x18,               // subcommand
+                         0x0A,               // data size
+                         0x03,               // holding
+                         (addr >> 8) & 0xFF, // address Hi
+                         addr & 0xFF,        // address Lo
+                         0x01,               // count
+                         0x01,               // enable
+                         0x0F,               // disable reset event
+                         0x00,               //
+                         0x00,               //
+                         0x01,               //
+                         0x00                //
+                     }),
+                     WrapPDU({
+                         0x46,                // function code
+                         error ? 0x14 : 0x18, // subcommand
+                         0x02,                // data size
+                         res,                 //
+                         0x00                 //
+                     }),
+                     __func__,
+                     readTime);
+    }
+
+    PExpector Expector() const override
+    {
+        return Port;
+    }
+
+    TModbusDeviceConfig MakeDeviceConfig(const std::string& name, const std::string& addr)
+    {
+        TModbusDeviceConfig config;
+        config.CommonConfig = std::make_shared<TDeviceConfig>(name, addr, "modbus");
+        config.CommonConfig->FrameTimeout = 0ms;
+        return config;
+    }
+
+    PDeviceChannelConfig MakeChannelConfig(
+        const std::string& deviceName,
+        uint16_t addr,
+        milliseconds readPeriod = 0ms,
+        TRegisterConfig::TSporadicMode sporadicMode = TRegisterConfig::TSporadicMode::DISABLED)
+    {
+        auto channel = std::make_shared<TDeviceChannelConfig>("value", deviceName);
+        channel->RegisterConfigs.push_back(TRegister::Create(Modbus::REG_HOLDING, addr));
+        if (readPeriod != 0ms) {
+            channel->RegisterConfigs[0]->ReadPeriod = readPeriod;
+        }
+        channel->RegisterConfigs[0]->SporadicMode = sporadicMode;
+        return channel;
+    }
+
+    std::shared_ptr<TModbusDevice> MakeDevice(const TModbusDeviceConfig& config)
+    {
+        return std::make_shared<TModbusDevice>(std::make_unique<Modbus::TModbusRTUTraits>(),
+                                               config,
+                                               Port,
+                                               DeviceFactory.GetProtocol("modbus"));
+    }
+
+    std::list<PRegister> GetRegList(PSerialDevice device)
+    {
+        std::list<PRegister> regList;
+        for (const auto& channelConfig: device->DeviceConfig()->DeviceChannelConfigs) {
+            auto channel = std::make_shared<TDeviceChannel>(device, channelConfig);
+            for (const auto& reg: channel->Registers) {
+                regList.push_back(reg);
+            }
+        }
+        return regList;
+    }
+
+    std::shared_ptr<TFakeSerialPortWithTime> Port;
+    TTimeMock TimeMock;
+    TSerialDeviceFactory DeviceFactory;
+};
+
+TEST_F(TPollTest, SingleDeviceSingleRegister)
+{
+    // One register without fixed read period and without events support
+    // Check what poller reads it as soon as possible
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithReadPeriod)
+{
+    // One register with fixed read period
+    // Check what read period is preserved
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 100ms));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSeveralRegisters)
+{
+    // One register with fixed read period and one without it
+    // Check what read period is preserved and poller wait for the first register,
+    // if there are not enough time to read the second register
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2, 50ms));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 1, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+
+        // Not enough time before reading register with read period
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEvents)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Only read events
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndPolling)
+{
+    // One register with events and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register without read period must be polled during free time
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Enable events and read first register
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+        // Not enough time for polling
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndPollingWithReadPeriod)
+{
+    // One register with events, one with read period and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register with read period must be polled during free time as much close to read period as possible
+    // 5. Register without read period must be polled during free time
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2, 100ms));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 3));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Enable events and read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before reading register with read period
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before events reading
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register with read period
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before reading register with read period
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read the last register
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+    EnqueueReadHolding(1, 3, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Not enough time before events reading
+    Cycle(serialClient, lastAccessedDevice);
+
+    // It is already time to read events
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register with read period
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+}
+
+TEST_F(TPollTest, SingleDeviceEventsAndBigReadTime)
+{
+    // One register with events, one with read period and one without read period
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Register without read period must be polled after some time of event reads because of time balancing
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 100ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 2));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Enable events and read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 13; ++i) {
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+
+        // Calculated read time is too big
+        Cycle(serialClient, lastAccessedDevice);
+    }
+
+    EnqueueReadEvents(4ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Read register
+    EnqueueReadHolding(1, 2, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
+            EnqueueReadEvents(4ms);
+            Cycle(serialClient, lastAccessedDevice);
+
+            // Calculated read time is too big
+            Cycle(serialClient, lastAccessedDevice);
+        }
+
+        EnqueueReadEvents(4ms);
+        Cycle(serialClient, lastAccessedDevice);
+
+        // Read register
+        EnqueueReadHolding(1, 2, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithBigReadTime)
+{
+    // One register without fixed read period but with big read time
+    // Check what poller reads it as soon as possible
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 100ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 30ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceSingleRegisterWithEventsAndErrors)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Some read requests have errors
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Only read events
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+
+    for (size_t i = 0; i < 3; ++i) {
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(30ms, true);
+        EnqueueReadEvents(25ms, true, 0x40);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}
+
+TEST_F(TPollTest, SingleDeviceEnableEventsError)
+{
+    // One register with events
+    // 1. Events must be enabled
+    // 2. The register is read once by normal request and excluded from polling
+    // 3. Events read requests are sent every 50ms
+    // 4. Some read requests have errors
+
+    Port->SetBaudRate(115200);
+    auto config = MakeDeviceConfig("device1", "1");
+    config.CommonConfig->RequestDelay = 10ms;
+    config.CommonConfig->AddChannel(MakeChannelConfig("device1", 1, 0ms, TRegisterConfig::TSporadicMode::ENABLED));
+    auto device = MakeDevice(config);
+    auto regList = GetRegList(device);
+
+    TSerialClientRegisterAndEventsReader serialClient(regList, 50ms, [this]() { return TimeMock.GetTime(); });
+    TSerialClientDeviceAccessHandler lastAccessedDevice(serialClient.GetEventsReader());
+
+    // Read registers
+    EnqueueEnableEvents(1, 1, 10ms, 0x01, true);
+    Cycle(serialClient, lastAccessedDevice);
+
+    // Events are disabled, poll register
+    EnqueueEnableEvents(1, 1, 10ms, 0x00);
+    EnqueueReadHolding(1, 1, 1, 10ms);
+    Cycle(serialClient, lastAccessedDevice);
+
+    for (size_t i = 0; i < 10; ++i) {
+        EnqueueReadHolding(1, 1, 1, 10ms);
+        Cycle(serialClient, lastAccessedDevice);
+    }
+}

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -146,12 +146,7 @@ void TSerialClientTest::SetUp()
     config->FrameTimeout = std::chrono::milliseconds(100);
     Device = std::make_shared<TFakeSerialDevice>(config, Port, DeviceFactory.GetProtocol("fake"));
     Device->InitSetupItems();
-    std::vector<PSerialDevice> devices;
-    devices.push_back(Device);
-    SerialClient = std::make_shared<TSerialClient>(devices, Port, PortOpenCloseSettings);
-#if 0
-    SerialClient->SetModbusDebug(true);
-#endif
+    SerialClient = std::make_shared<TSerialClient>(Port, PortOpenCloseSettings, std::chrono::steady_clock::now);
     SerialClient->SetReadCallback([this](PRegister reg) {
         if (reg->GetErrorState().count()) {
             EmitErrorMsg(reg);


### PR DESCRIPTION
* Read at least one register every cycle if there are not devices with enabled events even if read time is bigger than MAX_POLL_TIME
* Fix calculation of total events read time. Unexpected zeroing of total read time lead to stop polling registers with big response-request times