### PR TITLE
Fix round_to default value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.99.1) stable; urgency=medium
+
+  * Fix round_to default value (wb-mqtt-serial.schema.json)
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 11 Sep 2023 11:48:00 +0400
+
 wb-mqtt-serial (2.99.0) stable; urgency=medium
 
   * Add new template ONOKOM-AIR-HS-3-MB-B

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -579,7 +579,7 @@
           "type": "number",
           "title": "Round to",
           "description": "Value displayed = round((value read * scale) + offset) / round_to) * round_to",
-          "default" : 1,
+          "default": 0.1,
           "propertyOrder": 13,
           "minimum": 0
         },


### PR DESCRIPTION
Приводило к:
`TypeError: c.step.toString().split(...)[1] is undefined` на https://github.com/wirenboard/homeui/blob/566ef8629676b089359b3c9cefed2b8040c58033/app/scripts/directives/valuecell.js#L24

<img width="467" alt="Näyttökuva 2023-9-11 kello 11 13 25" src="https://github.com/wirenboard/wb-mqtt-serial/assets/688044/f310f6a4-6c07-4eda-9ee3-e3908139a3cf">
