### PR TITLE
Remove comments from config files

### DIFF
--- a/config.json.default
+++ b/config.json.default
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/config.json.wb234
+++ b/config.json.wb234
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/config.json.wb5
+++ b/config.json.wb5
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/config.json.wb6
+++ b/config.json.wb6
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/config.json.wb67
+++ b/config.json.wb67
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/config.json.wb7
+++ b/config.json.wb7
@@ -1,4 +1,3 @@
-// Configuration options
 {
     "debug": false,
     "ports": [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.87.3) stable; urgency=medium
+
+  * Remove comments from config files
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 02 Jun 2023 01:21:00 +0400
+
 wb-mqtt-serial (2.87.2) stable; urgency=medium
 
   * Update build options. No functional changes

--- a/test/configs/config-s2k-test.json
+++ b/test/configs/config-s2k-test.json
@@ -1,4 +1,3 @@
-// Configuration options
 {
   "debug": false,
   "ports": [

--- a/test/configs/config-uniel-test.json
+++ b/test/configs/config-uniel-test.json
@@ -1,4 +1,3 @@
-// Configuration options
 {
   "debug": false,
   "ports": [


### PR DESCRIPTION
* Эти коментарии не несут никакой полезной информации
* Они будут выкинуты при первом же сохранении конфига через UI
* Благодаря им конфиг не является валидным JSON и многие тулзы на этом ломаются (напр. wb-mcu-fw-updater)

Before:
```sh
$ wb-mcu-fw-updater update-all
2023-06-02 01:49:04,838 Error in /etc/wb-mqtt-serial.conf
2023-06-02 01:49:04,851 Unhandled exception!
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 239, in get_ports_on_driver
    config_dict = json.load(open(driver_config_fname, "r", encoding="utf-8"))
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/wb-mcu-fw-updater", line 511, in <module>
    else update_monitor.get_ports_on_driver(CONFIG["SERIAL_DRIVER_CONFIG_FNAME"])
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 242, in get_ports_on_driver
    raise ConfigParsingError from e
wb_mcu_fw_updater.update_monitor.ConfigParsingError
```

After:
```sh
wb-mcu-fw-updater update-all
2023-06-02 01:54:08,257 Will probe all devices on enabled serial ports of /etc/wb-mqtt-serial.conf:
2023-06-02 01:54:08,261 No devices has found in /etc/wb-mqtt-serial.conf
2023-06-02 01:54:08,263 0 upgraded, 0 skipped upgrade, 0 stuck in bootloader, 0 disconnected and 0 too old for any updates.
```