### PR TITLE
Feature/int 198 add template for opentherm fw 1.7.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.148.0) stable; urgency=medium
+
+  * Add new template for wbe2-i-opentherm fw1.7.3
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Mon, 11 Nov 2024 11:45:00 +0300
+
 wb-mqtt-serial (2.147.0) stable; urgency=medium
 
   * Store press_counter register values as soon as possible.

--- a/templates/config-wbe2-i-opentherm-fw1.7.3.json
+++ b/templates/config-wbe2-i-opentherm-fw1.7.3.json
@@ -1,0 +1,681 @@
+{
+    "title": "WBE2-I-OPENTHERM_template_title",
+    "device_type": "WBE2-I-OPENTHERM-FW-1.7.3",
+    "group": "g-wb",
+    "device": {
+        "name": "WBE2-I-OPENTHERM fw1.7.3",
+        "id": "wbe2-i-opentherm",
+        "response_timeout": 200,
+        "guard_interval_us": 2500,
+		
+        "groups": [
+            {
+                "title": "Boiler State",
+                "id": "boiler_state"
+            },
+            {
+                "title": "Hot Water Settings",
+                "id": "hot_water_settings"
+            },
+            {
+                "title": "OpenTherm Commands",
+                "id": "opentherm_commands"
+            },
+            {
+                "title": "HW Info",
+                "id": "hw_info"
+            }
+        ],
+
+        "channels": [
+            {
+                "name": "Boiler Status",
+                "address": 205,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler fault indication",
+                "address": "205:0:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler CH mode",
+                "address": "205:1:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler DHW mode",
+                "address": "205:2:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler CH2 mode",
+                "address": "205:5:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler Flame Status",
+                "address": "205:3:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+
+            {
+                "name": "Master CH enable",
+                "address": "205:8:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+
+            {
+                "name": "Master DHW enable",
+                "address": "205:9:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Master CH2 enable",
+                "address": "205:12:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Master OTC active",
+                "address": "205:11:1",
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+			
+			
+            {
+                "name": "Error Code",
+                "address": 206,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Invalid Connection",
+                "address": 217,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+
+            {
+                "name": "CH Min Value",
+                "address": 214,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "CH Max Value",
+                "address": 215,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "CH Gest",
+                "address": 216,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "DHW Gest",
+                "address": 217,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Hot Water Setpoint",
+                "address": 204,
+                "reg_type": "holding",
+                "type": "temperature",
+                "format": "u16",
+                "min": 0,
+                "max": 80,
+                "group": "hot_water_settings"
+            },
+
+            {
+                "name": "Hot Water Temperature",
+                "address": 208,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Solar Storage temp",
+                "address": 220,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "CH2 Temperature",
+                "address": 222,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Heating Temperature",
+                "address": 207,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Heating Return Water Temperature",
+                "address": 216,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Burner Modulation Level (%)",
+                "address": 209,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Water Pressure",
+                "address": 210,
+                "reg_type": "input",
+                "type": "pressure",
+                "format": "u16",
+                "scale": 0.1,
+                "offset": -100,
+                "round_to": 0.1,
+                "group": "boiler_state"
+            },
+            {
+                "name": "Boiler Outdoor Temperature Sensor",
+                "address": 211,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "s16",
+                "scale": 0.1,
+                "offset": -100,
+                "round_to": 0.1,
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Hot Water Setpoint Max",
+                "address": 212,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Hot Water Setpoint Min",
+                "address": 213,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Heating Setpoint Max",
+                "address": 214,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Heating Setpoint Min",
+                "address": 215,
+                "reg_type": "input",
+                "type": "temperature",
+                "format": "u16",
+                "group": "boiler_state",
+                "enabled": false
+            },
+            {
+                "name": "Heating Settings",
+                "id": "",
+                "oneOf": [
+                    "room_sensor",
+                    "outdoor_sensor",
+                    "direct_heating_control",
+                    "heating_off"
+                ],
+                "device_type": "room_sensor"
+            },
+            {
+                "name": "Command Type",
+                "address": 209,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "min": 1,
+                "max": 10,
+                "group": "opentherm_commands",
+                "enabled": false
+            },
+            {
+                "name": "Command ID",
+                "address": 210,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "opentherm_commands",
+                "enabled": false
+            },
+            {
+                "name": "Data Type",
+                "address": 211,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "opentherm_commands",
+                "enabled": false
+            },
+            {
+                "name": "Auto Temp Switch",
+                "address": 213,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "Season reg",
+                "address": 212,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "scale": 1,
+                "group": "boiler_state"
+            },
+            {
+                "name": "OT MasterID",
+                "address": 218,
+                "reg_type": "holding",
+                "type": "value",
+                "format": "u16",
+                "group": "opentherm_commands"
+            },
+            {
+                "name": "DHW Override",
+                "address": 218,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+			{
+                "name": "DHW Transfer",
+                "address": 219,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "group": "boiler_state"
+            },
+            {
+                "name": "FW Version",
+                "address": 204,
+                "reg_type": "input",
+                "type": "value",
+                "format": "u16",
+                "scale": 0.01,
+                "group": "hw_info"
+            }
+        ],
+
+        "subdevices": [
+            {
+                "title": "Room Temperature Sensor",
+                "device_type": "room_sensor",
+                "device": {
+                    "setup": [
+                        {
+                            "title": "disable direct heating control",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "value": 0
+                        },
+                        {
+                            "title": "enable room sensor",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "value": 1
+                        },
+                        {
+                            "title": "enable winter mode",
+                            "address": 212,
+                            "reg_type": "holding",
+                            "value": 1
+                        }
+                    ],
+                    "channels": [
+                        {
+                            "name": "Temperature Sensor Type",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "type": "value",
+                            "readonly": true
+                        },
+                        {
+                            "name": "Calculated Heating Setpoint",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "u16",
+                            "min": 0,
+                            "max": 80,
+                            "readonly": true
+                        },
+                        {
+                            "name": "Room Temperature",
+                            "address": 208,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "s16",
+                            "scale": 0.1,
+                            "offset": -100,
+                            "min": -50,
+                            "max": 60
+                        },
+                        {
+                            "name": "Room Temperature Setpoint",
+                            "address": 205,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "u16",
+                            "min": 0,
+                            "max": 35
+                        }
+                    ]
+                }
+            },
+            {
+                "title": "Outdoor Temperature Sensor",
+                "device_type": "outdoor_sensor",
+                "device": {
+                    "setup": [
+                        {
+                            "title": "disable direct heating control",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "value": 0
+                        },
+                        {
+                            "title": "enable outdoor sensor",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "value": 2
+                        },
+                        {
+                            "title": "enable winter mode",
+                            "address": 212,
+                            "reg_type": "holding",
+                            "value": 1
+                        }
+                    ],
+                    "parameters": {
+                        "climate_curve_number": {
+                            "title": "Climate Curve Number",
+                            "description": "climate_curve_number_description",
+                            "address": 206,
+                            "reg_type": "holding",
+                            "format": "u16",
+                            "min": 1,
+                            "max": 200,
+                            "default": 1,
+                            "order": 1
+                        }
+                    },
+                    "channels": [
+                        {
+                            "name": "Temperature Sensor Type",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "type": "value",
+                            "readonly": true
+                        },
+                        {
+                            "name": "Outdoor Temperature",
+                            "address": 208,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "s16",
+                            "scale": 0.1,
+                            "offset": -100,
+                            "min": -50,
+                            "max": 60
+                        },
+                        {
+                            "name": "Calculated Heating Setpoint",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "u16",
+                            "min": 0,
+                            "max": 80,
+                            "readonly": true
+                        },
+                        {
+                            "name": "Heating Status",
+                            "reg_type": "holding",
+                            "address": 205,
+                            "type": "switch"
+                        }
+                    ]
+                }
+            },
+            {
+                "title": "Direct Heating Setpoint Control",
+                "device_type": "direct_heating_control",
+                "device": {
+                    "setup": [
+                        {
+                            "title": "enable direct heating control",
+                            "address": 205,
+                            "reg_type": "holding",
+                            "value": 0
+                        },
+                        {
+                            "title": "enable room sensor",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "value": 0
+                        },
+                        {
+                            "title": "enable winter mode",
+                            "address": 212,
+                            "reg_type": "holding",
+                            "value": 1
+                        }
+                    ],
+                    "parameters": {
+                        "boiler_mode": {
+                            "title": "Current Boiler Mode",
+                            "address": 212,
+                            "reg_type": "holding",
+                            "enum": [
+                                0, 1, 2
+                            ],
+                            "enum_titles": [
+                                "STANDBY", "WINTER", "SUMMER"
+                            ],
+                            "default": 1
+                        }
+                    },
+                    "channels": [
+                        {
+                            "name": "Temperature Sensor Type",
+                            "address": 207,
+                            "reg_type": "holding",
+                            "type": "value",
+                            "readonly": true
+                        },
+                        {
+                            "name": "Heating Setpoint",
+                            "write_address": 203,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "u16",
+                            "min": 0,
+                            "max": 80
+                        }
+                    ]
+                }
+            },
+            {
+                "title": "Heating Off",
+                "device_type": "heating_off",
+                "device": {
+                    "setup": [
+                        {
+                            "title": "enable direct heating control",
+                            "address": 205,
+                            "reg_type": "holding",
+                            "value": 0
+                        },
+                        {
+                            "title": "disable heating",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "value": 	0
+                        }
+                    ],
+                    "channels": [
+                        {
+                            "name": "Heating Setpoint",
+                            "address": 203,
+                            "reg_type": "holding",
+                            "type": "temperature",
+                            "format": "u16",
+                            "min": 0,
+                            "max": 80,
+                            "readonly": true
+                        }
+                    ]
+                }
+            }
+        ],
+        "translations": {
+            "en": {
+                "WBE2-I-OPENTHERM_template_title": "WBE2-I-OPENTHERM fw1.7.3 (OpenTherm boiler interface)",
+                "climate_curve_number_description": "Values from 1 to 19 are transformed in module as value/200"
+            },
+            "ru": {
+                "WBE2-I-OPENTHERM_template_title": "WBE2-I-OPENTHERM fw1.7.3 (интерфейс OpenTherm для котлов)",
+                "Boiler State": "Состояние котла",
+                "Boiler fault indication": "Индикатор ошибки котла",
+                "Boiler CH mode": "Контура отопления котла",
+                "Boiler DHW mode": "Контура ГВС котла",
+                "Boiler Flame Status": "Состояние горелки котла",
+                "Boiler CH2 mode": "Второй контур котла",
+                "Master CH enable": "Разрешение контура отопления",
+                "Master DHW enable": "Разрешение контура ГВС",
+                "Master OTC active": "Разрешение погодозависимого реж. котла",
+                "Master CH2 enable": "Разрешение второго контура",
+
+                "Hot Water Settings": "Параметры ГВС",
+                "OpenTherm Commands": "Команды OpenTherm",
+                "HW Info": "Данные модуля",
+                "Boiler Status": "Статус котла",
+                "Error Code": "Код ошибки",
+                "Hot Water Temperature": "t° ГВС",
+                "Solar Storage temp": "t° БКН",
+                "CH2 Temperature": "t° CH2", 
+                "Heating Temperature": "t° подачи отопления",
+                "Heating Return Water Temperature":	"t° обратной воды отопления",
+                "Burner Modulation Level (%)": "Модуляция горелки (%)",
+                "Water Pressure": "Давление воды",
+                "Boiler Outdoor Temperature Sensor": "Уличная t° - датчик котла",
+                "Hot Water Setpoint Max": "Max t° ГВС котла",
+                "Hot Water Setpoint Min": "Min t° ГВС котла",
+                "Heating Setpoint Max": "Max t° теплоносителя котла",
+                "Heating Setpoint Min": "Min t° теплоносителя котла",
+                "Hot Water Setpoint": "Уставка ГВС",
+                "Heating Settings": "Параметры отопления",
+                "Command Type": "Тип команды запись/чтение",
+                "Command ID": "ID команды",
+                "Data Type": "Значение",
+                "Season reg": "Режим работы по сезону",
+                "FW Version": "Версия прошивки",
+                "Invalid Connection": "Ошибка связи с котлом",
+                "Auto Temp Switch": "Режим отключения контуров",
+                "CH Max Value": "Max t° теплоносителя",
+                "CH Min Value": "Min t° теплоносителя",
+                "CH Gest": "Гистерезис теплоносителя",
+                "DHW Gest": "Гистерезис ГВС",
+                "OT MasterID": "Идентификатор мастера",
+                "DHW Override": "Перезапись уставки ГВС",
+                "DHW Transfer": "Передача температуры ГВС",
+                "Room Temperature Sensor": "Датчик комнатной температуры",
+                "Temperature Sensor Type": "Тип датчика температуры",
+                "Heating Setpoint": "Уставка отопления",
+                "Calculated Heating Setpoint": "Расчетная уставка отопления",
+                "Room Temperature": "Комнатная t°",
+                "Room Temperature Setpoint": "Уставка комнатной t°",
+                "Outdoor Temperature Sensor": "Датчик уличной температуры",
+                "Climate Curve Number": "Номер климатической кривой",
+                "climate_curve_number_description": "Кривые с первой по пятую для тёплого пола. Значения от 1 до 19 преобразуются в модуле как значение/200",
+                "Outdoor Temperature": "Уличная температура",
+                "Heating Status": "Статус отопления",
+                "Direct Heating Setpoint Control": "Управление уставкой отопления",
+
+                "Heating Off": "Отопление отключено",
+				"Current Boiler Mode": "Текущий режим работы котла",
+				"STANDBY": "СПЯЩИЙ РЕЖИМ",
+				"WINTER": "ЗИМА",
+				"SUMMER": "ЛЕТО"
+
+            }
+        }
+    }
+} 

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -20588,6 +20588,60 @@ WBE2-I-OPENTHERM-FW-1.4
 	Hot Water Temperature  =>  Hot Water Temperature
 	Invalid Connection  =>  Invalid Connection
 	Water Pressure  =>  Water Pressure
+WBE2-I-OPENTHERM-FW-1.7.3
+	Auto Temp Switch  =>  Auto Temp Switch
+	Boiler CH mode  =>  Boiler CH mode
+	Boiler CH2 mode  =>  Boiler CH2 mode
+	Boiler DHW mode  =>  Boiler DHW mode
+	Boiler Flame Status  =>  Boiler Flame Status
+	Boiler Outdoor Temperature Sensor  =>  Boiler Outdoor Temperature Sensor
+	Boiler Status  =>  Boiler Status
+	Boiler fault indication  =>  Boiler fault indication
+	Burner Modulation Level (%)  =>  Burner Modulation Level (%)
+	CH Gest  =>  CH Gest
+	CH Max Value  =>  CH Max Value
+	CH Min Value  =>  CH Min Value
+	CH2 Temperature  =>  CH2 Temperature
+	Command ID  =>  Command ID
+	Command Type  =>  Command Type
+	DHW Gest  =>  DHW Gest
+	DHW Override  =>  DHW Override
+	DHW Transfer  =>  DHW Transfer
+	Data Type  =>  Data Type
+	Error Code  =>  Error Code
+	FW Version  =>  FW Version
+	Heating Return Water Temperature  =>  Heating Return Water Temperature
+	Heating Setpoint Max  =>  Heating Setpoint Max
+	Heating Setpoint Min  =>  Heating Setpoint Min
+	Heating Settings: room_sensor
+		Calculated Heating Setpoint  =>  Calculated Heating Setpoint
+		Room Temperature  =>  Room Temperature
+		Room Temperature Setpoint  =>  Room Temperature Setpoint
+		Temperature Sensor Type  =>  Temperature Sensor Type
+	Heating Settings: outdoor_sensor
+		Calculated Heating Setpoint  =>  Calculated Heating Setpoint
+		Heating Status  =>  Heating Status
+		Outdoor Temperature  =>  Outdoor Temperature
+		Temperature Sensor Type  =>  Temperature Sensor Type
+	Heating Settings: direct_heating_control
+		Heating Setpoint  =>  Heating Setpoint
+		Temperature Sensor Type  =>  Temperature Sensor Type
+	Heating Settings: heating_off
+		Heating Setpoint  =>  Heating Setpoint
+	Heating Temperature  =>  Heating Temperature
+	Hot Water Setpoint  =>  Hot Water Setpoint
+	Hot Water Setpoint Max  =>  Hot Water Setpoint Max
+	Hot Water Setpoint Min  =>  Hot Water Setpoint Min
+	Hot Water Temperature  =>  Hot Water Temperature
+	Invalid Connection  =>  Invalid Connection
+	Master CH enable  =>  Master CH enable
+	Master CH2 enable  =>  Master CH2 enable
+	Master DHW enable  =>  Master DHW enable
+	Master OTC active  =>  Master OTC active
+	OT MasterID  =>  OT MasterID
+	Season reg  =>  Season reg
+	Solar Storage temp  =>  Solar Storage temp
+	Water Pressure  =>  Water Pressure
 WBIO-AI-DV-12
 	A1  =>  A1
 	A10  =>  A10


### PR DESCRIPTION
В шаблоне оставил структуру с subdevices, т.к. без нее нет возможности реализовать нормально функционал, чтобы при выборе режима отопления писалось в несколько регистров разные значения, как это можно сделать через setup



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new firmware template for the WBE2-I OpenTherm device (version 1.7.3), enhancing device configuration options.
	- Added support for various groups and channels, allowing detailed monitoring and control of heating and hot water systems.
	- Included translations for configuration terms in English and Russian for improved accessibility.

- **Bug Fixes**
	- Improved handling of the `press_counter` register to ensure timely data storage and prevent outdated information publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->