### PR TITLE
Bugfix/mao4 template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.117.1) stable; urgency=medium
+
+  * Fix WB-MAO4 template compability with old configs
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.ru>  Wed, 03 Apr 2024 16:42:54 +0300
+
 wb-mqtt-serial (2.117.0) stable; urgency=medium
 
   * Start service with invalid config to provide functions for wb-mqtt-homeui

--- a/templates/config-wb-mao4.json.jinja
+++ b/templates/config-wb-mao4.json.jinja
@@ -289,7 +289,6 @@
                     "Switch"
                 ],
                 "default": 0,
-                "required": true,
                 "group": "input_{{ch_number + 1}}"
             },
             {
@@ -302,7 +301,7 @@
                 "min": 500,
                 "max": 5000,
                 "group": "input_{{ch_number + 1}}_parameters",
-                "condition": "input_{{ch_number + 1}}_mode==0",
+                "condition": "input_{{ch_number + 1}}_mode!=1",
                 "order": 1
             },
             {
@@ -315,7 +314,7 @@
                 "min": 0,
                 "max": 2000,
                 "group": "input_{{ch_number + 1}}_parameters",
-                "condition": "input_{{ch_number + 1}}_mode==0",
+                "condition": "input_{{ch_number + 1}}_mode!=1",
                 "order": 2
             },
             {
@@ -351,7 +350,7 @@
                 ],
                 "default": 0,
                 "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_')}}_press_action",
-                "condition": "input_{{ch_number + 1}}_mode==0",
+                "condition": "input_{{ch_number + 1}}_mode!=1",
                 "order": 1
             },
             {


### PR DESCRIPTION
Оказалось, что нельзя делать новые параметры с `"required": true`, это ломает обратную совместимость конфига. serial не стартует со старым конфигом, где нет новых параметров