### PR TITLE
Add "protocol:" prefix to type in config/Load

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.151.0) stable; urgency=medium
+
+  * Add "protocol:" prefix to type field in config/Load RPC response for schemas of custom devices.
+    This fixes displaying on Mercury 230 configs in wb-mqtt-homeui.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 11 Dec 2024 11:47:56 +0500
+
 wb-mqtt-serial (2.150.0) stable; urgency=medium
 
   * Add template for BHT-006

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
-Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.82.0~~)
+Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.107.0~~)
 Description: Wiren Board Smart Home MQTT serial protocol driver
  wb-mqtt-serial is a service which communicates with devices on RS-485
  via Modbus or other supported protocols. Modbus TCP is also supported.

--- a/src/rpc/rpc_config_handler.cpp
+++ b/src/rpc/rpc_config_handler.cpp
@@ -13,6 +13,8 @@ namespace
     const std::string WB_GROUP_NAME = "g-wb";
     const std::string WB_OLD_GROUP_NAME = "g-wb-old";
 
+    const std::string PROTOCOL_PREFIX = "protocol:";
+
     struct TDeviceTypeGroup
     {
         typedef std::vector<PDeviceTemplate> TemplatesArray;
@@ -47,7 +49,10 @@ namespace
     {
         Json::Value res;
         res["name"] = schema.GetTitle(lang);
-        res["type"] = schema.Type;
+        res["deprecated"] = false;
+        res["type"] = PROTOCOL_PREFIX + schema.Type;
+        res["protocol"] = schema.Type;
+        res["mqtt-id"] = schema.Type;
         return res;
     }
 
@@ -192,9 +197,9 @@ Json::Value TRPCConfigHandler::GetDeviceTypes(const Json::Value& request)
 Json::Value TRPCConfigHandler::GetSchema(const Json::Value& request)
 {
     std::string type = request.get("type", "").asString();
-    try {
-        return *DeviceConfedSchemas.GetSchema(type);
-    } catch (const std::out_of_range&) {
+    if (type.find(PROTOCOL_PREFIX) == 0) {
+        type = type.substr(PROTOCOL_PREFIX.size());
         return ProtocolConfedSchemas.GetSchema(type);
     }
+    return *DeviceConfedSchemas.GetSchema(type);
 }


### PR DESCRIPTION
config/Load RPC response contains a list of device templates. Each template item has type field with value from templates' s device_type. Protocols for custom devices are also in the list. Type field for them is populated with a protocol name. The type field must be unique across all items, but some device types and protocol names are the same. Add prefix to protocol types to make them unique

При запросе списка доступных шаблонов устройств, возвращаются в этом же списке и схемы для произвольных йстройств с заданным протоколом. Для каждого элемента в этом списке есть поле type, которое является ключём. Потом по этому полю можно запросить схему для json-editor. Для произвольных устройств туда пишется название протокола. Оказалось, что тип устройства в шаблоне и протокол могут совпадать. В результатет поле type не уникальное. Для протоколов добавил префикс в поле type



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "protocol:" prefix to the type field in configuration responses for custom devices, improving compatibility with Mercury 230 configurations in the interface.
  
- **Bug Fixes**
  - Updated compatibility requirements for the `wb-mqtt-homeui` package to ensure proper functionality with the latest version of `wb-mqtt-serial`.

- **Enhancements**
  - Improved handling of protocol types in JSON responses, streamlining the schema retrieval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->