### PR TITLE
Handle timeout of enable events command

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.87.5) stable; urgency=medium
+
+  * Poll registers if a device firmware doesn't respond to enable events command 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 05 Jun 2023 19:58:51 +0500
+
 wb-mqtt-serial (2.87.4) stable; urgency=medium
 
   * Minor fix debug logging

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.87.5) stable; urgency=medium
 
-  * Poll registers if a device firmware doesn't respond to enable events command 
+  * Poll registers if a device firmware does not respond to enable events command 
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 05 Jun 2023 19:58:51 +0500
 

--- a/src/file_descriptor_port.cpp
+++ b/src/file_descriptor_port.cpp
@@ -192,7 +192,7 @@ TReadFrameResult TFileDescriptorPort::ReadFrame(uint8_t* buf,
     }
 
     if (!res.Count) {
-        throw TSerialDeviceTransientErrorException("request timed out");
+        throw TResponseTimeoutException();
     }
 
     LastInteraction = std::chrono::steady_clock::now();

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1124,7 +1124,7 @@ namespace Modbus // modbus protocol common utilities
 
             LOG(Debug) << "Transaction id mismatch";
         }
-        throw TSerialDeviceTransientErrorException("request timed out");
+        throw TResponseTimeoutException();
     }
 
     uint8_t* TModbusTCPTraits::GetPDU(std::vector<uint8_t>& frame) const

--- a/src/serial_client_events_reader.cpp
+++ b/src/serial_client_events_reader.cpp
@@ -282,6 +282,8 @@ void TSerialClientEventsReader::EnableEvents(PSerialDevice device, TPort& port)
         }
     } catch (const TSerialDevicePermanentRegisterException& e) {
         LOG(Warn) << "Failed to enable events for " << MakeDeviceDescriptionString(slaveId) << ": " << e.what();
+    } catch (const TResponseTimeoutException& e) {
+        LOG(Warn) << "Failed to enable events for " << MakeDeviceDescriptionString(slaveId) << ": " << e.what();
     } catch (const TSerialDeviceTransientErrorException& e) {
         throw TSerialDeviceTransientErrorException(std::string("Failed to enable events: ") + e.what());
     }

--- a/src/serial_exc.cpp
+++ b/src/serial_exc.cpp
@@ -31,3 +31,6 @@ TSerialDevicePermanentRegisterException::TSerialDevicePermanentRegisterException
 TSerialDeviceInternalErrorException::TSerialDeviceInternalErrorException(const std::string& message)
     : TSerialDeviceTransientErrorException(message)
 {}
+
+TResponseTimeoutException::TResponseTimeoutException(): TSerialDeviceTransientErrorException("request timed out")
+{}

--- a/src/serial_exc.h
+++ b/src/serial_exc.h
@@ -67,3 +67,10 @@ class TSerialDevicePermanentRegisterException: public TSerialDeviceException
 public:
     TSerialDevicePermanentRegisterException(const std::string& message);
 };
+
+//! Response timeout expired exception
+class TResponseTimeoutException: public TSerialDeviceTransientErrorException
+{
+public:
+    TResponseTimeoutException();
+};

--- a/test/fake_serial_port.cpp
+++ b/test/fake_serial_port.cpp
@@ -183,7 +183,7 @@ TReadFrameResult TFakeSerialPort::ReadFrame(uint8_t* buf,
     }
     DumpWhatWasRead();
     if ((res.Count == 0) && (count != 0)) {
-        throw TSerialDeviceTransientErrorException("request timed out");
+        throw TResponseTimeoutException();
     }
     return res;
 }


### PR DESCRIPTION
Some old firmwares don't respond to unknown commands. So count timeout as absence of events support