### PR TITLE
WB-MDM3 template: fix deprecated template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.138.1-wb107) stable; urgency=medium
+
+  * WB-MDM3 template: fix deprecated template
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 21 Oct 2024 14:10:00 +0400
+
 wb-mqtt-serial (2.138.1-wb106) stable; urgency=medium
 
   * WB-MDM3 template: deleted light scenes

--- a/templates/config-wb-mdm3-deprecated.json.jinja
+++ b/templates/config-wb-mdm3-deprecated.json.jinja
@@ -6,6 +6,7 @@
     "title": "WB-MDM3_template_title",
     "device_type": "WB-MDM3",
     "group": "g-wb",
+    "deprecated": true,
     "hw": [
         {
             "signature": "WBMD3"


### PR DESCRIPTION
При бекпорте #819 не пометили шаблон как deprecated, хотя в оригинальном #802 был помечен.