### PR TITLE
Feature/fix mai6 version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.133.2) stable; urgency=medium
+
+  * WB-MAI6 template: remove FW version
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.ru>  Tue, 16 Jul 2024 19:14:15 +0300
+
 wb-mqtt-serial (2.133.1) stable; urgency=medium
 
   * Add min core voltage reg in wb-mir_v2 template

--- a/templates/config-wb-mai6.json.jinja
+++ b/templates/config-wb-mai6.json.jinja
@@ -22,8 +22,7 @@
 {% if has_signature %}
     "hw": [
         {
-            "signature": "WBMAI6",
-            "fw": "2.1.0"
+            "signature": "WBMAI6"
         }
     ],
 {% endif %}


### PR DESCRIPTION
Шаблон MAI6 поддерживает все версии прошивок. Ошибочно туда попало поле с версией 2.1.0
