### PR TITLE
Add MQTT topic id to config/Load RPC response

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.121.0) stable; urgency=medium
+
+  * Add MQTT topic id to config/Load RPC response
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 26 Apr 2024 12:27:27 +0500
+
 wb-mqtt-serial (2.120.3) stable; urgency=medium
 
   * Add device signature to MAP3E, MAP3ET, MAP3EV templates

--- a/src/rpc_config_handler.cpp
+++ b/src/rpc_config_handler.cpp
@@ -28,6 +28,7 @@ namespace
         res["deprecated"] = dt->IsDeprecated();
         res["type"] = dt->Type;
         res["protocol"] = dt->GetProtocol();
+        res["mqtt-id"] = dt->GetMqttId();
         if (!dt->GetHardware().empty()) {
             auto& hwJsonArray = MakeArray("hw", res);
             for (const auto& hw: dt->GetHardware()) {

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -69,6 +69,7 @@ PDeviceTemplate TTemplateMap::MakeTemplateFromJson(const Json::Value& data, cons
         }
         deviceTemplate->SetHardware(hws);
     }
+    deviceTemplate->SetMqttId(data["device"].get("id", "").asString());
     return deviceTemplate;
 }
 
@@ -281,6 +282,15 @@ const std::string& TDeviceTemplate::GetProtocol() const
     return Protocol;
 }
 
+void TDeviceTemplate::SetMqttId(const std::string& id)
+{
+    MqttId = id;
+}
+
+const std::string& TDeviceTemplate::GetMqttId() const
+{
+    return MqttId;
+}
 //=============================================================================
 //                          TSubDevicesTemplateMap
 //=============================================================================

--- a/src/templates_map.h
+++ b/src/templates_map.h
@@ -23,6 +23,7 @@ struct TDeviceTemplate
     void SetGroup(const std::string& group);
     void SetTitle(const std::unordered_map<std::string, std::string>& translations);
     void SetHardware(const std::vector<TDeviceTemplateHardware>& hardware);
+    void SetMqttId(const std::string& id);
 
     std::string GetTitle(const std::string& lang = std::string("en")) const;
     const Json::Value& GetTemplate();
@@ -32,6 +33,7 @@ struct TDeviceTemplate
     bool IsDeprecated() const;
     bool WithSubdevices() const;
     const std::string& GetProtocol() const;
+    const std::string& GetMqttId() const;
 
 private:
     std::unordered_map<std::string, std::string> Title;
@@ -43,6 +45,7 @@ private:
     Json::Value Template;
     bool Subdevices;
     std::string Protocol;
+    std::string MqttId;
 };
 
 typedef std::shared_ptr<TDeviceTemplate> PDeviceTemplate;


### PR DESCRIPTION
Передю идентификатор mqtt топика по умолчанию. Это нужно для организации на фронте проверки того, что топики у разных устройств не совпадают