### PR TITLE
Fix memory leak

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.93.3) stable; urgency=medium
+
+  * Fixed increasing memory consumption if there are disconnected devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 31 Jul 2023 12:29:01 +0500
+
 wb-mqtt-serial (2.93.2) stable; urgency=medium
 
   * WB-MR*, WB-MCM8, WB-MWAC templates: add condition for some special sporadic channels

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1157,7 +1157,8 @@ namespace Modbus // modbus protocol common utilities
                                 uint8_t slaveId,
                                 TRegisterCache& cache)
     {
-        auto reg = TRegister::Intern(device, TRegister::Create(Modbus::REG_HOLDING, ENABLE_CONTINUOUS_READ_REGISTER));
+        auto reg = std::make_shared<TRegister>(device,
+                                               TRegister::Create(Modbus::REG_HOLDING, ENABLE_CONTINUOUS_READ_REGISTER));
         try {
             Modbus::WriteRegister(traits, port, slaveId, *reg, TRegisterValue(1), cache);
             LOG(Info) << "Continuous read enabled [slave_id is " << device->DeviceConfig()->SlaveId + "]";


### PR DESCRIPTION
TRegister::Intern внутри сохраняет все регистры в таблицу с ключём по устройству и настройкам. Ключ сравнивается не по содержимому объектов, а по их адресу.
Тут же каждый раз создаётся TRegisterConfig, следовательно, каждый раз новый регистр сохраняется в табличке. Табличка растёт