### PR TITLE
Make vendor templates searchable from wb-device-manager

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.146.0-wb101-cb8ea449-1) stable; urgency=medium
 
-  * Make oni templates searchable from wb-device-manager
+  * Make vendor templates searchable from wb-device-manager
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 03 Dec 2024 15:12:12 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.146.0-wb101-cb8ea449-1) stable; urgency=medium
+
+  * Make oni templates searchable from wb-device-manager
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 03 Dec 2024 15:12:12 +0300
+
 wb-mqtt-serial (2.146.0-wb101-cb8ea449) stable; urgency=medium
 
   * Move vendor devices up in templates list

--- a/templates/config-oni-plc-w-acs-0800-imp.json.jinja
+++ b/templates/config-oni-plc-w-acs-0800-imp.json.jinja
@@ -4,6 +4,6 @@
         group = "g-oni",
         device_name = "PLC-W-ACS-0800-IMP",
         device_id = "oni-plc-w-acs-0800-imp",
-        has_signature = false %}
+        has_signature = true %}
 {% include "config-wb-mcm8.json.jinja" %}
 {% endwith %}

--- a/templates/config-oni-plc-w-ema-0304.json.jinja
+++ b/templates/config-oni-plc-w-ema-0304.json.jinja
@@ -4,6 +4,6 @@
         group = "g-oni",
         device_name = "PLC-W-EMA-0304",
         device_id = "oni-plc-w-ema-0304",
-        has_signature = false %}
+        has_signature = true %}
 {% include "config-wb-mao4.json.jinja" %}
 {% endwith %}

--- a/templates/config-oni-plc-w-ema-06u00.json.jinja
+++ b/templates/config-oni-plc-w-ema-06u00.json.jinja
@@ -4,6 +4,6 @@
         group = "g-oni",
         device_name = "PLC-W-EMA-06U00",
         device_id = "oni-plc-w-ema-06u00",
-        has_signature = false %}
+        has_signature = true %}
 {% include "config-wb-mai6.json.jinja" %}
 {% endwith %}

--- a/templates/config-oni-plc-w-emd-0706.json.jinja
+++ b/templates/config-oni-plc-w-emd-0706.json.jinja
@@ -4,6 +4,6 @@
         group = "g-oni",
         device_name = "PLC-W-EMD-0706",
         device_id = "oni-plc-w-emd-0706",
-        has_signature = false %}
+        has_signature = true %}
 {% include "config-wb-mr6c.json.jinja" %}
 {% endwith %}

--- a/templates/config-wb-mai6.json.jinja
+++ b/templates/config-wb-mai6.json.jinja
@@ -4,7 +4,7 @@
 {% set group = group | default("g-wb") -%}
 {% set device_name = device_name | default("WB-MAI6") -%}
 {% set device_id = device_id | default("wb-mai6") -%}
-{% set has_signature = has_signature | default(true) -%}
+{% set has_signature = has_signature | default(false) -%}
 
 {% set CHANNELS_NUMBER = 6 -%}
 {% set TYPES_WITH_GAIN = [3, 257] -%}

--- a/templates/config-wb-mao4.json.jinja
+++ b/templates/config-wb-mao4.json.jinja
@@ -4,7 +4,7 @@
 {% set group = group | default("g-wb") -%}
 {% set device_name = device_name | default("WB-MAO4") -%}
 {% set device_id = device_id | default("wb-mao4") -%}
-{% set has_signature = has_signature | default(true) -%}
+{% set has_signature = has_signature | default(false) -%}
 
 {% set INPUTS_NUMBER = 3 -%}
 {% set OUTPUTS_NUMBER = 4 -%}

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -4,7 +4,7 @@
 {% set group = group | default("g-wb") -%}
 {% set device_name = device_name | default("WB-MCM8") -%}
 {% set device_id = device_id | default("wb-mcm8") -%}
-{% set has_signature = has_signature | default(true) -%}
+{% set has_signature = has_signature | default(false) -%}
 
 {% set INPUTS_NUMBER = 8 -%}
 {% set FIRST_INPUT = 1 -%}

--- a/templates/config-wb-mr6c.json.jinja
+++ b/templates/config-wb-mr6c.json.jinja
@@ -4,7 +4,7 @@
 {% set group = group | default("g-wb") -%}
 {% set device_name = device_name | default("WB-MR6C") -%}
 {% set device_id = device_id | default("wb-mr6c") -%}
-{% set has_signature = has_signature | default(true) -%}
+{% set has_signature = has_signature | default(false) -%}
 
 {% set OUTPUTS_NUMBER = 6 -%}
 {% set CURTAINS_NUMBER = OUTPUTS_NUMBER // 2 -%}


### PR DESCRIPTION
Так как в шаблонах вендора не используются сигнатуры, при поиске выводились имена по нашей номенклатуре. Выключила сигнатуры из наших шаблонов, включила в вендорских