### PR TITLE
Fix clang-tidy issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ debian/*.substvars
 debhelper-build-stamp
 .clang-format
 build
+compile_commands.json
 
 ### direnv ###
 .direnv

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,4 @@
 *.o
-wb-homa-gpio/wb-homa-gpio
-wb-mqtt-serial/wb-mqtt-serial
-wb-mqtt-serial/test/wb-homa-test
-wb-mqtt-serial/test/*.out
-wb-homa-ninja-bridge/wb-homa-ninja-bridge
-wb-homa-w1/wb-homa-w1
-wb-homa-adc/wb-homa-adc
-wb-mqtt-lirc/wb-mqtt-lirc
-mqtt-logger/mqtt-logger
-wb-homa-zway/wb-homa-zway
 test/wb-homa-test
 *.deb
 debian/files
@@ -21,11 +11,8 @@ debian/files
 *.debhelper
 debian/*.substvars
 debian/wb-mqtt-serial/
-debian/wb-homa-modbus/
 debian/tmp/
 .d
-wb-mqtt-serial/build
-wb-mqtt-serial
 vgcore.*
 test/*.out
 
@@ -61,11 +48,10 @@ workspace.xml
 
 debian/tmp
 debian/files
-debian/wb-homa-modbus
 debian/wb-mqtt-serial
 debian/*.substvars
 debhelper-build-stamp
-.clang-format
+.clang-*
 build
 compile_commands.json
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.108.7) stable; urgency=medium
+
+  * Fix clang-tidy issues
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 27 Dec 2023 18:00:00 +0400
+
 wb-mqtt-serial (2.108.6) stable; urgency=medium
 
   * Fix duplicated parameters for MR3, MR6C, MR6C-NC templates

--- a/src/bin_utils.h
+++ b/src/bin_utils.h
@@ -87,7 +87,7 @@ namespace BinUtils
     {
         for (size_t i = 0; i < byteCount; ++i) {
             *it = value & 0xFF;
-            value >>= 8;
+            value >>= 8; // NOLINT(clang-diagnostic-shift-count-overflow)
         }
     }
 

--- a/src/confed_schema_generator.cpp
+++ b/src/confed_schema_generator.cpp
@@ -315,11 +315,9 @@ namespace
         r["propertyOrder"] = propertyOrder;
 
         std::string format(deviceTemplate["ui_options"].get("channels_format", "default").asString());
-        bool tabs = deviceTemplate.isMember("groups");
+        bool tabs = true;
         if (format == "default") {
             tabs = std::any_of(channels.begin(), channels.end(), IsSubdeviceChannel);
-        } else {
-            tabs = true;
         }
 
         if (tabs) {

--- a/src/devices/curtains/dauerhaft_device.cpp
+++ b/src/devices/curtains/dauerhaft_device.cpp
@@ -29,9 +29,9 @@ namespace
     };
 
     const size_t MOTOR_STATUS_RESPONSE_SIZE = 10;
-    const size_t CURTAIN_MOTOR_STATUS_RESPONSE_SIZE = 9;
+    // const size_t CURTAIN_MOTOR_STATUS_RESPONSE_SIZE = 9;
     const size_t MOTOR_STATUS_POSITION_OFFSET = 7;
-    const size_t CURTAIN_MOTOR_STATUS_BITS_OFFSET = 8;
+    // const size_t CURTAIN_MOTOR_STATUS_BITS_OFFSET = 8;
 
     uint8_t CalcCrc(const std::vector<uint8_t>& bytes)
     {

--- a/src/file_descriptor_port.cpp
+++ b/src/file_descriptor_port.cpp
@@ -28,7 +28,7 @@ TFileDescriptorPort::TFileDescriptorPort(): Fd(-1)
 
 TFileDescriptorPort::~TFileDescriptorPort()
 {
-    if (IsOpen()) {
+    if (TFileDescriptorPort::IsOpen()) {
         close(Fd);
     }
 }

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -634,7 +634,8 @@ namespace Modbus // modbus protocol common utilities
         valueToWrite &= ~(GetLSBMask(reg.GetDataWidth()) << reg.GetDataOffset());
 
         // Place data
-        valueToWrite |= (value <<= reg.GetDataOffset());
+        value <<= reg.GetDataOffset();
+        valueToWrite |= value;
 
         for (size_t i = 0; i < widthInModbusWords; ++i) {
             address.Address = baseAddress + i;

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -32,7 +32,7 @@ namespace ModbusExt // modbus extension protocol declarations
     const size_t EVENT_HEADER_SIZE = 4;
     const size_t MIN_ENABLE_EVENTS_RESPONSE_SIZE = 6;
     const size_t MIN_ENABLE_EVENTS_REC_SIZE = 5;
-    const size_t EXCEPTION_SIZE = 5;
+    // const size_t EXCEPTION_SIZE = 5;
 
     const size_t EVENTS_REQUEST_MAX_BYTES = MAX_PACKET_SIZE - EVENTS_RESPONSE_HEADER_SIZE - CRC_SIZE;
     const size_t ARBITRATION_HEADER_MAX_BYTES = 32;
@@ -42,7 +42,7 @@ namespace ModbusExt // modbus extension protocol declarations
     const size_t SUB_COMMAND_POS = 2;
     const size_t EXCEPTION_CODE_POS = 2;
 
-    const size_t EVENTS_RESPONSE_SLAVE_ID_POS = 0;
+    // const size_t EVENTS_RESPONSE_SLAVE_ID_POS = 0;
     const size_t EVENTS_RESPONSE_CONFIRM_FLAG_POS = 3;
     const size_t EVENTS_RESPONSE_DATA_SIZE_POS = 5;
     const size_t EVENTS_RESPONSE_DATA_POS = 6;
@@ -56,9 +56,9 @@ namespace ModbusExt // modbus extension protocol declarations
     const size_t ENABLE_EVENTS_RESPONSE_DATA_SIZE_POS = 3;
     const size_t ENABLE_EVENTS_RESPONSE_DATA_POS = 4;
 
-    const size_t ENABLE_EVENTS_REC_TYPE_POS = 0;
-    const size_t ENABLE_EVENTS_REC_ADDR_POS = 1;
-    const size_t ENABLE_EVENTS_REC_STATE_POS = 3;
+    // const size_t ENABLE_EVENTS_REC_TYPE_POS = 0;
+    // const size_t ENABLE_EVENTS_REC_ADDR_POS = 1;
+    // const size_t ENABLE_EVENTS_REC_STATE_POS = 3;
 
     // max(3.5 symbols, (20 bits + 800us)) + 9 * max(13 bits, 12 bits + 50us)
     std::chrono::milliseconds GetTimeout(const TPort& port)

--- a/src/running_average.h
+++ b/src/running_average.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stddef.h>
 #include <stdint.h>
 
 template<class ValueType, size_t WindowSize> class TRunningAverage

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -15,9 +15,9 @@ namespace
     const auto PORT_OPEN_ERROR_NOTIFICATION_INTERVAL = 5min;
     const auto CLOSED_PORT_CYCLE_TIME = 500ms;
     const auto MAX_POLL_TIME = 100ms;
-    const auto MAX_FLUSHES_WHEN_POLL_IS_DUE = 20;
+    // const auto MAX_FLUSHES_WHEN_POLL_IS_DUE = 20;
     const auto BALANCING_THRESHOLD = 500ms;
-    const auto MIN_READ_EVENTS_TIME = 25ms;
+    // const auto MIN_READ_EVENTS_TIME = 25ms;
     const size_t MAX_EVENT_READ_ERRORS = 10;
 
     std::chrono::milliseconds GetReadEventsPeriod(const TPort& port)

--- a/src/serial_client_register_poller.cpp
+++ b/src/serial_client_register_poller.cpp
@@ -26,6 +26,7 @@ namespace
     public:
         TRegisterReader(milliseconds maxPollTime, bool readAtLeastOneRegister)
             : MaxPollTime(maxPollTime),
+              Priority(TPriority::Low),
               ReadAtLeastOneRegister(readAtLeastOneRegister)
         {}
 

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -855,11 +855,11 @@ TSubDevicesTemplateMap::TSubDevicesTemplateMap(const std::string& deviceType, co
         for (const auto& subdeviceTemplate: Templates) {
             for (const auto& ch: subdeviceTemplate.second.Schema["channels"]) {
                 if (ch.isMember("device_type")) {
-                    GetTemplate(ch["device_type"].asString());
+                    TSubDevicesTemplateMap::GetTemplate(ch["device_type"].asString());
                 }
                 if (ch.isMember("oneOf")) {
                     for (const auto& subdeviceType: ch["oneOf"]) {
-                        GetTemplate(subdeviceType.asString());
+                        TSubDevicesTemplateMap::GetTemplate(subdeviceType.asString());
                     }
                 }
             }

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -255,6 +255,7 @@ TUInt32SlaveId::TUInt32SlaveId(const std::string& slaveId, bool allowBroadcast):
 {
     if (allowBroadcast) {
         if (slaveId.empty()) {
+            SlaveId = 0;
             HasBroadcastSlaveId = true;
             return;
         }

--- a/src/tcp_port.cpp
+++ b/src/tcp_port.cpp
@@ -50,9 +50,9 @@ void TTcpPort::Open()
     }
 
     struct sockaddr_in serv_addr;
-    bzero((char*)&serv_addr, sizeof(serv_addr));
+    memset((char*)&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
-    bcopy((char*)server->h_addr, (char*)&serv_addr.sin_addr.s_addr, server->h_length);
+    memmove((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr, server->h_length);
     serv_addr.sin_port = htons(Settings.Port);
 
     // set socket to non-blocking state

--- a/test/expressions_test.cpp
+++ b/test/expressions_test.cpp
@@ -151,12 +151,12 @@ TEST_F(TExpressionsTest, Eval)
     TParams params;
     TParser parser;
     for (const auto& expr: trueExpressions) {
-        bool res;
+        bool res = false;
         ASSERT_NO_THROW(res = Eval(parser.Parse(expr).get(), params)) << expr;
         ASSERT_TRUE(res) << expr;
     }
     for (const auto& expr: falseExpressions) {
-        bool res;
+        bool res = true;
         ASSERT_NO_THROW(res = Eval(parser.Parse(expr).get(), params)) << expr;
         ASSERT_FALSE(res) << expr;
     }

--- a/test/poll_test.cpp
+++ b/test/poll_test.cpp
@@ -41,6 +41,8 @@ namespace
               TimeMock(timeMock)
         {}
 
+        using TFakeSerialPort::Expect;
+
         void Expect(const std::vector<int>& request,
                     const std::vector<int>& response,
                     const char* func,
@@ -74,7 +76,7 @@ namespace
 class TPollTest: public TLoggedFixture, public TModbusExpectationsBase
 {
 public:
-    void SetUp()
+    void SetUp() override
     {
         TLoggedFixture::SetUp();
         TimeMock.Reset();
@@ -83,7 +85,7 @@ public:
         Port->Open();
     }
 
-    void TearDown()
+    void TearDown() override
     {
         Port->Close();
         TLoggedFixture::TearDown();


### PR DESCRIPTION
How-to:
```sh
# Generate compile_commands.json
$ bear -- make test
$ find src -name '*.cpp' -o -name '*.h' | xargs clang-tidy -p .
...
src/bin_utils.h:90:19: warning: shift count >= width of type [clang-diagnostic-shift-count-overflow]
            value >>= 8;
                  ^   ~
src/modbus_ext_common.cpp:100:9: note: in instantiation of function template specialization 'BinUtils::Append<std::back_insert_iterator<std::vector<unsigned char>>, unsigned char>' requested here
        Append(it, startingSlaveId);
        ^
src/running_average.h:4:27: error: unknown type name 'size_t' [clang-diagnostic-error]
template<class ValueType, size_t WindowSize> class TRunningAverage
                          ^
src/confed_schema_generator.cpp:318:14: warning: Value stored to 'tabs' during its initialization is never read [clang-analyzer-deadcode.DeadStores]
        bool tabs = deviceTemplate.isMember("groups");
             ^~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/confed_schema_generator.cpp:318:14: note: Value stored to 'tabs' during its initialization is never read
        bool tabs = deviceTemplate.isMember("groups");
             ^~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/devices/curtains/dauerhaft_device.cpp:32:18: warning: unused variable 'CURTAIN_MOTOR_STATUS_RESPONSE_SIZE' [clang-diagnostic-unused-const-variable]
    const size_t CURTAIN_MOTOR_STATUS_RESPONSE_SIZE = 9;
                 ^
src/devices/curtains/dauerhaft_device.cpp:34:18: warning: unused variable 'CURTAIN_MOTOR_STATUS_BITS_OFFSET' [clang-diagnostic-unused-const-variable]
    const size_t CURTAIN_MOTOR_STATUS_BITS_OFFSET = 8;
                 ^
src/file_descriptor_port.cpp:31:9: warning: Call to virtual method 'TFileDescriptorPort::IsOpen' during destruction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
    if (IsOpen()) {
        ^~~~~~~~
src/file_descriptor_port.cpp:31:9: note: Call to virtual method 'TFileDescriptorPort::IsOpen' during destruction bypasses virtual dispatch
    if (IsOpen()) {
        ^~~~~~~~
src/modbus_common.cpp:637:26: warning: Although the value stored to 'value' is used in the enclosing expression, the value is never actually read from 'value' [clang-analyzer-deadcode.DeadStores]
        valueToWrite |= (value <<= reg.GetDataOffset());
                         ^         ~~~~~~~~~~~~~~~~~~~
src/modbus_common.cpp:637:26: note: Although the value stored to 'value' is used in the enclosing expression, the value is never actually read from 'value'
        valueToWrite |= (value <<= reg.GetDataOffset());
                         ^         ~~~~~~~~~~~~~~~~~~~
src/modbus_ext_common.cpp:35:18: warning: unused variable 'EXCEPTION_SIZE' [clang-diagnostic-unused-const-variable]
    const size_t EXCEPTION_SIZE = 5;
                 ^
src/modbus_ext_common.cpp:45:18: warning: unused variable 'EVENTS_RESPONSE_SLAVE_ID_POS' [clang-diagnostic-unused-const-variable]
    const size_t EVENTS_RESPONSE_SLAVE_ID_POS = 0;
                 ^
src/modbus_ext_common.cpp:59:18: warning: unused variable 'ENABLE_EVENTS_REC_TYPE_POS' [clang-diagnostic-unused-const-variable]
    const size_t ENABLE_EVENTS_REC_TYPE_POS = 0;
                 ^
src/modbus_ext_common.cpp:60:18: warning: unused variable 'ENABLE_EVENTS_REC_ADDR_POS' [clang-diagnostic-unused-const-variable]
    const size_t ENABLE_EVENTS_REC_ADDR_POS = 1;
                 ^
src/modbus_ext_common.cpp:61:18: warning: unused variable 'ENABLE_EVENTS_REC_STATE_POS' [clang-diagnostic-unused-const-variable]
    const size_t ENABLE_EVENTS_REC_STATE_POS = 3;
                 ^
src/serial_client.cpp:18:16: warning: unused variable 'MAX_FLUSHES_WHEN_POLL_IS_DUE' [clang-diagnostic-unused-const-variable]
    const auto MAX_FLUSHES_WHEN_POLL_IS_DUE = 20;
               ^
src/serial_client.cpp:20:16: warning: unused variable 'MIN_READ_EVENTS_TIME' [clang-diagnostic-unused-const-variable]
    const auto MIN_READ_EVENTS_TIME = 25ms;
               ^
src/serial_client_register_poller.cpp:29:38: warning: 1 uninitialized field at the end of the constructor call [clang-analyzer-optin.cplusplus.UninitializedObject]
              ReadAtLeastOneRegister(readAtLeastOneRegister)
                                     ^
src/serial_client_register_poller.cpp:23:19: note: uninitialized field 'this->Priority'
        TPriority Priority;
                  ^~~~~~~~
src/serial_client_register_poller.cpp:150:21: note: Calling constructor for 'TRegisterReader'
    TRegisterReader reader(maxPollingTime, readAtLeastOneRegister);
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_client_register_poller.cpp:29:38: note: 1 uninitialized field at the end of the constructor call
              ReadAtLeastOneRegister(readAtLeastOneRegister)
                                     ^~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:858:21: warning: Call to virtual method 'TSubDevicesTemplateMap::GetTemplate' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
                    GetTemplate(ch["device_type"].asString());
                    ^
src/serial_config.cpp:776:47: note: Left side of '&&' is false
    if (Get(root, "deprecated", isDeprecated) && isDeprecated) {
                                              ^
src/serial_config.cpp:776:5: note: Taking false branch
    if (Get(root, "deprecated", isDeprecated) && isDeprecated) {
    ^
src/serial_config.cpp:787:9: note: Assuming the condition is true
    if (root["device"].isMember("subdevices")) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:787:5: note: Taking true branch
    if (root["device"].isMember("subdevices")) {
    ^
src/serial_config.cpp:788:32: note: Calling constructor for 'TSubDevicesTemplateMap'
        TSubDevicesTemplateMap subdevices(deviceType, root["device"]);
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:851:9: note: Assuming the condition is true
    if (device.isMember("subdevices")) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:851:5: note: Taking true branch
    if (device.isMember("subdevices")) {
    ^
src/serial_config.cpp:857:21: note: Assuming the condition is true
                if (ch.isMember("device_type")) {
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:857:17: note: Taking true branch
                if (ch.isMember("device_type")) {
                ^
src/serial_config.cpp:858:21: note: Call to virtual method 'TSubDevicesTemplateMap::GetTemplate' during construction bypasses virtual dispatch
                    GetTemplate(ch["device_type"].asString());
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:862:25: warning: Call to virtual method 'TSubDevicesTemplateMap::GetTemplate' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
                        GetTemplate(subdeviceType.asString());
                        ^
src/serial_config.cpp:776:47: note: Left side of '&&' is false
    if (Get(root, "deprecated", isDeprecated) && isDeprecated) {
                                              ^
src/serial_config.cpp:776:5: note: Taking false branch
    if (Get(root, "deprecated", isDeprecated) && isDeprecated) {
    ^
src/serial_config.cpp:787:9: note: Assuming the condition is true
    if (root["device"].isMember("subdevices")) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:787:5: note: Taking true branch
    if (root["device"].isMember("subdevices")) {
    ^
src/serial_config.cpp:788:32: note: Calling constructor for 'TSubDevicesTemplateMap'
        TSubDevicesTemplateMap subdevices(deviceType, root["device"]);
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:851:9: note: Assuming the condition is true
    if (device.isMember("subdevices")) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:851:5: note: Taking true branch
    if (device.isMember("subdevices")) {
    ^
src/serial_config.cpp:857:21: note: Assuming the condition is false
                if (ch.isMember("device_type")) {
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:857:17: note: Taking false branch
                if (ch.isMember("device_type")) {
                ^
src/serial_config.cpp:860:21: note: Assuming the condition is true
                if (ch.isMember("oneOf")) {
                    ^~~~~~~~~~~~~~~~~~~~
src/serial_config.cpp:860:17: note: Taking true branch
                if (ch.isMember("oneOf")) {
                ^
src/serial_config.cpp:862:25: note: Call to virtual method 'TSubDevicesTemplateMap::GetTemplate' during construction bypasses virtual dispatch
                        GetTemplate(subdeviceType.asString());
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_device.cpp:259:13: warning: 1 uninitialized field at the end of the constructor call [clang-analyzer-optin.cplusplus.UninitializedObject]
            return;
            ^
src/serial_device.h:160:14: note: uninitialized field 'this->SlaveId'
    uint32_t SlaveId;
             ^~~~~~~
src/serial_device.cpp:44:13: note: Calling constructor for 'TUInt32SlaveId'
    return (TUInt32SlaveId(id1, AllowBroadcast) == TUInt32SlaveId(id2, AllowBroadcast));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/serial_device.cpp:256:9: note: Assuming 'allowBroadcast' is true
    if (allowBroadcast) {
        ^~~~~~~~~~~~~~
src/serial_device.cpp:256:5: note: Taking true branch
    if (allowBroadcast) {
    ^
src/serial_device.cpp:257:13: note: Assuming the condition is true
        if (slaveId.empty()) {
            ^~~~~~~~~~~~~~~
src/serial_device.cpp:257:9: note: Taking true branch
        if (slaveId.empty()) {
        ^
src/serial_device.cpp:259:13: note: 1 uninitialized field at the end of the constructor call
            return;
            ^~~~~~
src/tcp_port.cpp:53:5: warning: The bzero() function is obsoleted by memset() [clang-analyzer-security.insecureAPI.bzero]
    bzero((char*)&serv_addr, sizeof(serv_addr));
    ^~~~~
src/tcp_port.cpp:53:5: note: The bzero() function is obsoleted by memset()
    bzero((char*)&serv_addr, sizeof(serv_addr));
    ^~~~~
src/tcp_port.cpp:55:5: warning: The bcopy() function is obsoleted by memcpy() or memmove() [clang-analyzer-security.insecureAPI.bcopy]
    bcopy((char*)server->h_addr, (char*)&serv_addr.sin_addr.s_addr, server->h_length);
    ^~~~~
src/tcp_port.cpp:55:5: note: The bcopy() function is obsoleted by memcpy() or memmove()
    bcopy((char*)server->h_addr, (char*)&serv_addr.sin_addr.s_addr, server->h_length);
    ^~~~~
...
$ find test -name '*.cpp' -o -name '*.h' | xargs clang-tidy -p .
...
test/expressions_test.cpp:160:9: warning: variable 'res' is used uninitialized whenever 'if' condition is false [clang-diagnostic-sometimes-uninitialized]
        ASSERT_NO_THROW(res = Eval(parser.Parse(expr).get(), params)) << expr;
        ^
...
test/expressions_test.cpp:160:9: note: remove the 'if' if its condition is always true
        ASSERT_NO_THROW(res = Eval(parser.Parse(expr).get(), params)) << expr;
        ^
...
test/expressions_test.cpp:159:17: note: initialize the variable 'res' to silence this warning
        bool res;
                ^
                 = false
test/poll_test.cpp:44:14: warning: '(anonymous namespace)::TFakeSerialPortWithTime::Expect' hides overloaded virtual function [clang-diagnostic-overloaded-virtual]
        void Expect(const std::vector<int>& request,
             ^
test/fake_serial_port.h:47:10: note: hidden overloaded virtual function 'TFakeSerialPort::Expect' declared here: different number of parameters (3 vs 4)
    void Expect(const std::vector<int>& request, const std::vector<int>& response, const char* func = 0) override;
         ^
test/poll_test.cpp:77:10: warning: 'SetUp' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
    void SetUp()
         ^
libwbmqtt1-4.3.5/include/wblib/testing/testlog.h:80:18: note: overridden virtual function is here
            void SetUp() override;
                 ^
test/poll_test.cpp:86:10: warning: 'TearDown' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
    void TearDown()
         ^
libwbmqtt1-4.3.5/include/wblib/testing/testlog.h:81:18: note: overridden virtual function is here
            void TearDown() override;
                 ^
...
```