### PR TITLE
Add TResponseTimeoutException handling for device/LoadConfig RPC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.160.3) stable; urgency=medium
+
+  * Add TResponseTimeoutException handling for device/LoadConfig RPC
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Mon, 28 Apr 2025 13:24:03 +0300
+
 wb-mqtt-serial (2.160.2) stable; urgency=medium
 
   * Fix changelog, no functional changes

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -710,8 +710,8 @@ namespace Modbus // modbus protocol common utilities
     {
         Modbus::TRegisterCache tmpCache;
 
-        LOG(Info) << port.GetDescription() << " modbus:" << std::to_string(slaveId) << " write "
-                  << GetModbusDataWidthIn16BitWords(reg) << " " << reg.TypeName << "(s) @ " << reg.GetWriteAddress();
+        LOG(Debug) << port.GetDescription() << " modbus:" << std::to_string(slaveId) << " write "
+                   << GetModbusDataWidthIn16BitWords(reg) << " " << reg.TypeName << "(s) @ " << reg.GetWriteAddress();
 
         std::vector<uint8_t> data;
         auto addr = GetUint32RegisterAddress(reg.GetWriteAddress()) + shift;

--- a/src/rpc/rpc_device_load_config_task.cpp
+++ b/src/rpc/rpc_device_load_config_task.cpp
@@ -39,6 +39,10 @@ namespace
                 if (i == MAX_RETRIES) {
                     throw;
                 }
+            } catch (const TResponseTimeoutException& e) {
+                if (i == MAX_RETRIES) {
+                    throw;
+                }
             }
         }
 
@@ -72,6 +76,10 @@ namespace
                     break;
                 }
             } catch (const Modbus::TErrorBase& err) {
+                if (i == MAX_RETRIES) {
+                    throw;
+                }
+            } catch (const TResponseTimeoutException& e) {
                 if (i == MAX_RETRIES) {
                     throw;
                 }


### PR DESCRIPTION
* добавил обработку `TResponseTimeoutException` для device/LoadConfig RPC
* поправил уровень легирования для `Modbus::WriteRegister` (ошибочно было изменено в https://github.com/wirenboard/wb-mqtt-serial/pull/896)