### PR TITLE
add translation and order channels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 wb-mqtt-serial (2.149.2) stable; urgency=medium
 
-  * Add translate for template BHT-6000
-
+  * Add translations for template BHT-6000
+  
  -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 05 Dec 2024 14:15:00 +0300
 
 wb-mqtt-serial (2.149.1) stable; urgency=medium

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.149.1) stable; urgency=medium
+
+  * Add translate for template BHT-6000
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Wed, 04 Dec 2024 13:00:00 +0300
+
 wb-mqtt-serial (2.149.0) stable; urgency=medium
 
   * Add template for WBE2-I-OPENTHERM-FW-1-7-3

--- a/templates/config-bht-6000-series.json
+++ b/templates/config-bht-6000-series.json
@@ -1,69 +1,88 @@
 {
- "device_type": "BHT-6000 Series",
- "group": "g-thermostat",
- "device": {
-  "name": "BHT-6000 Series",
-  "id": "bht-6000-series", 
-  "channels": [
-   {
-    "name": "Power",
-    "reg_type": "holding",
-    "address": "0x00",
-    "type": "switch",
-    "format": "s16"
-   },
-   {
-    "name": "Lock buttons",
-    "reg_type": "holding",
-    "address": "0x06",
-    "type": "switch",
-    "format": "s16"
-   },
-   {
-    "name": "Temperature from internal sensor",
-    "reg_type": "holding",
-    "address": "0x01",
-    "type": "temperature",
-    "format": "s16",
-    "scale": 0.1,
-    "readonly": true
-   },
-   {
-    "name": "Weekly program setting temperature",
-    "reg_type": "holding",
-    "address": "0x05",
-    "type": "temperature",
-    "format": "s16",
-    "type": "range",
-    "scale": 0.1,
-    "min": 5,
-    "max": 35
-   },
-   {
-    "name": "Heating status",
-    "reg_type": "holding",
-    "address": "0x03",
-    "type": "switch",
-    "format": "s16",
-    "readonly": true
-   },
-   {
-    "name": "Manual mode",
-    "reg_type": "holding",
-    "address": "0x02",
-    "type": "switch",
-    "format": "s16"
-   },
-   {
-    "name": "Setting temperature", 
-    "reg_type": "holding",
-    "address": "0x04",
-    "type": "range",
-    "format": "s16",
-    "scale": 0.1,
-    "min": 5,
-    "max": 35
-   }
-  ]
- }
+    "device_type": "BHT-6000 Series",
+    "group": "g-thermostat",
+    "device": {
+        "name": "BHT-6000 Series",
+        "id": "bht-6000-series",
+        "channels": [
+            {
+                "name": "Power",
+                "reg_type": "holding",
+                "address": "0x00",
+                "type": "switch",
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
+            },
+            {
+                "name": "Temperature from internal sensor",
+                "reg_type": "holding",
+                "address": "0x01",
+                "type": "temperature",
+                "format": "s16",
+                "scale": 0.1,
+                "readonly": true
+            },
+            {
+                "name": "Manual mode",
+                "reg_type": "holding",
+                "address": "0x02",
+                "type": "switch",
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
+            },
+            {
+                "name": "Heating status",
+                "reg_type": "holding",
+                "address": "0x03",
+                "type": "switch",
+                "format": "s16",
+                "readonly": true,
+                "on_value": 1,
+                "off_value": 0
+            },
+            {
+                "name": "Setting temperature",
+                "reg_type": "holding",
+                "address": "0x04",
+                "type": "range",
+                "format": "s16",
+                "scale": 0.1,
+                "min": 5,
+                "max": 35
+            },
+            {
+                "name": "Weekly program setting temperature",
+                "reg_type": "holding",
+                "address": "0x05",
+                "format": "s16",
+                "type": "range",
+                "scale": 0.1,
+                "min": 5,
+                "max": 35
+            },
+            {
+                "name": "Lock buttons",
+                "reg_type": "holding",
+                "address": "0x06",
+                "type": "switch",
+                "format": "s16",
+                "on_value": 1,
+                "off_value": 0
+            }
+        ],
+        "translations": {
+            "ru": {
+                "BHT-6000 Series": "Термостат BHT-6000 Series",
+                "Power": "Включение",
+                "Temperature from internal sensor": "Температура внутреннего датчика",
+                "Manual mode": "Ручной режим",
+                "Heating status": "Статус нагрева",
+                "Setting temperature": "Настройка температуры",
+                "Weekly program setting temperature": "Установка температуры для недельной программы",
+                "Lock buttons": "Блокировка кнопок"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Добавил переводы для шаблона BHT-6000, так как делал шаблон для очень похожего устройства BHT-006
https://github.com/wirenboard/wb-mqtt-serial/pull/841
[Облако, где посмотреть шаблон](https://amrztmud.http.wirenboard.cloud/#!/devices)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced switch channels with `on_value` and `off_value` properties for "Power," "Manual mode," "Heating status," and "Lock buttons."
	- Introduced a new `translations` object for Russian translations of device attributes, improving localization support.

- **Improvements**
	- Restructured the "Weekly program setting temperature" channel for better organization while maintaining existing specifications.

- **Changelog Updates**
	- Updated version to `2.149.2`, reflecting the addition of translations for the BHT-6000 template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->