### PR TITLE
Minor fix debug logging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.87.4) stable; urgency=medium
+
+  * Minor fix debug logging
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 05 Jun 2023 11:10:00 +0400
+
 wb-mqtt-serial (2.87.3) stable; urgency=medium
 
   * Remove comments from config files

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -303,7 +303,12 @@ void TDeviceChannel::PublishValueAndError(WBMQTT::TDeviceDriver& deviceDriver,
                                           const std::string& error)
 {
     if (::Debug.IsEnabled()) {
-        LOG(Debug) << Describe() << " <-- " << value << ", error: \"" << error << "\"";
+        std::stringstream ss;
+        ss << Describe() << " <-- " << value;
+        if (!error.empty()) {
+            ss << ", error: \"" << error << "\"";
+        }
+        LOG(Debug) << ss.str();
     }
     CachedCurrentValue = value;
     CachedErrorText = error;


### PR DESCRIPTION
`DEBUG: [serial port driver] channel 'Input 4' of device 'wb-mcm8_196' <-- 1, error: ""`