### PR TITLE
Show template validation errors in log

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.123.2) stable; urgency=medium
+
+  * Show template validation errors in log
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 27 May 2024 14:48:37 +0500
+
 wb-mqtt-serial (2.123.1) stable; urgency=medium
 
   * Add missed wb-utils dependency, no functional changes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,7 +266,7 @@ namespace
                     confedSchemasMap.InvalidateCache(deviceType);
                 }
             } catch (const exception& e) {
-                LOG(Debug) << "Failed to reload template: " << e.what();
+                LOG(Error) << "Failed to reload template: " << e.what();
             }
             return;
         }

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -129,12 +129,12 @@ std::vector<std::string> TTemplateMap::UpdateTemplate(const std::string& path)
     if (!EndsWith(path, ".json")) {
         return res;
     }
-    auto deviceTemplate = MakeTemplateFromJson(WBMQTT::JSON::Parse(path), path);
     std::unique_lock m(Mutex);
     auto deletedType = DeleteTemplateUnsafe(path);
     if (!deletedType.empty()) {
         res.push_back(deletedType);
     }
+    auto deviceTemplate = MakeTemplateFromJson(WBMQTT::JSON::Parse(path), path);
     auto& typeArray = Templates.try_emplace(deviceTemplate->Type, std::vector<PDeviceTemplate>{}).first->second;
     if (!PreferredTemplatesDir.empty() && WBMQTT::StringStartsWith(path, PreferredTemplatesDir)) {
         typeArray.push_back(deviceTemplate);


### PR DESCRIPTION
* show errors in log if template became invalid after changing
* fix deletion of invalid templates from cache

Выводим ошибки разбора шаблона в лог.

При получении события об изменении шаблона сначала чистим кэш, потом пытаемся прочитать новый шаблон. Раньше сначала пытались читать. В результате старый шаблон оставался в кэше, т.к. процедура выкидывала исключение до шага очиски кэша.