### PR TITLE
Refactor Modbus::WriteRegister method

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.159.1) stable; urgency=medium
+
+  * Refactor Modbus::WriteRegister method, no functional changes
+  * Add Modbus::ExceptionCode enumerator, no functional changes
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Wed, 23 Apr 2025 10:09:20 +0000
+
 wb-mqtt-serial (2.159.0) stable; urgency=medium
 
   * Update Gurux.DLMS.cpp to 20250303.1

--- a/src/modbus_base.h
+++ b/src/modbus_base.h
@@ -27,7 +27,14 @@ namespace Modbus
         FN_WRITE_SINGLE_COIL = 0x5,
         FN_WRITE_SINGLE_REGISTER = 0x6,
         FN_WRITE_MULTIPLE_COILS = 0xF,
-        FN_WRITE_MULTIPLE_REGISTERS = 0x10,
+        FN_WRITE_MULTIPLE_REGISTERS = 0x10
+    };
+
+    enum ExceptionCode
+    {
+        ILLEGAL_FUNCTION = 0x1,
+        ILLEGAL_DATA_ADDRESS = 0x2,
+        ILLEGAL_DATA_VALUE = 0x3
     };
 
     struct TReadResult

--- a/src/modbus_base.h
+++ b/src/modbus_base.h
@@ -30,7 +30,7 @@ namespace Modbus
         FN_WRITE_MULTIPLE_REGISTERS = 0x10
     };
 
-    enum ExceptionCode
+    enum EExceptionCode
     {
         ILLEGAL_FUNCTION = 0x1,
         ILLEGAL_DATA_ADDRESS = 0x2,

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -710,9 +710,8 @@ namespace Modbus // modbus protocol common utilities
     {
         Modbus::TRegisterCache tmpCache;
 
-        LOG(Debug) << "write " << GetModbusDataWidthIn16BitWords(reg) << " " << reg.TypeName << "(s) @ "
-                   << reg.GetWriteAddress() << " of device "
-                   << (reg.Device() ? reg.Device()->ToString() : std::to_string(slaveId));
+        LOG(Info) << port.GetDescription() << " modbus:" << std::to_string(slaveId) << " write "
+                  << GetModbusDataWidthIn16BitWords(reg) << " " << reg.TypeName << "(s) @ " << reg.GetWriteAddress();
 
         std::vector<uint8_t> data;
         auto addr = GetUint32RegisterAddress(reg.GetWriteAddress()) + shift;

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -72,7 +72,10 @@ namespace // general utilities
 
     void RethrowSerialDeviceException(const Modbus::TModbusExceptionError& err)
     {
-        if (err.GetExceptionCode() == 1 || err.GetExceptionCode() == 2 || err.GetExceptionCode() == 3) {
+        if (err.GetExceptionCode() == Modbus::ILLEGAL_FUNCTION ||
+            err.GetExceptionCode() == Modbus::ILLEGAL_DATA_ADDRESS ||
+            err.GetExceptionCode() == Modbus::ILLEGAL_DATA_VALUE)
+        {
             throw TSerialDevicePermanentRegisterException(err.what());
         }
         throw TSerialDeviceTransientErrorException(err.what());

--- a/src/modbus_common.h
+++ b/src/modbus_common.h
@@ -62,7 +62,7 @@ namespace Modbus // modbus protocol common utilities
     void WriteRegister(IModbusTraits& traits,
                        TPort& port,
                        uint8_t slaveId,
-                       TRegister& reg,
+                       const TRegisterConfig& reg,
                        const TRegisterValue& value,
                        TRegisterCache& cache,
                        std::chrono::microseconds requestDelay,
@@ -80,7 +80,7 @@ namespace Modbus // modbus protocol common utilities
     TRegisterValue ReadRegister(IModbusTraits& traits,
                                 TPort& port,
                                 uint8_t slaveId,
-                                const TRegisterConfig& registerConfig,
+                                const TRegisterConfig& reg,
                                 std::chrono::microseconds requestDelay,
                                 std::chrono::milliseconds responseTimeout,
                                 std::chrono::milliseconds frameTimeout);

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -900,15 +900,7 @@ void TSerialDeviceFactory::RegisterProtocol(PProtocol protocol, IDeviceFactory* 
     Protocols.insert(std::make_pair(protocol->GetName(), params));
 }
 
-PProtocol TSerialDeviceFactory::GetProtocol(const std::string& name)
-{
-    auto it = Protocols.find(name);
-    if (it == Protocols.end())
-        throw TSerialDeviceException("unknown protocol: " + name);
-    return it->second.protocol;
-}
-
-TDeviceProtocolParams TSerialDeviceFactory::GetProtocolParams(const std::string& protocolName)
+TDeviceProtocolParams TSerialDeviceFactory::GetProtocolParams(const std::string& protocolName) const
 {
     auto it = Protocols.find(protocolName);
     if (it == Protocols.end()) {
@@ -917,22 +909,19 @@ TDeviceProtocolParams TSerialDeviceFactory::GetProtocolParams(const std::string&
     return it->second;
 }
 
+PProtocol TSerialDeviceFactory::GetProtocol(const std::string& protocolName) const
+{
+    return GetProtocolParams(protocolName).protocol;
+}
+
 const std::string& TSerialDeviceFactory::GetCommonDeviceSchemaRef(const std::string& protocolName) const
 {
-    auto it = Protocols.find(protocolName);
-    if (it == Protocols.end()) {
-        throw TSerialDeviceException("unknown protocol: " + protocolName);
-    }
-    return it->second.factory->GetCommonDeviceSchemaRef();
+    return GetProtocolParams(protocolName).factory->GetCommonDeviceSchemaRef();
 }
 
 const std::string& TSerialDeviceFactory::GetCustomChannelSchemaRef(const std::string& protocolName) const
 {
-    auto it = Protocols.find(protocolName);
-    if (it == Protocols.end()) {
-        throw TSerialDeviceException("unknown protocol: " + protocolName);
-    }
-    return it->second.factory->GetCustomChannelSchemaRef();
+    return GetProtocolParams(protocolName).factory->GetCustomChannelSchemaRef();
 }
 
 std::vector<std::string> TSerialDeviceFactory::GetProtocolNames() const

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -189,8 +189,8 @@ class TSerialDeviceFactory
 
 public:
     void RegisterProtocol(PProtocol protocol, IDeviceFactory* deviceFactory);
-    PProtocol GetProtocol(const std::string& name);
-    TDeviceProtocolParams GetProtocolParams(const std::string& protocolName);
+    TDeviceProtocolParams GetProtocolParams(const std::string& protocolName) const;
+    PProtocol GetProtocol(const std::string& protocolName) const;
     const std::string& GetCommonDeviceSchemaRef(const std::string& protocolName) const;
     const std::string& GetCustomChannelSchemaRef(const std::string& protocolName) const;
     std::vector<std::string> GetProtocolNames() const;


### PR DESCRIPTION
* теперь мето `Modbus::WriteRegister` вместо `TRegister` принимает `TRegisterConfig` 
* обновил отладочный лог метода `Modbus::WriteRegister`
* добавил enum `Modbus::ExceptionCode` для Моdbus исключений в ответах от устройств
* убрал повторяющийся код в методах `serial_config`, заменив его на вызовы метода `GetProtocolParams`