### PR TITLE
Read all fast modbus packets

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.93.3-wb102) stable; urgency=medium
+
+  * Fix fast modbus reading errors 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 04 Oct 2023 12:03:57 +0500
+
 wb-mqtt-serial (2.93.3-wb101) stable; urgency=medium
 
   * WB-LED and WB-MRGBW-D templates: add sporadic events for channels

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -133,9 +133,11 @@ namespace ModbusExt // modbus extension protocol declarations
                 case NO_EVENTS_RESPONSE_COMMAND: {
                     return size == start + NO_EVENTS_RESPONSE_SIZE;
                 }
-                default:
-                    // Unexpected sub command
-                    return true;
+                default: {
+                    // Unexpected sub command.
+                    // Can't calculate size, so read until timeout or max packet size
+                    return false;
+                }
             }
         };
     }


### PR DESCRIPTION
Read all data if fast modbus packet is malformed. It prevents from reading garbage after future requests

Бэкпорт из тестинга