### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: "75"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: "75"
+               defaultCoverageMin: '74'

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,7 @@ endif
 templates: $(JINJA_TEMPLATES:$(TEMPLATES_DIR)/%.json.jinja=$(GENERATED_TEMPLATES_DIR)/%.json)
 
 clean:
-	-rm -rf build/release
-	-rm -rf build/debug
+	-rm -rf build
 	-rm -rf $(TEST_DIR)/$(TEST_BIN)
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
+COV_REPORT ?= $(BUILD_DIR)/cov.html
+GCOVR_FLAGS := --html $(COV_REPORT)
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
+
 SRCS=$(SERIAL_SRCS) $(TEST_SRCS)
 
 TEMPLATES_DIR = templates
@@ -84,14 +90,11 @@ test: templates $(TEST_DIR)/$(TEST_BIN)
 	else \
 		$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
 	fi
+ifneq ($(DEBUG),)
+	gcovr $(GCOVR_FLAGS) $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)
+endif
 
 templates: $(JINJA_TEMPLATES:$(TEMPLATES_DIR)/%.json.jinja=$(GENERATED_TEMPLATES_DIR)/%.json)
-
-lcov: test
-ifeq ($(DEBUG), 1)
-	geninfo --no-external -b . -o $(BUILD_DIR)/coverage.info $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)
-	genhtml -o $(BUILD_DIR)/cov_html $(BUILD_DIR)/coverage.info
-endif
 
 clean:
 	-rm -rf build/release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.143.4) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 25 Sep 2024 13:10:00 +0400
+
 wb-mqtt-serial (2.143.3) stable; urgency=medium
 
   * WB-LED template: safety mode, switch mode, powerup actions support

--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,20 @@
 Source: wb-mqtt-serial
-Maintainer: Evgeny Boger <boger@contactless.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev (>= 5.0.0~~), libwbmqtt1-5-test-utils (>= 5.0.0~~), j2cli:all, libgtest-dev
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               j2cli:all,
+               libgtest-dev,
+               libwbmqtt1-5-dev (>= 5.0.0~~),
+               libwbmqtt1-5-test-utils (>= 5.0.0~~),
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), libwbmqtt1-5 (>= 5.0.0~~), wb-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.82.0~~)

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
+
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=74 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-9-27 kello 2 36 07" src="https://github.com/user-attachments/assets/553320fa-1554-492c-85b7-31c10c69f03c">
