### PR TITLE
Fix port reopen after connection errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.106.3) stable; urgency=medium
+
+  * Fix port reopen after connection errors
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 19 Oct 2023 12:11:14 +0500
+
 wb-mqtt-serial (2.106.2) stable; urgency=medium
 
   * Add NEVA MT 324 third and forth tarifs reading

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -331,6 +331,8 @@ PSerialDevice TSerialClientRegisterAndEventsReader::OpenPortCycle(TPort& port,
                                   TPriority::High);
         }
         SpentTime.Start();
+
+        // TODO: Need to notify port open/close logic about errors
         return nullptr;
     }
 

--- a/src/serial_client_register_poller.cpp
+++ b/src/serial_client_register_poller.cpp
@@ -176,12 +176,12 @@ TPollResult TSerialClientRegisterPoller::OpenPortCycle(TPort& port,
         return res;
     }
 
-    auto device = range->RegisterList().front()->Device();
-    bool deviceWasConnected = !device->GetIsDisconnected();
+    res.Device = range->RegisterList().front()->Device();
+    bool deviceWasConnected = !res.Device->GetIsDisconnected();
 
     bool readOk = false;
-    if (lastAccessedDevice.PrepareToAccess(device)) {
-        device->ReadRegisterRange(range);
+    if (lastAccessedDevice.PrepareToAccess(res.Device)) {
+        res.Device->ReadRegisterRange(range);
         readOk = true;
     }
 
@@ -196,10 +196,10 @@ TPollResult TSerialClientRegisterPoller::OpenPortCycle(TPort& port,
         ScheduleNextPoll(reg, spentTime.GetStartTime());
     }
 
-    if (deviceWasConnected && device->GetIsDisconnected()) {
-        DeviceDisconnected(device, spentTime.GetStartTime());
+    if (deviceWasConnected && res.Device->GetIsDisconnected()) {
+        DeviceDisconnected(res.Device, spentTime.GetStartTime());
         if (DeviceDisconnectedCallback) {
-            DeviceDisconnectedCallback(device);
+            DeviceDisconnectedCallback(res.Device);
         }
     }
 

--- a/test/TSerialClientIntegrationTest.ReconnectAfterNetworkDisconnect.dat
+++ b/test/TSerialClientIntegrationTest.ReconnectAfterNetworkDisconnect.dat
@@ -1,0 +1,60 @@
+Subscribe: /devices/+/meta/driver (QoS 0)
+Publish: /devices/reconnect-test/meta: '{"driver":"serial-client-integration-test","title":{"en":"Reconnect test"}}' (QoS 1, retained)
+Publish: /devices/reconnect-test/meta/driver: 'serial-client-integration-test' (QoS 1, retained)
+Publish: /devices/reconnect-test/meta/name: 'Reconnect test' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1/meta: '{"order":1,"readonly":false,"type":"value"}' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1/meta/error: '' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1/meta/order: '1' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1/meta/readonly: '0' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1/meta/type: 'value' (QoS 1, retained)
+Publish: /devices/reconnect-test/controls/I1: '0' (QoS 1, retained)
+Subscribe: /devices/reconnect-test/controls/I1/on (QoS 0)
+Subscribe: /devices/reconnect-test/controls/# (QoS 0)
+(retain) -> /devices/reconnect-test/controls/I1: '0' (QoS 1, retained)
+(retain) -> /devices/reconnect-test/controls/I1/meta: '{"order":1,"readonly":false,"type":"value"}' (QoS 1, retained)
+(retain) -> /devices/reconnect-test/controls/I1/meta/order: '1' (QoS 1, retained)
+(retain) -> /devices/reconnect-test/controls/I1/meta/readonly: '0' (QoS 1, retained)
+(retain) -> /devices/reconnect-test/controls/I1/meta/type: 'value' (QoS 1, retained)
+Unsubscribe -- serial-client-integration-test: /devices/reconnect-test/controls/#
+>>> LoopOnce()
+Open()
+Sleep(20000)
+fake_serial_device '12': read address '1' value '0'
+fake_serial_device '12': transfer OK
+fake_serial_device '12': reconnected
+Publish: /devices/reconnect-test/controls/I1: '0' (QoS 1, retained)
+>>> LoopOnce()
+fake_serial_device '12': read address '1' value '0'
+>>> LoopOnce()
+fake_serial_device '12': read address '1' value '0'
+fake_serial_device: block address '1' for reading
+>>> LoopOnce()
+fake_serial_device '12': read address '1' failed: 'Serial protocol error: read blocked'
+fake_serial_device '12': transfer FAIL
+Publish: /devices/reconnect-test/controls/I1/meta/error: 'r' (QoS 1, retained)
+>>> LoopOnce()
+fake_serial_device '12': read address '1' failed: 'Serial protocol error: read blocked'
+fake_serial_device '12': transfer FAIL
+fake_serial_device '12': disconnected
+>>> LoopOnce()
+Sleep(20000)
+fake_serial_device '12': read address '1' failed: 'Serial protocol error: read blocked'
+fake_serial_device '12': transfer FAIL
+Sleep(20000)
+fake_serial_device '12': read address '1' failed: 'Serial protocol error: read blocked'
+fake_serial_device '12': transfer FAIL
+Close()
+fake_serial_device: unblock address '1' for reading
+>>> LoopOnce()
+Open()
+Sleep(20000)
+fake_serial_device '12': read address '1' value '0'
+fake_serial_device '12': transfer OK
+fake_serial_device '12': reconnected
+Publish: /devices/reconnect-test/controls/I1/meta/error: '' (QoS 1, retained)
+>>> LoopOnce()
+fake_serial_device '12': read address '1' value '0'
+>>> LoopOnce()
+fake_serial_device '12': read address '1' value '0'
+Close()
+stop: serial-client-integration-test

--- a/test/configs/reconnect_test_network.json
+++ b/test/configs/reconnect_test_network.json
@@ -1,0 +1,33 @@
+{
+  "ports": [
+    {
+      "path" : "/dev/ttyNSC0",
+      "baud_rate": 9600,
+      "parity": "N",
+      "data_bits": 8,
+      "stop_bits": 1,
+      "connection_timeout_ms" : 70,
+      "connection_max_fail_cycles": 2,
+      "devices" : [
+        {
+          "name": "Reconnect test",
+          "id": "reconnect-test",
+          "slave_id": 12,
+          "protocol": "fake",
+          "device_timeout_ms": 50,
+          "device_max_fail_cycles": 2,
+          "channels": [
+            {
+              "name": "I1",
+              "reg_type": "fake",
+              "address": "0x01",
+              "format": "u8",
+              "type": "value",
+              "scale": 0.001
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/66980/

Проблема при отключении tcp устройсва. Со стороны контроллера сокет живой, записать в него можно без ошибок, но нет ответов. Через длительное время сокет протухает. В wb-mqtt-serial есть логика про закрытие и открытие порта, если все устройства на нём не отвечают. К сожалению, я эту логику сломал, а существующие тесты не выявили ничего. Логика была завязана на объект устройства, которое опрашивается в текузем цикле. Но указатель на этот объект не передавался никуда, если былыи ошибки опроса.
Добавил ещё тест на проверку логики закрытия и открытия порта в аналогичных ситуациях.