### PR TITLE
Fix apc-nmc2 template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.138.1) stable; urgency=medium
+
+  * Fix APC NMC2 AP9630 template
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 06 Aug 2024 16:05:00 +0400
+
 wb-mqtt-serial (2.138.0) stable; urgency=medium
 
   * Add template PID-controller Ptex

--- a/templates/config-apc-nmc2.json
+++ b/templates/config-apc-nmc2.json
@@ -1,5 +1,5 @@
 {
-    "title": "template_title",
+    "title": "UPS NMC2 AP9630",
     "device_type": "APC_series",
     "group": "g-ups",
     "device": {
@@ -20,11 +20,6 @@
                 "title": "Device Setting",
                 "id": "device_setting",
                 "order": 3
-            },
-            {
-                "title": "Managment Commands",
-                "id": "diagnostics",
-                "order": 4
             }
         ],
         "channels": [
@@ -308,7 +303,6 @@
                 "Device Status": "Состояние устройства",
                 "Power Status": "Состояние питания",
                 "Device Setting": "Настройка",
-                "Managment Commands": "Команды управления",
                 "Version 2.6": "Версия 2.6",
                 "Battery Charge": "Заряд АКБ",
                 "Minutes Left": "Минут осталось",


### PR DESCRIPTION
Follow up https://github.com/wirenboard/wb-mqtt-serial/pull/782

<img width="733" alt="Näyttökuva 2024-8-6 kello 16 09 07" src="https://github.com/user-attachments/assets/ca83241b-da66-49e7-ac99-224ae5ecb6f2">

"Managment Commands" группа не используется.