### PR TITLE
Add port name to logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.149.1) stable; urgency=medium
+
+  * Add port name to logs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 03 Dec 2024 11:30:19 +0500
+
 wb-mqtt-serial (2.149.0) stable; urgency=medium
 
   * Add template for WBE2-I-OPENTHERM-FW-1-7-3

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -61,7 +61,11 @@ TSerialDevice::TSerialDevice(PDeviceConfig config, PPort port, PProtocol protoco
 
 std::string TSerialDevice::ToString() const
 {
-    return Protocol()->GetName() + ":" + DeviceConfig()->SlaveId;
+    auto portDescription = Port()->GetDescription();
+    if (!portDescription.empty()) {
+        portDescription += " ";
+    }
+    return portDescription + Protocol()->GetName() + ":" + DeviceConfig()->SlaveId;
 }
 
 PRegisterRange TSerialDevice::CreateRegisterRange() const

--- a/test/fake_serial_port.cpp
+++ b/test/fake_serial_port.cpp
@@ -22,7 +22,7 @@ namespace
     const auto DB_PATH = "/tmp/wb-mqtt-serial-test.db";
 }
 
-TFakeSerialPort::TFakeSerialPort(TLoggedFixture& fixture, const std::string& portName)
+TFakeSerialPort::TFakeSerialPort(TLoggedFixture& fixture, const std::string& portName, bool emptyDescription)
     : Fixture(fixture),
       AllowOpen(true),
       IsPortOpen(false),
@@ -31,7 +31,8 @@ TFakeSerialPort::TFakeSerialPort(TLoggedFixture& fixture, const std::string& por
       RespPos(0),
       DumpPos(0),
       BaudRate(9600),
-      PortName(portName)
+      PortName(portName),
+      EmptyDescription(emptyDescription)
 {}
 
 void TFakeSerialPort::SetExpectedFrameTimeout(const std::chrono::microseconds& timeout)
@@ -273,7 +274,7 @@ std::chrono::microseconds TFakeSerialPort::GetSendTimeBytes(double bytesNumber) 
 
 std::string TFakeSerialPort::GetDescription(bool verbose) const
 {
-    return PortName;
+    return EmptyDescription ? "" : PortName;
 }
 
 void TFakeSerialPort::SetBaudRate(size_t value)

--- a/test/fake_serial_port.h
+++ b/test/fake_serial_port.h
@@ -24,7 +24,9 @@ public:
         BadFileDescriptorOnWriteAndRead //! Port can be successfully open, but all operations fail with EBADF
     };
 
-    TFakeSerialPort(WBMQTT::Testing::TLoggedFixture& fixture, const std::string& portName);
+    TFakeSerialPort(WBMQTT::Testing::TLoggedFixture& fixture,
+                    const std::string& portName,
+                    bool emptyDescription = true);
 
     void SetExpectedFrameTimeout(const std::chrono::microseconds& timeout);
     void CheckPortOpen() const override;
@@ -70,6 +72,7 @@ private:
     std::chrono::microseconds ExpectedFrameTimeout = std::chrono::microseconds(-1);
     size_t BaudRate;
     std::string PortName;
+    bool EmptyDescription;
 };
 
 typedef std::shared_ptr<TFakeSerialPort> PFakeSerialPort;

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -1433,7 +1433,7 @@ TEST_F(TSerialClientIntegrationTest, SlaveIdCollision)
 
     auto factory = [=](const Json::Value& port_data, PRPCConfig rpcConfig) -> std::pair<PPort, bool> {
         auto path = port_data["path"].asString();
-        return std::make_pair(std::make_shared<TFakeSerialPort>(*this, path), false);
+        return std::make_pair(std::make_shared<TFakeSerialPort>(*this, path, false), false);
     };
 
     EXPECT_THROW(LoadConfig(GetDataFilePath("configs/config-collision-test.json"),


### PR DESCRIPTION
Поправил Вовин PR https://github.com/wirenboard/wb-mqtt-serial/pull/821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities by adding port name to logs in version `2.149.1`.
	- Improved string representation of serial devices with additional port description.

- **Bug Fixes**
	- Refined error handling for serial device connections and register reading.

- **Tests**
	- Expanded tests for handling slave ID collisions and connection states, ensuring robust error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->