### PR TITLE
Fix port scan WB-MAP signature check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.158.4) stable; urgency=medium
+
+  * Fix port scan WB-MAP signature check
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 08 Apr 2025 15:52:08 +0300
+
 wb-mqtt-serial (2.158.3) stable; urgency=medium
 
   * Fix serial client event logs

--- a/src/rpc/rpc_port_scan_serial_client_task.cpp
+++ b/src/rpc/rpc_port_scan_serial_client_task.cpp
@@ -6,6 +6,7 @@
 #include "serial_exc.h"
 #include "serial_port.h"
 #include "wb_registers.h"
+#include <regex>
 
 #define LOG(logger) ::logger.Log() << "[RPC] "
 
@@ -28,7 +29,7 @@ namespace
 
     uint32_t GetSnFromRegister(const std::string& deviceModel, uint32_t sn)
     {
-        if (WBMQTT::StringStartsWith(deviceModel, "WB-MAP")) {
+        if (std::regex_match(deviceModel, std::regex("^MAP[0-9]{1,2}.*"))) {
             return sn & 0x00FFFFFF;
         }
         return sn;


### PR DESCRIPTION
Исправил ошибку, из-за которой, при сканировании порта, для счетчиков WB-MAP некорректно считался серийный номер.