### PR TITLE
Fix SOKOL-M template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.118.2) stable; urgency=medium
+
+  * Fix SOKOL-M template
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 12 Apr 2024 12:18:14 +0500
+
 wb-mqtt-serial (2.118.1) stable; urgency=medium
 
   * Add protocol information to config loading RPC request

--- a/templates/config-sokol-m.json
+++ b/templates/config-sokol-m.json
@@ -14,7 +14,6 @@
                 "format": "u16",
                 "address": 3,
                 "type": "temperature",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -25,7 +24,6 @@
                 "format": "u16",
                 "address": 4,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -35,7 +33,6 @@
                 "format": "u16",
                 "address": 5,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -46,7 +43,6 @@
                 "format": "u16",
                 "address": 6,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -56,7 +52,6 @@
                 "format": "u16",
                 "address": 7,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -67,7 +62,6 @@
                 "format": "u16",
                 "address": 8,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -76,7 +70,6 @@
                 "format": "u16",
                 "address": 9,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -87,7 +80,6 @@
                 "format": "u16",
                 "address": 10,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -97,7 +89,6 @@
                 "format": "u16",
                 "address": 11,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -106,7 +97,6 @@
                 "format": "u16",
                 "address": 12,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -115,7 +105,6 @@
                 "format": "u16",
                 "address": 13,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -124,7 +113,6 @@
                 "format": "u16",
                 "address": 70,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -133,7 +121,6 @@
                 "format": "u16",
                 "address": 71,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -142,7 +129,6 @@
                 "format": "u16",
                 "address": 72,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -151,7 +137,6 @@
                 "format": "u16",
                 "address": 73,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -160,7 +145,6 @@
                 "format": "u16",
                 "address": 74,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -169,7 +153,6 @@
                 "format": "u16",
                 "address": 75,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -178,7 +161,6 @@
                 "format": "u16",
                 "address": 76,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -187,7 +169,6 @@
                 "format": "u16",
                 "address": 77,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -196,7 +177,6 @@
                 "format": "u16",
                 "address": 78,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -205,7 +185,6 @@
                 "format": "u16",
                 "address": 79,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             },
             {
@@ -214,7 +193,6 @@
                 "format": "u16",
                 "address": 80,
                 "type": "value",
-                "group": "channels",
                 "readonly": true
             }
         ],


### PR DESCRIPTION
В шаблоне использовались группы, которые не были объявлены. Старым версия wb-mqtt-homeui было плохо от такого. Быдем делать бэкпорт в wb-2401