### PR TITLE
Fix average response time calculation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.92.1) stable; urgency=medium
+
+  * Fix warnings about too long poll period
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 25 Jul 2023 15:36:31 +0500
+
 wb-mqtt-serial (2.92.0) stable; urgency=medium
 
   * Add new template ONOKOM-AIR-DK-1-MB-B

--- a/src/file_descriptor_port.cpp
+++ b/src/file_descriptor_port.cpp
@@ -164,6 +164,7 @@ TReadFrameResult TFileDescriptorPort::ReadFrame(uint8_t* buf,
     }
 
     util::TSpentTimeMeter spentTime(std::chrono::steady_clock::now);
+    spentTime.Start();
 
     // Will wait first byte up to responseTimeout us
     auto selectTimeout = responseTimeout;


### PR DESCRIPTION
При ожидании ответа не запоминался начальный момент времени, в результате время получения ответа всегда считалось от 0 и получалось очень большим.