### PR TITLE
Fix clearing read error on sporadic registers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.121.3) stable; urgency=medium
+
+  * Fixed a crash caused by receiving a large number of incorrect Modbus packets
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 14 May 2024 18:26:13 +0500
+
 wb-mqtt-serial (2.121.2) stable; urgency=medium
 
   * Add more verbose internal errors. No functional changes

--- a/src/serial_client_register_poller.cpp
+++ b/src/serial_client_register_poller.cpp
@@ -105,6 +105,11 @@ void TSerialClientRegisterPoller::PrepareRegisterRanges(const std::list<PRegiste
 void TSerialClientRegisterPoller::ScheduleNextPoll(PRegister reg, steady_clock::time_point pollStartTime)
 {
     if (reg->IsExcludedFromPolling()) {
+        // If register is sporadic it must be read once to get actual value
+        // Keep polling it until successful read
+        if (reg->GetValue().GetType() == TRegisterValue::ValueType::Undefined) {
+            Scheduler.AddEntry(reg, pollStartTime + 1us, reg->IsHighPriority() ? TPriority::High : TPriority::Low);
+        }
         return;
     }
     if (reg->IsHighPriority()) {

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -255,6 +255,7 @@ void TDeviceChannel::UpdateValueAndError(WBMQTT::TDeviceDriver& deviceDriver,
             LOG(Debug) << "Trying to publish " << Describe() << " with undefined value";
         }
         UpdateError(deviceDriver);
+        return;
     }
     auto error = GetErrorText();
     bool errorIsChanged = (CachedErrorText != error);


### PR DESCRIPTION
* Reschedule sporadic registers reading on errors. The register must be read before excluding from polling. If not, current register's value will be undefined
* Handle undefined value, when clearing sporadic register read error
 
https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/74538/

Было 2 проблемы:
1. Регистры с событиями должны опрашиваться один раз, чтобы получить актуальное значение. Потом они исключаются из опроса, и значения меняются только по событию. Если при этом первом опросе возникала ошибка, регистр повторно не опрашивался, и его значение в программе было `Undefined`.
2. События включаются для всех регистров устройства, начинается запрос событий. Если запрос событий 10 раз подряд завершается с ошибкой, все регистры с событиями помечаются ошибкой чтения. Если потом чтение событий проходит хоть раз без ошибок, эти ошибки чтения снимаются. При снятии ошибки чтения публикуется /meta/error и значение регистра. Но регистры могут быть ещё не вычитаны первый раз. Код пытается сконвертировать `Undefined` в текст и получает исключение, которое нигде не ловится. Программа падает. п.1 усугубляет ситуацию