### PR TITLE
Fix reconfiguration of fast modbus events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.147.1) stable; urgency=medium
+
+  * Reconfigure fast modbus events after device restart
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 12 Nov 2024 21:25:35 +0500
+
 wb-mqtt-serial (2.147.0) stable; urgency=medium
 
   * Store press_counter register values as soon as possible.

--- a/src/poll_plan.h
+++ b/src/poll_plan.h
@@ -12,6 +12,15 @@ public:
     {
         return std::find_if(this->c.cbegin(), this->c.cend(), pred) != this->c.cend();
     }
+
+    template<typename Pred> void Remove(Pred pred)
+    {
+        auto it = std::find_if(this->c.begin(), this->c.end(), pred);
+        if (it != this->c.end()) {
+            this->c.erase(it);
+            std::make_heap(this->c.begin(), this->c.end(), this->comp);
+        }
+    }
 };
 
 template<class TEntry, typename ComparePredicate> class TPriorityQueueSchedule
@@ -70,6 +79,11 @@ public:
     bool Contains(TEntry entry) const
     {
         return Entries.Contains([&](const TItem& item) { return item.Data == entry; });
+    }
+
+    void Remove(TEntry entry)
+    {
+        Entries.Remove([&](const TItem& item) { return item.Data == entry; });
     }
 
 private:
@@ -291,6 +305,12 @@ public:
     bool Contains(TEntry entry)
     {
         return LowPriorityQueue.Contains(entry) || HighPriorityQueue.Contains(entry);
+    }
+
+    void Remove(TEntry entry)
+    {
+        LowPriorityQueue.Remove(entry);
+        HighPriorityQueue.Remove(entry);
     }
 
     bool IsEmpty() const

--- a/src/serial_client_register_poller.h
+++ b/src/serial_client_register_poller.h
@@ -53,6 +53,7 @@ private:
     std::chrono::steady_clock::time_point GetDeadline(bool lowPriorityRateLimitIsExceeded,
                                                       const util::TSpentTimeMeter& spentTime) const;
     void OnDeviceConnectionStateChanged(PSerialDevice device);
+    void RescheduleDisconnectedDevices();
 
     std::multimap<PSerialDevice, PPollableDevice> Devices;
 
@@ -61,4 +62,6 @@ private:
     TThrottlingStateLogger ThrottlingStateLogger;
 
     TRateLimiter LowPriorityRateLimiter;
+
+    std::vector<PSerialDevice> DisconnectedDevicesWaitingForReschedule;
 };

--- a/test/TPollTest.ReconnectWithOnlyEvents.dat
+++ b/test/TPollTest.ReconnectWithOnlyEvents.dat
@@ -1,0 +1,202 @@
+Open()
+0: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+31000: <modbus:1:(type 0): 1>
+50000: Cycle end
+
+50000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+100000: Cycle end
+
+100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+150000: Cycle end
+
+150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+200000: Cycle end
+
+200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+250000: Cycle end
+
+250000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+300000: Cycle end
+
+300000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+350000: Cycle end
+
+350000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+400000: Cycle end
+
+400000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+450000: Cycle end
+
+450000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+500000: Cycle end
+
+500000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+550000: Cycle end
+
+550000: Cycle
+Sleep(335)
+EnqueueResetEvent()
+>> FD 46 10 00 F8 00 00 79 5B
+<< 01 46 11 00 01 04 00 0F 00 00 3B 73
+Sleep(335)
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 01 F8 01 00 79 37
+<< FD 46 12 52 5D
+Sleep(335)
+600000: Cycle end
+
+600000: Cycle
+1000000: Cycle end
+
+1000000: Cycle
+Sleep(1000)
+EnqueueEnableEvents()
+>> 01 46 18 0A 03 00 01 01 01 0F 00 00 01 00 28 7D
+<< 01 46 18 02 01 00 2E F5
+Sleep(10000)
+EnqueueReadHolding()
+>> 01 03 00 01 00 01 D5 CA
+<< 01 03 02 00 00 B8 44
+1031000: <modbus:1:(type 0): 1>
+1050000: Cycle end
+
+1050000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1100000: Cycle end
+
+1100000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1150000: Cycle end
+
+1150000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1200000: Cycle end
+
+1200000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1250000: Cycle end
+
+1250000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1300000: Cycle end
+
+1300000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1350000: Cycle end
+
+1350000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1400000: Cycle end
+
+1400000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1450000: Cycle end
+
+1450000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1500000: Cycle end
+
+1500000: Cycle
+Sleep(335)
+EnqueueReadEvents()
+>> FD 46 10 00 F8 00 00 79 5B
+<< FD 46 12 52 5D
+Sleep(335)
+1550000: Cycle end
+
+Close()


### PR DESCRIPTION
https://wirenboard.youtrack.cloud/issue/SOFT-4633/Ne-vosstanavlivaetsya-opros-ustrojstv-posle-perezegruzki

Если устройство опрашивалось только через события, то после его перезагрузки опрос останавливался. После перезагрузки настройки отправки событий в устройстве сбрасываются. Их надо перенастроить. Для этого надо послать команды, они посылаются только перед обычным чтением регистров. Но в списке регистров для чтения ничего не было про это устройстов, т.к. всё через события.
По событию перезагрузки записываем устройстов в список тех, что надо снова запланировать для опроса. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the `wb-mqtt-serial` package to version 2.147.1, enhancing the handling of Modbus events after device restarts.
	- Introduced a method to manage disconnected devices more effectively, allowing for better rescheduling of device registers.
	- Enhanced event handling in tests, including new methods for simulating device resets.

- **Bug Fixes**
	- Addressed issues related to device communication and configuration validation in previous versions.

- **Documentation**
	- Updated changelog to reflect the latest changes and improvements across multiple versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->