### PR TITLE
Fix conditional jump depending on uninitialised value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.158.6) stable; urgency=medium
+
+  * Fix conditional jump depending on uninitialised value
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 09 Apr 2025 13:00:00 +0400
+
 wb-mqtt-serial (2.158.5) stable; urgency=medium
 
   * Fix register exclusion log

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -166,7 +166,9 @@ namespace ModbusExt // modbus extension protocol declarations
 
         switch (buf[SUB_COMMAND_POS]) {
             case EVENTS_RESPONSE_COMMAND: {
-                if ((size <= EVENTS_RESPONSE_DATA_SIZE_POS) || (size != EVENTS_RESPONSE_HEADER_SIZE + buf[EVENTS_RESPONSE_DATA_SIZE_POS] + CRC_SIZE)) {
+                if ((size <= EVENTS_RESPONSE_DATA_SIZE_POS) ||
+                    (size != EVENTS_RESPONSE_HEADER_SIZE + buf[EVENTS_RESPONSE_DATA_SIZE_POS] + CRC_SIZE))
+                {
                     return false;
                 }
                 break;

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -166,7 +166,7 @@ namespace ModbusExt // modbus extension protocol declarations
 
         switch (buf[SUB_COMMAND_POS]) {
             case EVENTS_RESPONSE_COMMAND: {
-                if (size != EVENTS_RESPONSE_HEADER_SIZE + buf[EVENTS_RESPONSE_DATA_SIZE_POS] + CRC_SIZE) {
+                if ((size <= EVENTS_RESPONSE_DATA_SIZE_POS) || (size != EVENTS_RESPONSE_HEADER_SIZE + buf[EVENTS_RESPONSE_DATA_SIZE_POS] + CRC_SIZE)) {
                     return false;
                 }
                 break;


### PR DESCRIPTION
Fix valgrind error:
```sh
 ==717== Conditional jump or move depends on uninitialised value(s)
 ==717==    at 0x57E40B: ModbusExt::IsModbusExtPacket(unsigned char const*, unsigned long) (in ./test/wb-homa-test)
 ==717==    by 0x57E452: ModbusExt::GetPacketStart(unsigned char const*, unsigned long) (in ./test/wb-homa-test)
 ==717==    by 0x57E491: std::_Function_handler<bool (unsigned char*, unsigned long), ModbusExt::ExpectFastModbus()::{lambda(unsigned char*, unsigned long)#1}>::_M_invoke(std::_Any_data const&, unsigned char*&&, unsigned long&&) (in ./test/wb-homa-test)
 ==717==    by 0x5E9F09: TFakeSerialPort::ReadFrame(unsigned char*, unsigned long, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::function<bool (unsigned char*, unsigned long)>) (in ./test/wb-homa-test)
 ==717==    by 0x66532D: (anonymous namespace)::TFakeSerialPortWithTime::ReadFrame(unsigned char*, unsigned long, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, std::function<bool (unsigned char*, unsigned long)>) (in ./test/wb-homa-test)
 ==717==    by 0x57F617: ModbusExt::ReadEvents(TPort&, std::chrono::duration<long, std::ratio<1l, 1000l> >, unsigned char, ModbusExt::TEventConfirmationState&, ModbusExt::IEventsVisitor&) (in ./test/wb-homa-test)
 ==717==    by 0x4DAA05: TSerialClientEventsReader::ReadEvents(TPort&, std::chrono::duration<long, std::ratio<1l, 1000l> >, std::function<void (std::shared_ptr<TRegister>)>, std::function<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > ()>) (in ./test/wb-homa-test)
 ==717==    by 0x4B99CD: TSerialClientRegisterAndEventsReader::OpenPortCycle(TPort&, std::function<void (std::shared_ptr<TRegister>)>, TSerialClientDeviceAccessHandler&) (in ./test/wb-homa-test)
 ==717==    by 0x66C74C: TPollTest::Cycle(TSerialClientRegisterAndEventsReader&, TSerialClientDeviceAccessHandler&) (in ./test/wb-homa-test)
 ==717==    by 0x66ABE3: TPollTest_ReconnectWithOnlyEvents_Test::TestBody() (in ./test/wb-homa-test)
 ==717==    by 0x4A4827A: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in ./gtest-1.16.0/lib/libgtest.so.1.16.0)
 ==717==    by 0x4A34FF5: testing::Test::Run() (in ./gtest-1.16.0/lib/libgtest.so.1.16.0)
 ==717==
```