### PR TITLE
Add missed wb-utils dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.123.1) stable; urgency=medium
+
+  * Add missed wb-utils dependency, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 22 May 2024 15:10:00 +0400
+
 wb-mqtt-serial (2.123.0) stable; urgency=medium
 
   * Add min_request_interval option to device config. 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-5 (>= 5.0.0~~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-5 (>= 5.0.0~~), wb-utils
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.82.0~~)


### PR DESCRIPTION
`/usr/lib/wb-utils/wb_env.sh` используется в postinst скрипте.