### PR TITLE
Bugfix/int-307 fix translate for mean well

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.155.2) stable; urgency=medium
+
+  * Fix translate for meanwell-drs-series
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Tue, 18 Feb 2025 08:30:00 +0300
+
 wb-mqtt-serial (2.155.1) stable; urgency=medium
 
   * Check motor id in A-OK protocol to filter the responses that match the request

--- a/templates/config-meanwell-drs.json
+++ b/templates/config-meanwell-drs.json
@@ -532,7 +532,7 @@
         "translations": {
             "en": {
                 "template_title": "MEAN WELL DRS Series - Multi-function Power Supply",
-                "remote_control": "Remote Control",
+                "remote_control": "DC output",
                 "voltage_dc_setpoint": "Voltage DC Setpoint (V)",
                 "voltage_dc_setpoint_description": "The Value Will Be Applied After Device Is Re-powered",
                 "charging_current_setpoint": "Charging Current Setpoint (A)",
@@ -574,7 +574,7 @@
                 "Unit Status": "Состояние устройства",
                 "Settings": "Настройка",
                 "HW Info": "Данные устройства",
-                "remote_control": "Удаленное управление",
+                "remote_control": "Выход DC",
                 "Off": "Отключить",
                 "On": "Включить",
                 "voltage_dc_setpoint": "Уставка выходного напряжения (В)",


### PR DESCRIPTION
Изменен перевод для одного канала, т.к. прошлый вариант вносил путаницу.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected translation terms for improved clarity. The interface now labels the remote control function as "DC output" in both English and Russian, ensuring a more accurate and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->