### PR TITLE
Feature/int 192 add bht 006 template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.150.0) stable; urgency=medium
+
+  * Add template for BHT-006
+
+-- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Wed, 04 Dec 2024 13:07:00 +0300
+
 wb-mqtt-serial (2.149.0) stable; urgency=medium
 
   * Add template for WBE2-I-OPENTHERM-FW-1-7-3

--- a/templates/config-bht-006-series.json
+++ b/templates/config-bht-006-series.json
@@ -1,0 +1,89 @@
+{
+    "device_type": "BHT-006 Series",
+    "group": "g-thermostat",
+    "device": {
+       "name": "BHT-006 Series",
+       "id": "bht-006-series", 
+     "channels": [
+      {
+         "name": "power_status",
+         "reg_type": "holding",
+         "address": "0x00",
+         "type": "switch",
+         "format": "s16"
+      },
+      {
+         "name": "temperature_from_internal_sensor",
+         "reg_type": "holding",
+         "address": "0x01",
+         "type": "temperature",
+         "format": "s16",
+         "scale": 0.1,
+         "readonly": true
+      },
+      {
+         "name": "manual_mode",
+         "reg_type": "holding",
+         "address": "0x02",
+         "type": "switch",
+         "format": "s16"
+      },
+      {
+         "name": "heating_status",
+         "reg_type": "holding",
+         "address": "0x03",
+         "type": "switch",
+         "format": "s16",
+         "readonly": true
+      },
+      {
+         "name": "setting_temperature", 
+         "reg_type": "holding",
+         "address": "0x04",
+         "type": "range",
+         "format": "s16",
+         "scale": 0.1,
+         "min": 5,
+         "max": 35
+      },
+      {
+         "name": "weekly_program_setting_temperature",
+         "reg_type": "holding",
+         "address": "0x05",
+         "format": "s16",
+         "type": "range",
+         "scale": 0.1,
+         "min": 5,
+         "max": 35
+      },
+      {
+         "name": "lock_buttons",
+         "reg_type": "holding",
+         "address": "0x06",
+         "type": "switch",
+         "format": "s16"
+      }
+     ],
+    "translations": {
+        "en":{
+            "power_status":"Power Status",
+            "temperature_from_internal_sensor":"Temperature From Internal Sensor",
+            "manual_mode":"Manual Mode",
+            "heating_status":"Heating Status",
+            "setting_temperature":"Setting Temperature",
+            "weekly_program_setting_temperature":"Weekly program setting temperature",
+            "lock_buttons":"Lock Buttons"
+        },
+      "ru": {
+         "BHT-006 Series": "Термостат BHT-006 Series",
+         "power_status": "Включение",
+         "temperature_from_internal_sensor": "Температура внутреннего датчика",
+         "manual_mode": "Ручной режим",
+         "heating_status": "Статус нагрева",
+         "setting_temperature": "Настройка температуры",
+         "weekly_program_setting_temperature": "Установка температуры для недельной программы",
+         "lock_buttons": "Блокировка кнопок"
+       }
+     }
+    }
+   }

--- a/templates/config-bht-006-series.json
+++ b/templates/config-bht-006-series.json
@@ -82,7 +82,7 @@
                 "manual_mode": "Manual Mode",
                 "heating_status": "Heating Status",
                 "setting_temperature": "Setting Temperature",
