### PR TITLE
Fix timeout with enabled force_frame_timeout parameter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.68.6-wb109) stable; urgency=medium
+
+  * Fix timeout error when force frame timeout config parameter is enabled,
+    but there isn't extra garbage data after device's responses.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 29 Sep 2023 15:45:03 +0500
+
 wb-mqtt-serial (2.68.6-wb108) stable; urgency=medium
 
   * Add force frame timeout config parameter.

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1029,7 +1029,7 @@ namespace Modbus // modbus protocol common utilities
             std::array<uint8_t, 256> buf;
             try {
                 port.ReadFrame(buf.data(), buf.size(), frameTimeout, frameTimeout);
-            } catch (const TResponseTimeoutException& e) {
+            } catch (const TSerialDeviceTransientErrorException& e) {
                 // No extra data
             }
         }

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1027,7 +1027,11 @@ namespace Modbus // modbus protocol common utilities
 
         if (ForceFrameTimeout) {
             std::array<uint8_t, 256> buf;
-            port.ReadFrame(buf.data(), buf.size(), frameTimeout, frameTimeout);
+            try {
+                port.ReadFrame(buf.data(), buf.size(), frameTimeout, frameTimeout);
+            } catch (const TResponseTimeoutException& e) {
+                // No extra data
+            }
         }
 
         auto requestSlaveId = req[0];

--- a/test/TModbusTest.SkipNoiseAtPacketEnd.dat
+++ b/test/TModbusTest.SkipNoiseAtPacketEnd.dat
@@ -3,3 +3,6 @@ EnqueueReadResponseWithNoiseAtTheEnd()
 >> 01 03 27 2E 00 01 EE B7
 << 01 03 02 11 78 B4 36
 << B0 AA
+EnqueueReadResponseWithNoiseAtTheEnd()
+>> 01 03 27 2E 00 01 EE B7
+<< 01 03 02 11 78 B4 36

--- a/test/modbus_expectations.cpp
+++ b/test/modbus_expectations.cpp
@@ -2038,16 +2038,18 @@ void TModbusExpectations::EnqueueHoldingSeparateReadResponse(uint8_t exception)
         __func__);
 }
 
-void TModbusExpectations::EnqueueReadResponseWithNoiseAtTheEnd()
+void TModbusExpectations::EnqueueReadResponseWithNoiseAtTheEnd(bool addNoise)
 {
-    auto responseWithNoise = WrapPDU({
+    auto response = WrapPDU({
         0x03, // function code
         0x02, // byte count
         0x11, // data Hi 4
         0x78, // data Lo 4
     });
-    responseWithNoise.push_back(0xb0);
-    responseWithNoise.push_back(0xaa);
+    if (addNoise) {
+        response.push_back(0xb0);
+        response.push_back(0xaa);
+    }
     Expector()->Expect(WrapPDU({
                            0x03, // function code
                            0x27, // starting address Hi
@@ -2055,6 +2057,6 @@ void TModbusExpectations::EnqueueReadResponseWithNoiseAtTheEnd()
                            0x00, // quantity Hi
                            0x01, // quantity Lo
                        }),
-                       responseWithNoise,
+                       response,
                        __func__);
 }

--- a/test/modbus_expectations.h
+++ b/test/modbus_expectations.h
@@ -78,5 +78,5 @@ public:
     void EnqueueHoldingSingleOneByOneReadResponse(uint8_t exception = 0);
     void EnqueueHoldingMultiOneByOneReadResponse(uint8_t exception = 0);
 
-    void EnqueueReadResponseWithNoiseAtTheEnd();
+    void EnqueueReadResponseWithNoiseAtTheEnd(bool addNoise);
 };

--- a/test/modbus_test.cpp
+++ b/test/modbus_test.cpp
@@ -394,7 +394,8 @@ TEST_F(TModbusTest, WrongFunctionCodeWithExceptionWrite)
 
 TEST_F(TModbusTest, SkipNoiseAtPacketEnd)
 {
-    EnqueueReadResponseWithNoiseAtTheEnd();
+    EnqueueReadResponseWithNoiseAtTheEnd(true);
+    EnqueueReadResponseWithNoiseAtTheEnd(false);
 
     auto modbusRtuTraits = std::make_unique<Modbus::TModbusRTUTraits>(true);
     auto deviceConfig = GetDeviceConfig();
@@ -407,6 +408,9 @@ TEST_F(TModbusTest, SkipNoiseAtPacketEnd)
     auto range = dev->CreateRegisterRange();
     auto reg = TRegister::Intern(dev, TRegisterConfig::Create(Modbus::REG_HOLDING, 0x272E, U16));
     range->Add(reg, std::chrono::milliseconds::max());
+    // Read with noise
+    EXPECT_NO_THROW(dev->ReadRegisterRange(range));
+    // Read without noise
     EXPECT_NO_THROW(dev->ReadRegisterRange(range));
 }
 


### PR DESCRIPTION
Do not raise timeout error when force frame timeout config parameter is enabled, but there isn't extra garbage data after device's responses