### PR TITLE
WB-MRWM2: Change the default overvoltage threshold to 242V

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.157.1) stable; urgency=medium
+
+  * WB-MRWM2 template: Change the default overvoltage threshold to 242V
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Wed, 12 Mar 2025 11:12:00 +0300
+
 wb-mqtt-serial (2.157.0) stable; urgency=medium
 
   * Add WB-MAI2-mini/CC v.3 support

--- a/templates/config-wb-mrwm2.json.jinja
+++ b/templates/config-wb-mrwm2.json.jinja
@@ -449,7 +449,7 @@
                 "scale": 0.01,
                 "min": 230,
                 "max": 277,
-                "default": 253,
+                "default": 242,
                 "group": "gg_out{{out_num}}_voltage_params",
                 "order": 4
             },
@@ -789,7 +789,7 @@
                 {% endfor -%}
                 "protective_functions_description": "For Protective Functions firmware v1.21.0 or newer is required",
                 "undervoltage_description": "120 to 220, factory default - 207",
-                "overvoltage_description": "230 to 277, factory default - 253",
+                "overvoltage_description": "230 to 277, factory default - 242",
                 "voltage_dip_duration_description": "0.5 to 10, factory default - 5",
                 "startup_delay_ctrl_dis_description": "0 to 999, factory default - 0",
                 "startup_delay_ctrl_en_description": "3 to 999, factory default - 10",
@@ -916,7 +916,7 @@
 
                 "protective_functions_description": "Для использования защитных функций требуется прошивка версии 1.21.0 и выше",
                 "undervoltage_description": "120...220, заводское - 207",
-                "overvoltage_description": "230...277, заводское - 253",
+                "overvoltage_description": "230...277, заводское - 242",
                 "voltage_dip_duration_description": "0.5...10, заводское - 5",
                 "startup_delay_ctrl_dis_description": "0...999, заводское - 0",
                 "startup_delay_ctrl_en_description": "3...999, заводское - 10",


### PR DESCRIPTION
Изменен верхний предел напряжения по умолчанию