### PR TITLE
Fix json-schema generation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.125.1) stable; urgency=medium
+
+  * Fix WB-MAI6 configuration interface
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 10 Jun 2024 17:18:03 +0500
+
 wb-mqtt-serial (2.125.0) stable; urgency=medium
 
   * WB-MDM3 template: add light scenes, switch mode, safety and powerup actions support

--- a/src/confed_schema_generator_with_groups.cpp
+++ b/src/confed_schema_generator_with_groups.cpp
@@ -84,7 +84,7 @@ namespace
         SetAndRemoveIfExists(newProp, prop, "propertyOrder");
         SetAndRemoveIfExists(newProp, prop, "title");
         SetAndRemoveIfExists(newProp, prop, "requiredProp");
-        if (prop.isMember("options")) {
+        if (prop.isMember("options") && prop["options"].isMember("show_opt_in")) {
             SetAndRemoveIfExists(newProp["options"], prop["options"], "show_opt_in");
             if (prop["options"].empty()) {
                 prop.removeMember("options");


### PR DESCRIPTION
Remove null options properties

При вызове `SetAndRemoveIfExists(newProp["options"], prop["options"], "show_opt_in")` создаются null-свойства `options` у `newProp` и `prop`. `prop` потом чистится, если в нём ничего нет, а `newProp` может так и остаться. Это попадает в схему, и json-editor давится на `options: null`. Добавил проверку, чтоб не оставлять таких свойств.