### PR TITLE
Add default config for Wiren Board 8.5

### DIFF
--- a/configs/config.json.wb85
+++ b/configs/config.json.wb85
@@ -1,0 +1,59 @@
+{
+    "debug": false,
+    "ports": [
+        {
+            "path": "/dev/ttyRS485-1",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": true,
+            "devices": []
+        },
+        {
+            "path": "/dev/ttyRS485-2",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": true,
+            "devices": []
+        },
+        {
+            "path": "/dev/ttyMOD1",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": false,
+            "devices": []
+        },
+        {
+            "path": "/dev/ttyMOD2",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": false,
+            "devices": []
+        },
+        {
+            "path": "/dev/ttyMOD3",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": false,
+            "devices": []
+        },
+        {
+            "path": "/dev/ttyMOD4",
+            "baud_rate": 9600,
+            "parity": "N",
+            "data_bits": 8,
+            "stop_bits": 2,
+            "enabled": false,
+            "devices": []
+        }
+    ]
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.152.2) stable; urgency=medium
+
+  * Add default config with ttyMOD4 for Wiren Board 8.5
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 24 Dec 2024 19:54:50 +0500
+
 wb-mqtt-serial (2.152.1) stable; urgency=medium
 
   * WB-MAI6: add Internal 5V Bus Voltage channel

--- a/debian/wb-mqtt-serial.postinst
+++ b/debian/wb-mqtt-serial.postinst
@@ -8,6 +8,8 @@ wb_source "of"
 
 CONFFILE=/etc/wb-mqtt-serial.conf
 
+if of_machine_match "wirenboard,wirenboard-85x"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb85"
 if of_machine_match "wirenboard,wirenboard-8xx"; then
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb8"
 elif of_machine_match "wirenboard,wirenboard-720"; then

--- a/debian/wb-mqtt-serial.postinst
+++ b/debian/wb-mqtt-serial.postinst
@@ -10,7 +10,7 @@ CONFFILE=/etc/wb-mqtt-serial.conf
 
 if of_machine_match "wirenboard,wirenboard-85x"; then
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb85"
-if of_machine_match "wirenboard,wirenboard-8xx"; then
+elif of_machine_match "wirenboard,wirenboard-8xx"; then
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb8"
 elif of_machine_match "wirenboard,wirenboard-720"; then
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb7"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file for serial communication settings.
	- Added default configuration for the `ttyMOD4` device for Wiren Board 8.5.

- **Bug Fixes**
	- Enhanced conditional checks in the installation script for improved configuration handling based on machine type.

- **Chores**
	- Updated changelog for the new version of the `wb-mqtt-serial` package (2.152.2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->