### PR TITLE
Add IR indirect control registers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-wb-mqtt-serial (2.130.1) stable; urgency=medium
+wb-mqtt-serial (2.130.2) stable; urgency=medium
+
+  * Add indirect control channels for WB-MSW-v3/v4/v4-lora and WB-MIR-v2
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 10 Jul 2024 16:52:00 +0300
+ 
+ wb-mqtt-serial (2.130.1) stable; urgency=medium
 
   * Fix a type in WB-Domofon template
 

--- a/templates/config-wb-mir_v2.json
+++ b/templates/config-wb-mir_v2.json
@@ -1291,6 +1291,33 @@
                 "group": "ir_commands"
             },
             {
+                "name": "Play from BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5500,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "BANK -> RAM",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5501,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "Learn to BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5502,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
                 "name": "Input 1",
                 "id": "",
                 "oneOf": [
@@ -1565,6 +1592,9 @@
                 "Play from ROM39": "Воспроизвести команду из ROM39",
                 "Play from ROM40": "Воспроизвести команду из ROM40",
                 "Reset all ROM": "Стереть все команды в ROM",
+                "Play from BANK": "Воспроизвести команду из соответствующего банка ROM",
+                "BANK -> RAM":"Редактирование ИК-команд в банке с копированием в RAM",
+                "Learn to BANK": "Записать команду в соответствующий банк ROM",
                 "Input 1": "Вход 1",
                 "Serial NO": "Серийный номер",
                 "FW Version": "Версия прошивки",

--- a/templates/config-wb-msw_v3.json
+++ b/templates/config-wb-msw_v3.json
@@ -1342,6 +1342,33 @@
                 "group": "ir_commands"
             },
             {
+                "name": "Play from BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5500,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "BANK -> RAM",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5501,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "Learn to BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5502,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
                 "name": "Serial",
                 "type": "text",
                 "reg_type": "input",
@@ -1729,6 +1756,9 @@
                 "Play from ROM31": "Воспроизвести команду из ROM31",
                 "Play from ROM32": "Воспроизвести команду из ROM32",
                 "Reset all ROM": "Стереть все команды в ROM",
+                "Play from BANK": "Воспроизвести команду из соответствующего банка ROM",
+                "BANK -> RAM":"Редактирование ИК-команд в банке с копированием в RAM",
+                "Learn to BANK": "Записать команду в соответствующий банк ROM",
                 "Serial": "Серийный номер",
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",

--- a/templates/config-wb-msw_v4.json
+++ b/templates/config-wb-msw_v4.json
@@ -14,7 +14,6 @@
         "response_timeout_ms": 1,
         "frame_timeout_ms": 0,
         "enable_wb_continuous_read": true,
-
         "groups": [
             {
                 "title": "Air Quality",
@@ -53,14 +52,19 @@
                 "id": "debug"
             }
         ],
-
         "parameters": {
             "co2_sensor_enabled": {
                 "title": "CO₂ Sensor Enabled",
                 "address": 3,
                 "reg_type": "coil",
-                "enum": [0, 1],
-                "enum_titles": ["no", "yes"],
+                "enum": [
+                    0,
+                    1
+                ],
+                "enum_titles": [
+                    "no",
+                    "yes"
+                ],
                 "default": 1,
                 "group": "air_quality",
                 "order": 1
@@ -69,8 +73,14 @@
                 "title": "CO₂ Baseline Calibration",
                 "address": 95,
                 "reg_type": "holding",
-                "enum": [0, 1],
-                "enum_titles": ["off", "automatic"],
+                "enum": [
+                    0,
+                    1
+                ],
+                "enum_titles": [
+                    "off",
+                    "automatic"
+                ],
                 "default": 1,
                 "group": "air_quality",
                 "order": 2
@@ -109,7 +119,13 @@
                 "description": "baud_rate_description",
                 "address": 110,
                 "reg_type": "holding",
-                "enum": [96, 192, 384, 576, 1152],
+                "enum": [
+                    96,
+                    192,
+                    384,
+                    576,
+                    1152
+                ],
                 "default": 96,
                 "enum_titles": [
                     "9600",
@@ -133,14 +149,19 @@
                 "title": "Status LED",
                 "address": 130,
                 "reg_type": "holding",
-                "enum": [0, 1],
-                "enum_titles": ["Enabled", "Disabled"],
+                "enum": [
+                    0,
+                    1
+                ],
+                "enum_titles": [
+                    "Enabled",
+                    "Disabled"
+                ],
                 "default": 0,
                 "group": "general",
                 "order": 3
             }
         },
-
         "channels": [
             {
                 "name": "Temperature",
@@ -1295,6 +1316,33 @@
                 "group": "ir_commands"
             },
             {
+                "name": "Play from BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5500,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "BANK -> RAM",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5501,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "Learn to BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5502,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
                 "name": "Serial",
                 "type": "text",
                 "reg_type": "input",
@@ -1669,6 +1717,9 @@
                 "Play from ROM31": "Воспроизвести команду из ROM31",
                 "Play from ROM32": "Воспроизвести команду из ROM32",
                 "Reset all ROM": "Стереть все команды в ROM",
+                "Play from BANK": "Воспроизвести команду из соответствующего банка ROM",
+                "BANK -> RAM":"Редактирование ИК-команд в банке с копированием в RAM",
+                "Learn to BANK": "Записать команду в соответствующий банк ROM",
                 "Serial": "Серийный номер",
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",

--- a/templates/config-wb-msw_v4_lora.json
+++ b/templates/config-wb-msw_v4_lora.json
@@ -1288,6 +1288,33 @@
                 "group": "ir_commands"
             },
             {
+                "name": "Play from BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5500,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "BANK -> RAM",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5501,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
+                "name": "Learn to BANK",
+                "reg_type": "holding",
+                "format": "s16",
+                "address": 5502,
+                "type": "value",
+                "group": "ir_commands",
+                "enabled": false
+            },
+            {
                 "name": "Serial",
                 "type": "text",
                 "reg_type": "input",
@@ -1662,6 +1689,9 @@
                 "Play from ROM31": "Воспроизвести команду из ROM31",
                 "Play from ROM32": "Воспроизвести команду из ROM32",
                 "Reset all ROM": "Стереть все команды в ROM",
+                "Play from BANK": "Воспроизвести команду из соответствующего банка ROM",
+                "BANK -> RAM":"Редактирование ИК-команд в банке с копированием в RAM",
+                "Learn to BANK": "Записать команду в соответствующий банк ROM",
                 "Serial": "Серийный номер",
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -18709,7 +18709,7 @@ WB-MIR v2
 	ROM8 size  =>  ROM8 size
 	ROM9 -> RAM  =>  ROM9 -> RAM
 	ROM9 size  =>  ROM9 size
-	BANK -> RAM  =>  BANK -> RAM
+	Reset all ROM  =>  Reset all ROM
 	Serial NO  =>  Serial NO
 	Uptime  =>  Uptime
 WB-MR11

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -18707,6 +18707,9 @@ WB-MIR v2
 	ROM9 -> RAM  =>  ROM9 -> RAM
 	ROM9 size  =>  ROM9 size
 	Reset all ROM  =>  Reset all ROM
+	Learn to BANK  =>  Learn to BANK
+	Play from BANK  =>  Play from BANK
+	BANK -> RAM  =>  BANK -> RAM
 	Serial NO  =>  Serial NO
 	Uptime  =>  Uptime
 WB-MR11

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -18533,6 +18533,7 @@ WB-MIR (simple)
 	Play from ROM6  =>  Play from ROM6
 	Play from ROM7  =>  Play from ROM7
 WB-MIR v2
+	BANK -> RAM  =>  BANK -> RAM
 	FW Version  =>  FW Version
 	Input 1: input1_1wire
 		External Temperature Sensor  =>  External Temperature Sensor
@@ -18542,6 +18543,8 @@ WB-MIR v2
 		Input 1 Counter  =>  Input 1 Counter
 	Input 1: input_disabled
 	Input Voltage  =>  Input Voltage
+	Learn to BANK  =>  Learn to BANK
+	Play from BANK  =>  Play from BANK
 	Learn to RAM  =>  Learn to RAM
 	Learn to ROM1  =>  Learn to ROM1
 	Learn to ROM10  =>  Learn to ROM10
@@ -18706,9 +18709,6 @@ WB-MIR v2
 	ROM8 size  =>  ROM8 size
 	ROM9 -> RAM  =>  ROM9 -> RAM
 	ROM9 size  =>  ROM9 size
-	Reset all ROM  =>  Reset all ROM
-	Learn to BANK  =>  Learn to BANK
-	Play from BANK  =>  Play from BANK
 	BANK -> RAM  =>  BANK -> RAM
 	Serial NO  =>  Serial NO
 	Uptime  =>  Uptime

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -18544,7 +18544,6 @@ WB-MIR v2
 	Input 1: input_disabled
 	Input Voltage  =>  Input Voltage
 	Learn to BANK  =>  Learn to BANK
-	Play from BANK  =>  Play from BANK
 	Learn to RAM  =>  Learn to RAM
 	Learn to ROM1  =>  Learn to ROM1
 	Learn to ROM10  =>  Learn to ROM10
@@ -18588,6 +18587,7 @@ WB-MIR v2
 	Learn to ROM9  =>  Learn to ROM9
 	MCU Temperature  =>  MCU Temperature
 	MCU Voltage  =>  MCU Voltage
+	Play from BANK  =>  Play from BANK
 	Play from RAM  =>  Play from RAM
 	Play from ROM1  =>  Play from ROM1
 	Play from ROM10  =>  Play from ROM10
@@ -19495,6 +19495,7 @@ WB-MSGR
 	Uptime  =>  Uptime
 WB-MSW v.3
 	Air Quality (VOC)  =>  Air Quality (VOC)
+	BANK -> RAM  =>  BANK -> RAM
 	Buzzer  =>  Buzzer
 	CO2  =>  CO2
 	CO2 Autocalibration Period  =>  CO2 Autocalibration Period
@@ -19516,6 +19517,7 @@ WB-MSW v.3
 	Illuminance  =>  Illuminance
 	LED Glow Duration (ms)  =>  LED Glow Duration (ms)
 	LED Period (s)  =>  LED Period (s)
+	Learn to BANK  =>  Learn to BANK
 	Learn to RAM  =>  Learn to RAM
 	Learn to ROM1  =>  Learn to ROM1
 	Learn to ROM10  =>  Learn to ROM10
@@ -19554,6 +19556,7 @@ WB-MSW v.3
 	Max Motion  =>  Max Motion
 	Minimum Voltage Since Startup  =>  Minimum Voltage Since Startup
 	Motion Raw  =>  Motion Raw
+	Play from BANK  =>  Play from BANK
 	Play from RAM  =>  Play from RAM
 	Play from ROM1  =>  Play from ROM1
 	Play from ROM10  =>  Play from ROM10
@@ -19673,6 +19676,7 @@ WB-MSW v.3
 WB-MSW v.4
 	Air Quality (VOC)  =>  Air Quality (VOC)
 	Air Quality Index  =>  Air Quality Index
+	BANK -> RAM  =>  BANK -> RAM
 	Buzzer  =>  Buzzer
 	CO2  =>  CO2
 	CO2 Autocalibration Period  =>  CO2 Autocalibration Period
@@ -19689,6 +19693,7 @@ WB-MSW v.4
 	Illuminance  =>  Illuminance
 	LED Glow Duration (ms)  =>  LED Glow Duration (ms)
 	LED Period (s)  =>  LED Period (s)
+	Learn to BANK  =>  Learn to BANK
 	Learn to RAM  =>  Learn to RAM
 	Learn to ROM1  =>  Learn to ROM1
 	Learn to ROM10  =>  Learn to ROM10
@@ -19727,6 +19732,7 @@ WB-MSW v.4
 	Max Motion  =>  Max Motion
 	Minimum Voltage Since Startup  =>  Minimum Voltage Since Startup
 	Motion Raw  =>  Motion Raw
+	Play from BANK  =>  Play from BANK
 	Play from RAM  =>  Play from RAM
 	Play from ROM1  =>  Play from ROM1
 	Play from ROM10  =>  Play from ROM10
@@ -19847,6 +19853,7 @@ WB-MSW v.4
 WB-MSW-LORA v.4
 	Air Quality (VOC)  =>  Air Quality (VOC)
 	Air Quality Index  =>  Air Quality Index
+	BANK -> RAM  =>  BANK -> RAM
 	Buzzer  =>  Buzzer
 	CO2  =>  CO2
 	CO2 Autocalibration Period  =>  CO2 Autocalibration Period
@@ -19863,6 +19870,7 @@ WB-MSW-LORA v.4
 	Illuminance  =>  Illuminance
 	LED Glow Duration (ms)  =>  LED Glow Duration (ms)
 	LED Period (s)  =>  LED Period (s)
+	Learn to BANK  =>  Learn to BANK
 	Learn to RAM  =>  Learn to RAM
 	Learn to ROM1  =>  Learn to ROM1
 	Learn to ROM10  =>  Learn to ROM10
@@ -19901,6 +19909,7 @@ WB-MSW-LORA v.4
 	Max Motion  =>  Max Motion
 	Minimum Voltage Since Startup  =>  Minimum Voltage Since Startup
 	Motion Raw  =>  Motion Raw
+	Play from BANK  =>  Play from BANK
 	Play from RAM  =>  Play from RAM
 	Play from ROM1  =>  Play from ROM1
 	Play from ROM10  =>  Play from ROM10


### PR DESCRIPTION
Добавлены три канала в шаблоны устройств с IR:
- Воспроизведение ИК-команды из соответствующего банка ROM (Play)
- Редактирование ИК-команд (ROM) с копированием в RAM (ROM -> RAM)
- Запись в банк ИК-команд с использованием IR-приёмника (Learn)

Список устройств:

- WB-MSW v4
- WB-MSW v4-LoRa
- WB-MSW v3
- WB-MIR v2

