### PR TITLE
Milur: fix frame boundary detection predicate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ TEST_OBJS := $(TEST_SRCS:%=$(BUILD_DIR)/%.o)
 TEST_BIN = wb-homa-test
 TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
+VALGRIND_FLAGS = --error-exitcode=180 -q
+
 SRCS=$(SERIAL_SRCS) $(TEST_SRCS)
 
 TEMPLATES_DIR = templates
@@ -74,13 +76,13 @@ $(GENERATED_TEMPLATES_DIR)/%.json: $(TEMPLATES_DIR)/%.json.jinja
 test: templates $(TEST_DIR)/$(TEST_BIN)
 	rm -f $(TEST_DIR)/*.dat.out
 	if [ "$(shell arch)" != "armv7l" ] && [ "$(CROSS_COMPILE)" = "" ] || [ "$(CROSS_COMPILE)" = "x86_64-linux-gnu-" ]; then \
-		valgrind --error-exitcode=180 -q $(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || \
+		valgrind $(VALGRIND_FLAGS) $(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || \
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
 		else $(TEST_DIR)/abt.sh show; exit 1; fi; \
-    else \
-        $(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
+	else \
+		$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
 	fi
 
 templates: $(JINJA_TEMPLATES:$(TEMPLATES_DIR)/%.json.jinja=$(GENERATED_TEMPLATES_DIR)/%.json)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.108.4) stable; urgency=medium
+
+  * Milur: fix frame boundary detection predicate
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 18 Dec 2023 16:00:00 +0400
+
 wb-mqtt-serial (2.108.3) stable; urgency=medium
 
   * JSON schema: add missed "group" property

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.108.4) stable; urgency=medium
 
-  * Milur: fix frame boundary detection predicate
+  * Milur: fix potential issue with reading registers
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 18 Dec 2023 16:00:00 +0400
 

--- a/src/devices/milur_device.cpp
+++ b/src/devices/milur_device.cpp
@@ -7,7 +7,7 @@ namespace
     TPort::TFrameCompletePred ExpectNBytes(size_t slave_id_width, size_t n)
     {
         return [slave_id_width, n](uint8_t* buf, size_t size) {
-            if (size < 2)
+            if (size < slave_id_width + 1)
                 return false;
             if (buf[slave_id_width] & 0x80)
                 return size >= 5 + slave_id_width; // exception response


### PR DESCRIPTION
Valgrind detects an error on `TMilur32Test.MilurQuery` test:
```sh
 ==599== Conditional jump or move depends on uninitialised value(s)
 ==599==    at 0x4A04D5: std::_Function_handler<bool (unsigned char*, unsigned long), (anonymous namespace)::ExpectNBytes(unsigned long, unsigned long)::{lambda(unsigned char*, unsigned long)#1}>::_M_invoke(std::_Any_data const&, unsigned char*&&, unsigned long&&) (in /build/source/test/wb-homa-test)
 ==599==    by 0x564099: TFakeSerialPort::ReadFrame(unsigned char*, unsigned long, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::function<bool (unsigned char*, unsigned long)>) (in /build/source/test/wb-homa-test)
 ==599==    by 0x49FAA4: TEMDevice::ReadResponse(int, unsigned char*, int, std::function<bool (unsigned char*, unsigned long)>) (in /build/source/test/wb-homa-test)
 ==599==    by 0x4A1293: TMilurDevice::ConnectionSetup() (in /build/source/test/wb-homa-test)
 ==599==    by 0x49FFFC: TEMDevice::EnsureSlaveConnected(bool) (in /build/source/test/wb-homa-test)
 ==599==    by 0x4A0362: TEMDevice::Talk(unsigned char, unsigned char*, int, int, unsigned char*, int, std::function<bool (unsigned char*, unsigned long)>) (in /build/source/test/wb-homa-test)
 ==599==    by 0x4A0B63: TMilurDevice::ReadRegisterImpl(std::shared_ptr<TRegister>) (in /build/source/test/wb-homa-test)
 ==599==    by 0x604A87: TMilur32Test::VerifyMilurQuery() (in /build/source/test/wb-homa-test)
 ==599==    by 0x604CA7: TMilur32Test_MilurQuery_Test::TestBody() (in /build/source/test/wb-homa-test)
```