### PR TITLE
Feature/fw 274 mcm debounce

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.153.1) stable; urgency=medium
+
+  * WB-MCM8 template: set maximum debounce time to 2000 ms
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Tue, 21 Jan 2025 11:20:54 +0300
+
 wb-mqtt-serial (2.153.0) stable; urgency=medium
 
   * Deprecate WB-MIR v.2 template

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -103,7 +103,7 @@
                 "address": {{20 + in_num - 1}},
                 "reg_type": "holding",
                 "min": 0,
-                "max": 100,
+                "max": 2000,
                 "default": 50,
                 "group": "g_in{{in_num}}",
                 "order": 2


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->

Прошивка уже давно поддерживает 2000 мс максимальное время дебаунса, в шаблоне тоже поправил

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum debounce time for WB-MCM8 template from 100ms to 2000ms
	- Enhanced configuration options for signal processing timing

- **Documentation**
	- Updated package version to 2.153.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->