### PR TITLE
Add template validation error handling for config/GetSchema RPC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.160.4) stable; urgency=medium
+
+  * Add template validation error handling for config/GetSchema RPC
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 29 Apr 2025 15:03:21 +0300
+
 wb-mqtt-serial (2.160.3) stable; urgency=medium
 
   * Add TResponseTimeoutException handling for device/LoadConfig RPC

--- a/src/rpc/rpc_config_handler.cpp
+++ b/src/rpc/rpc_config_handler.cpp
@@ -206,6 +206,7 @@ Json::Value TRPCConfigHandler::GetSchema(const Json::Value& request)
         return *DeviceConfedSchemas.GetSchema(type);
     } catch (const std::runtime_error& e) {
         LOG(Error) << e.what();
-        throw TRPCException("Template \"" + type + "\" schema validation failed", TRPCResultCode::RPC_WRONG_TIMEOUT);
+        throw TRPCException("Template \"" + type + "\" schema validation failed",
+                            TRPCResultCode::RPC_WRONG_PARAM_VALUE);
     }
 }

--- a/src/rpc/rpc_config_handler.cpp
+++ b/src/rpc/rpc_config_handler.cpp
@@ -3,6 +3,7 @@
 #include "file_utils.h"
 #include "json_common.h"
 #include "log.h"
+#include "rpc_exception.h"
 #include "wblib/exceptions.h"
 
 #define LOG(logger) ::logger.Log() << "[RPC] "
@@ -201,5 +202,10 @@ Json::Value TRPCConfigHandler::GetSchema(const Json::Value& request)
         type = type.substr(PROTOCOL_PREFIX.size());
         return ProtocolConfedSchemas.GetSchema(type);
     }
-    return *DeviceConfedSchemas.GetSchema(type);
+    try {
+        return *DeviceConfedSchemas.GetSchema(type);
+    } catch (const std::runtime_error& e) {
+        LOG(Error) << e.what();
+        throw TRPCException("Template \"" + type + "\" schema validation failed", TRPCResultCode::RPC_WRONG_TIMEOUT);
+    }
 }


### PR DESCRIPTION
добавил обработку ошибки валидации шаблона для RPC `config/GetSchema`