-                "weekly_program_setting_temperature": "Weekly program setting temperature",
+                "weekly_program_setting_temperature": "Weekly Program Setting Temperature",
                 "lock_buttons": "Lock Buttons"
             },
             "ru": {

--- a/templates/config-bht-006-series.json
+++ b/templates/config-bht-006-series.json
@@ -18,7 +18,8 @@
                 "name": "temperature_from_internal_sensor",
                 "reg_type": "holding",
                 "address": "0x01",
-                "type": "temperature",
+                "type": "value",
+                "units": "deg C",
                 "format": "s16",
                 "scale": 0.1,
                 "readonly": true
@@ -47,6 +48,7 @@
                 "reg_type": "holding",
                 "address": "0x04",
                 "type": "range",
+                "units": "deg C",
                 "format": "s16",
                 "scale": 0.1,
                 "min": 5,
@@ -58,6 +60,7 @@
                 "address": "0x05",
                 "format": "s16",
                 "type": "range",
+                "units": "deg C",
                 "scale": 0.1,
                 "min": 5,
                 "max": 35

--- a/templates/config-bht-006-series.json
+++ b/templates/config-bht-006-series.json
@@ -10,7 +10,9 @@
                 "reg_type": "holding",
                 "address": "0x00",
                 "type": "switch",
-                "format": "s16"
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
             },
             {
                 "name": "temperature_from_internal_sensor",
@@ -26,7 +28,9 @@
                 "reg_type": "holding",
                 "address": "0x02",
                 "type": "switch",
-                "format": "s16"
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
             },
             {
                 "name": "heating_status",
@@ -34,7 +38,9 @@
                 "address": "0x03",
                 "type": "switch",
                 "format": "s16",
-                "readonly": true
+                "readonly": true,
+                "on_value": 1,
+                "off_value": 0
             },
             {
                 "name": "setting_temperature",
@@ -61,7 +67,9 @@
                 "reg_type": "holding",
                 "address": "0x06",
                 "type": "switch",
-                "format": "s16"
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
             }
         ],
         "translations": {

--- a/templates/config-bht-006-series.json
+++ b/templates/config-bht-006-series.json
@@ -2,88 +2,88 @@
     "device_type": "BHT-006 Series",
     "group": "g-thermostat",
     "device": {
-       "name": "BHT-006 Series",
-       "id": "bht-006-series", 
-     "channels": [
-      {
-         "name": "power_status",
-         "reg_type": "holding",
-         "address": "0x00",
-         "type": "switch",
-         "format": "s16"
-      },
-      {
-         "name": "temperature_from_internal_sensor",
-         "reg_type": "holding",
-         "address": "0x01",
-         "type": "temperature",
-         "format": "s16",
-         "scale": 0.1,
-         "readonly": true
-      },
-      {
-         "name": "manual_mode",
-         "reg_type": "holding",
-         "address": "0x02",
-         "type": "switch",
-         "format": "s16"
-      },
-      {
-         "name": "heating_status",
-         "reg_type": "holding",
-         "address": "0x03",
-         "type": "switch",
-         "format": "s16",
-         "readonly": true
-      },
-      {
-         "name": "setting_temperature", 
-         "reg_type": "holding",
-         "address": "0x04",
-         "type": "range",
-         "format": "s16",
-         "scale": 0.1,
-         "min": 5,
-         "max": 35
-      },
-      {
-         "name": "weekly_program_setting_temperature",
-         "reg_type": "holding",
-         "address": "0x05",
-         "format": "s16",
-         "type": "range",
-         "scale": 0.1,
-         "min": 5,
-         "max": 35
-      },
-      {
-         "name": "lock_buttons",
-         "reg_type": "holding",
-         "address": "0x06",
-         "type": "switch",
-         "format": "s16"
-      }
-     ],
-    "translations": {
-        "en":{
-            "power_status":"Power Status",
-            "temperature_from_internal_sensor":"Temperature From Internal Sensor",
-            "manual_mode":"Manual Mode",
-            "heating_status":"Heating Status",
-            "setting_temperature":"Setting Temperature",
-            "weekly_program_setting_temperature":"Weekly program setting temperature",
-            "lock_buttons":"Lock Buttons"
-        },
-      "ru": {
-         "BHT-006 Series": "Термостат BHT-006 Series",
-         "power_status": "Включение",
-         "temperature_from_internal_sensor": "Температура внутреннего датчика",
-         "manual_mode": "Ручной режим",
-         "heating_status": "Статус нагрева",
-         "setting_temperature": "Настройка температуры",
-         "weekly_program_setting_temperature": "Установка температуры для недельной программы",
-         "lock_buttons": "Блокировка кнопок"
-       }
-     }
+        "name": "BHT-006 Series",
+        "id": "bht-006-series",
+        "channels": [
+            {
+                "name": "power_status",
+                "reg_type": "holding",
+                "address": "0x00",
+                "type": "switch",
+                "format": "s16"
+            },
+            {
+                "name": "temperature_from_internal_sensor",
+                "reg_type": "holding",
+                "address": "0x01",
+                "type": "temperature",
+                "format": "s16",
+                "scale": 0.1,
+                "readonly": true
+            },
+            {
+                "name": "manual_mode",
+                "reg_type": "holding",
+                "address": "0x02",
+                "type": "switch",
+                "format": "s16"
+            },
+            {
+                "name": "heating_status",
+                "reg_type": "holding",
+                "address": "0x03",
+                "type": "switch",
+                "format": "s16",
+                "readonly": true
+            },
+            {
+                "name": "setting_temperature",
+                "reg_type": "holding",
+                "address": "0x04",
+                "type": "range",
+                "format": "s16",
+                "scale": 0.1,
+                "min": 5,
+                "max": 35
+            },
+            {
+                "name": "weekly_program_setting_temperature",
+                "reg_type": "holding",
+                "address": "0x05",
+                "format": "s16",
+                "type": "range",
+                "scale": 0.1,
+                "min": 5,
+                "max": 35
+            },
+            {
+                "name": "lock_buttons",
+                "reg_type": "holding",
+                "address": "0x06",
+                "type": "switch",
+                "format": "s16"
+            }
+        ],
+        "translations": {
+            "en": {
+                "power_status": "Power Status",
+                "temperature_from_internal_sensor": "Temperature From Internal Sensor",
+                "manual_mode": "Manual Mode",
+                "heating_status": "Heating Status",
+                "setting_temperature": "Setting Temperature",
+                "weekly_program_setting_temperature": "Weekly program setting temperature",
+                "lock_buttons": "Lock Buttons"
+            },
+            "ru": {
+                "BHT-006 Series": "Термостат BHT-006 Series",
+                "power_status": "Включение",
+                "temperature_from_internal_sensor": "Температура внутреннего датчика",
+                "manual_mode": "Ручной режим",
+                "heating_status": "Статус нагрева",
+                "setting_temperature": "Настройка температуры",
+                "weekly_program_setting_temperature": "Установка температуры для недельной программы",
+                "lock_buttons": "Блокировка кнопок"
+            }
+        }
     }
-   }
+}

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -109,6 +109,14 @@ BAC-6000ELNW
 	Room Temperature  =>  Room Temperature
 	Status  =>  Status
 	Temperature Setpoint  =>  Temperature Setpoint
+BHT-006 Series
+	heating_status  =>  heating_status
+	lock_buttons  =>  lock_buttons
+	manual_mode  =>  manual_mode
+	power_status  =>  power_status
+	setting_temperature  =>  setting_temperature
+	temperature_from_internal_sensor  =>  temperature_from_internal_sensor
+	weekly_program_setting_temperature  =>  weekly_program_setting_temperature
 BHT-6000 Series
 	Heating status  =>  Heating status
 	Lock buttons  =>  Lock buttons


### PR DESCRIPTION
New template for thermostat BHT-006 Series.

[YouTrack](https://wirenboard.youtrack.cloud/issue/INT-192)
[Wiki](https://wirenboard.com/wiki/BHT-006_Series)
[Cloud with the controller, where to find the template](https://amrztmud.http.wirenboard.cloud/#!/devices)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file for the "BHT-006 Series" device, defining various functionalities and properties.
	- Added support for multiple channels including power status, temperature readings, and manual mode.
	- Implemented localized channel names in English and Russian for improved user accessibility.
	- Updated changelog to reflect the addition of the BHT-006 device template in version 2.150.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->