### PR TITLE
Add min_request_interval to WBE2-I-EBUS template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.147.1) stable; urgency=medium
+
+  * Add min_request_interval=1000 to WBE2-I-EBUS template
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 18 Nov 2024 15:40:02 +0500
+
 wb-mqtt-serial (2.147.0) stable; urgency=medium
 
   * Store press_counter register values as soon as possible.

--- a/templates/config-wbe2-i-ebus.json
+++ b/templates/config-wbe2-i-ebus.json
@@ -5,6 +5,7 @@
     "device": {
         "name": "WBE2-I-EBUS",
         "id": "wbe2-i-ebus",
+        "min_request_interval": 1000,
 
         "groups": [
             {


### PR DESCRIPTION
Boiler's controller is not designed for fast polling. Limit requests to it by setting min_request_interval=1000


В инструкции по подключению модуля указано использование устаревшей настройки wb-mqtt-serial. Она нужна для ограничения числа запросов к бойлеру. Заменим эту настройку на актуальную



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to the WBE2-I-EBUS template, allowing users to set a minimum request interval of 1000 milliseconds.

- **Improvements**
	- Enhanced reliability by ensuring `press_counter` register values are stored immediately, preventing outdated data publication after unexpected service restarts.
	- Improved handling of fast Modbus events after device restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->