### PR TITLE
Fix publishing period if publish unchanged values is allowed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.112.1) stable; urgency=medium
+
+  * Fix publishing period if publish unchanged values is allowed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 13 Mar 2024 17:20:25 +0500
+
 wb-mqtt-serial (2.112.0) stable; urgency=medium
 
   * Add support for enums in templates

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
         // A timer in the application allow publishing, but lib's timer can be not expired and can reject it.
         // Real publish will occur only on next application's timer expiration
         // Set publish policy in libwbmqtt1 to PublishAll to disable its timer
-        WBMQTT::TPublishParameters driverPublishParameters = handlerConfig->PublishParameters;
+        auto driverPublishParameters = handlerConfig->PublishParameters;
         if (driverPublishParameters.Policy == WBMQTT::TPublishParameters::PublishSomeUnchanged) {
             driverPublishParameters.Policy = WBMQTT::TPublishParameters::PublishAll;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -298,13 +298,24 @@ int main(int argc, char* argv[])
 
         auto mqtt = WBMQTT::NewMosquittoMqttClient(mqttConfig);
         auto backend = WBMQTT::NewDriverBackend(mqtt);
+
+        // Publishing strategy is implemented both in libwbmqtt1 and in the application
+        // This results to a race condition with WBMQTT::TPublishParameters::PublishSomeUnchanged policy
+        // The application and libwbmqtt1 has own timers that are not in sinc
+        // A timer in the application allow publishing, but lib's timer can be not expired and can reject it.
+        // Real publish will occur only on next application's timer expiration
+        // Set publish policy in libwbmqtt1 to PublishAll to disable its timer
+        WBMQTT::TPublishParameters driverPublishParameters = handlerConfig->PublishParameters;
+        if (driverPublishParameters.Policy == WBMQTT::TPublishParameters::PublishSomeUnchanged) {
+            driverPublishParameters.Policy = WBMQTT::TPublishParameters::PublishAll;
+        }
         auto driver = WBMQTT::NewDriver(WBMQTT::TDriverArgs{}
                                             .SetId(driverName)
                                             .SetBackend(backend)
                                             .SetUseStorage(true)
                                             .SetReownUnknownDevices(true)
                                             .SetStoragePath(LIBWBMQTT_DB_FULL_FILE_PATH),
-                                        handlerConfig->PublishParameters);
+                                        driverPublishParameters);
 
         auto rpcServer(WBMQTT::NewMqttRpcServer(mqtt, APP_NAME));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,7 +301,7 @@ int main(int argc, char* argv[])
 
         // Publishing strategy is implemented both in libwbmqtt1 and in the application
         // This results to a race condition with WBMQTT::TPublishParameters::PublishSomeUnchanged policy
-        // The application and libwbmqtt1 has own timers that are not in sinc
+        // The application and libwbmqtt1 has own timers that are not in sync
         // A timer in the application allow publishing, but lib's timer can be not expired and can reject it.
         // Real publish will occur only on next application's timer expiration
         // Set publish policy in libwbmqtt1 to PublishAll to disable its timer


### PR DESCRIPTION
Логика публикации неизменившихся значений реализована и в wb-mqtt-serial, и в libwbmtt1. Это сделано, чтобы не дёргать либу на каждый чих, т.к. она жрёт ресурсы. Если настроена публикация неизменившихся значений раз в заданный интервал, то создаются 2 таймера: в либе и в wb-mqtt-serial. Может произойти такая ситуация, что таймер в wb-mqtt-serial позволяет публиковать, а таймер в либе ещё нет. Тогда реальная публикация произойдёт только при следующем истечении таймера в wb-mqtt-serial.  