### PR TITLE
Feature/fix mr param duplicates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.108.6) stable; urgency=medium
+
+  * Fix duplicated parameters for MR3, MR6C, MR6C-NC templates
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.ru>  Thu, 21 Dec 2023 22:35:19 +0300
+
 wb-mqtt-serial (2.108.5) stable; urgency=medium
 
   * Changing min value increase_rate_description and decrease_rate_description in /templates/config-wb-mdm3.json.jinja

--- a/templates/config-wb-mr3.json.jinja
+++ b/templates/config-wb-mr3.json.jinja
@@ -89,7 +89,7 @@
             {
                 "title": "HW Info",
                 "id": "g_hw_info"
-            }            
+            }
         ],
 
         "setup": [
@@ -283,6 +283,9 @@
                 "enum_titles": ["no action", "reset", "set", "toggle"],
                 "condition": "in{{in_num}}_mode==6"
             },
+            {% endfor -%}
+            {% endfor -%}
+            {% for out_num in range(1, OUTPUTS_NUMBER + 1) -%}
             "out{{out_num}}_safe_state": {
                 "title": "Output {{out_num}}",
                 "group": "gg_outputs_safe_state",
@@ -323,7 +326,6 @@
                     "Enable only in safety mode"
                 ]
             },
-            {% endfor -%}
             {% endfor -%}
             "outputs_restore_state": {
                 "title": "Outputs State After Power On",

--- a/templates/config-wb-mr6c-nc.json.jinja
+++ b/templates/config-wb-mr6c-nc.json.jinja
@@ -55,7 +55,6 @@
                 "title": "Output Safe State",
                 "id": "gg_outputs_safe_state",
                 "group": "g_outputs"
-                
             },
             {
                 "title": "Outputs group",
@@ -284,6 +283,9 @@
                 "enum_titles": ["no action", "set", "reset", "toggle"],
                 "condition": "in{{in_num}}_mode==6"
             },
+            {% endfor -%}
+            {% endfor -%}
+            {% for out_num in range(1, OUTPUTS_NUMBER + 1) -%}
             "out{{out_num}}_safe_state": {
                 "title": "Output {{out_num}}",
                 "group": "gg_outputs_safe_state",
@@ -324,7 +326,6 @@
                     "Enable only in safety mode"
                 ]
             },
-            {% endfor -%}
             {% endfor -%}
             "outputs_restore_state": {
                 "title": "Outputs State After Power On",

--- a/templates/config-wb-mr6c.json.jinja
+++ b/templates/config-wb-mr6c.json.jinja
@@ -62,7 +62,6 @@
                 "title": "Output Safe State",
                 "id": "gg_outputs_safe_state",
                 "group": "g_outputs"
-                
             },
             {
                 "title": "Outputs group",
@@ -290,6 +289,9 @@
                 "enum_titles": ["no action", "reset", "set", "toggle"],
                 "condition": "in{{in_num}}_mode==6"
             },
+            {% endfor -%}
+            {% endfor -%}
+            {% for out_num in range(1, OUTPUTS_NUMBER + 1) -%}
             "out{{out_num}}_safe_state": {
                 "title": "Output {{out_num}}",
                 "group": "gg_outputs_safe_state",
@@ -331,7 +333,6 @@
                 ]
             },
             {% endfor -%}
-            {% endfor -%}
             "outputs_restore_state": {
                 "title": "Outputs State After Power On",
                 "description": "outputs_state_after_power_on_description",
@@ -372,7 +373,6 @@
                 "order": 1
             }
         },
-        
         "channels": [
             {% for in_num in range(FIRST_INPUT, OUTPUTS_NUMBER + 1) -%}
             {% set NO_SPORADIC_MODE = 3 -%}


### PR DESCRIPTION
Заметил что в шаблонах реле параметры стояли не в том цикле, из-за чего дублировались в результирующем json. У нас на это нет никаких проверок?
В MR6Cv3 кстати нормально - видимо когда шаблон делали заметили и исправили, а остальные не поправили