### PR TITLE
Feature/wb led disable hue events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.152.4) stable; urgency=medium
+
+  * Disable events for `RGB Strip Hue` for WB-LED and WB-MRGBW-D
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 10 Jan 2025 15:56:33 +0300
+
 wb-mqtt-serial (2.152.3) stable; urgency=medium
 
   * Fix max_unchanged_interval description

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -1029,7 +1029,6 @@
                 "address": 2014,
                 "type": "range",
                 "reg_type": "holding",
-                "sporadic": true,
                 "min": 0,
                 "max": 360,
                 "error_value": "0xFFFF",

--- a/templates/config-wb-mrgbw-d-fw3.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw3.json.jinja
@@ -2102,7 +2102,6 @@
                 "address": 2014,
                 "type": "range",
                 "reg_type": "holding",
-                "sporadic": true,
                 "min": 0,
                 "max": 360,
                 "error_value": "0xFFFF",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->

Это уже исправляли тут https://github.com/wirenboard/wb-mqtt-serial/pull/807
Но потом сломали тут https://github.com/wirenboard/wb-mqtt-serial/pull/810/files#diff-08a2944d1f3713c6f4d7b0bb550eaa3d544a6257dcf79c27fa1bc9a5744fa965R1032

Исправляем снова, подробности в тикете https://wirenboard.youtrack.cloud/issue/FW-656#focus=Change-4-142657.0-0.pinned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for wb-mqtt-serial v2.152.4

- **Bug Fixes**
  - Disabled events for RGB Strip Hue on WB-LED and WB-MRGBW-D devices
  - Removed sporadic attribute from multiple channel configurations

- **Version Update**
  - Package updated from 2.152.3 to 2.152.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->