### PR TITLE
Fix clearing read error on sporadic registers (#742)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.117.2-wb100) stable; urgency=medium
+
+  * Fixed a crash caused by receiving a large number of incorrect Modbus packets
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 17 May 2024 10:31:04 +0500
+
 wb-mqtt-serial (2.117.2) stable; urgency=medium
 
   * Dauerhaft Roll 35/45: fix template

--- a/src/serial_client_register_poller.cpp
+++ b/src/serial_client_register_poller.cpp
@@ -105,6 +105,11 @@ void TSerialClientRegisterPoller::PrepareRegisterRanges(const std::list<PRegiste
 void TSerialClientRegisterPoller::ScheduleNextPoll(PRegister reg, steady_clock::time_point pollStartTime)
 {
     if (reg->IsExcludedFromPolling()) {
+        // If register is sporadic it must be read once to get actual value
+        // Keep polling it until successful read
+        if (reg->GetValue().GetType() == TRegisterValue::ValueType::Undefined) {
+            Scheduler.AddEntry(reg, pollStartTime + 1us, reg->IsHighPriority() ? TPriority::High : TPriority::Low);
+        }
         return;
     }
     if (reg->IsHighPriority()) {

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -244,7 +244,19 @@ PSerialClient TSerialPortDriver::GetSerialClient()
 void TDeviceChannel::UpdateValueAndError(WBMQTT::TDeviceDriver& deviceDriver,
                                          const WBMQTT::TPublishParameters& publishPolicy)
 {
-    auto value = GetTextValue();
+    std::string value;
+    try {
+        value = GetTextValue();
+    } catch (const TRegisterValueException& err) {
+        // Register value is not defined, still able to update error
+        // This can happen on successful events read after unsuccessful events read
+        // when some registers aren't yet polled for the first time
+        if (::Debug.IsEnabled()) {
+            LOG(Debug) << "Trying to publish " << Describe() << " with undefined value";
+        }
+        UpdateError(deviceDriver);
+        return;
+    }
     auto error = GetErrorText();
     bool errorIsChanged = (CachedErrorText != error);
     switch (publishPolicy.Policy) {


### PR DESCRIPTION
* Reschedule sporadic registers reading on errors. The register must be read before excluding from polling. If not, current register's value will be undefined
* Handle undefined value, when clearing sporadic register read error

Backport of https://github.com/wirenboard/wb-mqtt-serial/pull/742