### PR TITLE
Fix condition evaluation in device template setup section

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.148.1) stable; urgency=medium
+
+  * Fix condition evaluation in device template setup section
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 26 Nov 2024 13:45:24 +0500
+
 wb-mqtt-serial (2.148.0) stable; urgency=medium
 
   * Add condition to device template setup section

--- a/src/config_merge_template.cpp
+++ b/src/config_merge_template.cpp
@@ -42,9 +42,7 @@ void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config, TE
             if (!item.isMember("address")) {
                 throw TConfigParserException("Setup command '" + item["title"].asString() + "' must have address");
             }
-            if (CheckCondition(item, params, exprs)) {
-                newSetup.append(item);
-            }
+            newSetup.append(item);
         }
     }
 
@@ -73,7 +71,9 @@ void AppendSetupItems(Json::Value& deviceTemplate, const Json::Value& config, TE
 
     if (deviceTemplate.isMember("setup")) {
         for (const auto& item: deviceTemplate["setup"]) {
-            newSetup.append(item);
+            if (CheckCondition(item, params, exprs)) {
+                newSetup.append(item);
+            }
         }
     }
 

--- a/test/TConfigParserTest.SetupCondition.dat
+++ b/test/TConfigParserTest.SetupCondition.dat
@@ -47,13 +47,6 @@ Ports:
                 WordOrder: BigEndian
         SetupItems:
             ------
-            Name: s2
-            Address: 9992
-            Value: 0xfff2
-            RawValue: 0xfff2
-            Reg type: holding (0)
-            Reg format: U16
-            ------
             Name: s3
             Address: 9995
             Value: 10
@@ -100,9 +93,16 @@ Ports:
         SetupItems:
             ------
             Name: p1
-            Address: 9992
+            Address: 9993
             Value: 1
             RawValue: 0x01
+            Reg type: holding (0)
+            Reg format: U16
+            ------
+            Name: s2
+            Address: 9992
+            Value: 0xfff2
+            RawValue: 0xfff2
             Reg type: holding (0)
             Reg format: U16
             ------

--- a/test/device-templates/config-setup-items-with-condition.json
+++ b/test/device-templates/config-setup-items-with-condition.json
@@ -15,7 +15,7 @@
             {
                 "id": "p1",
                 "title": "p1",
-                "address": 9992
+                "address": 9993
             }
         ],
         "setup": [


### PR DESCRIPTION
Проверял условия на setup-секции из конфига, вместо секции из шаблона. Да ещё и параметры с setup-секцией перекрывались


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated device template configurations to enhance accuracy.
	- Conditional checks added for setup items to ensure only relevant items are included.

- **Bug Fixes**
	- Fixed condition evaluation in device template setup, addressing issues from the previous version.

- **Documentation**
	- Changelog updated to reflect the release of version 2.148.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->