### PR TITLE
Validate conditions syntax

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.152.4) stable; urgency=medium
+
+  * Validate conditions syntax in device templates
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 09 Jan 2025 12:51:23 +0500
+
 wb-mqtt-serial (2.152.3) stable; urgency=medium
 
   * Fix max_unchanged_interval description

--- a/src/expression_evaluator.h
+++ b/src/expression_evaluator.h
@@ -130,6 +130,7 @@ namespace Expressions
          *
          * @param str string containing expression to parse
          * @return resulting AST
+         * @throw std::runtime_error on parsing error
          */
         std::unique_ptr<TAstNode> Parse(const std::string& str);
     };

--- a/test/device-templates/config-invalid-channel-condition.json
+++ b/test/device-templates/config-invalid-channel-condition.json
@@ -1,0 +1,16 @@
+{
+    "device_type": "invalid_channel_condition",
+    "device": {
+        "name": "invalid channel condition",
+        "id": "invalid channel condition",
+        "channels": [
+            {
+                "name": "Temperature",
+                "reg_type": "input",
+                "format": "s32",
+                "address": "0x0504",
+                "condition": "( in1 > 3 )"
+            }
+        ]
+    }
+}

--- a/test/device-templates/config-invalid-param-condition.json
+++ b/test/device-templates/config-invalid-param-condition.json
@@ -1,0 +1,30 @@
+{
+    "device_type": "invalid_param_condition",
+    "device": {
+        "name": "invalid param condition",
+        "id": "invalid param condition",
+        "setup": [
+            {
+                "title": "Param",
+                "address": "0x0504",
+                "value": 1
+            }
+        ],
+        "channels": [
+            {
+                "name": "Temperature",
+                "reg_type": "input",
+                "format": "s32",
+                "address": "0x0504"
+            }
+        ],
+        "parameters": [
+            {
+                "id": "Test",
+                "title": "p1",
+                "address": 9992,
+                "condition": "( in1 > 3 )"
+            }
+        ]
+    }
+}

--- a/test/device-templates/config-invalid-setup-condition.json
+++ b/test/device-templates/config-invalid-setup-condition.json
@@ -1,0 +1,23 @@
+{
+    "device_type": "invalid_setup_condition",
+    "device": {
+        "name": "invalid setup condition",
+        "id": "invalid setup condition",
+        "setup": [
+            {
+                "title": "Param",
+                "address": "0x0504",
+                "value": 1,
+                "condition": "( in1 > 3 )"
+            }
+        ],
+        "channels": [
+            {
+                "name": "Temperature",
+                "reg_type": "input",
+                "format": "s32",
+                "address": "0x0504"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Validate conditions syntax on device template loading and during package build

Сразу проверяю корректность синтаксиса условий. Теперь пакет не соберётся с кривым шаблоном. Раньше часть условий проверялись только в момент загрузки настроек. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for wb-mqtt-serial v2.152.5

- **New Features**
  - Added validation for conditions syntax in device templates.
  - Introduced new functions for enhanced validation and error handling of device template conditions.
  
- **Bug Fixes**
  - Improved error messages for invalid conditions during template parsing.

- **Tests**
  - Added test cases to validate error handling for invalid conditions in device templates.

This release enhances the functionality and reliability of device template configurations by ensuring syntactical correctness and improving error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->