### PR TITLE
Add devices list to ISerialClientTask::Run parameters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.161.2) stable; urgency=medium
+wb-mqtt-serial (2.162.2) stable; urgency=medium
 
   * Source code refactoring. No functional changes
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.161.2) stable; urgency=medium
+
+  * Source code refactoring. No functional changes
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 14 May 2025 18:01:39 +0500
+
 wb-mqtt-serial (2.162.1) stable; urgency=medium
 
   * Source code refactoring. No functional changes

--- a/src/rpc/rpc_device_load_config_task.cpp
+++ b/src/rpc/rpc_device_load_config_task.cpp
@@ -284,7 +284,8 @@ TRPCDeviceLoadConfigSerialClientTask::TRPCDeviceLoadConfigSerialClientTask(PRPCD
 
 ISerialClientTask::TRunResult TRPCDeviceLoadConfigSerialClientTask::Run(
     PPort port,
-    TSerialClientDeviceAccessHandler& lastAccessedDevice)
+    TSerialClientDeviceAccessHandler& lastAccessedDevice,
+    const std::list<PSerialDevice>& polledDevices)
 {
     if (std::chrono::steady_clock::now() > ExpireTime) {
         if (Request->OnError) {

--- a/src/rpc/rpc_device_load_config_task.h
+++ b/src/rpc/rpc_device_load_config_task.h
@@ -54,7 +54,9 @@ class TRPCDeviceLoadConfigSerialClientTask: public ISerialClientTask
 {
 public:
     TRPCDeviceLoadConfigSerialClientTask(PRPCDeviceLoadConfigRequest request);
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRPCDeviceLoadConfigRequest Request;

--- a/src/rpc/rpc_port_driver_list.cpp
+++ b/src/rpc/rpc_port_driver_list.cpp
@@ -44,7 +44,7 @@ TSerialClientTaskExecutor::TSerialClientTaskExecutor(PPort port): Port(port), Ru
             lock.unlock();
             for (auto& task: tasksToRun) {
                 try {
-                    task->Run(Port, lastAccessedDevice);
+                    task->Run(Port, lastAccessedDevice, std::list<PSerialDevice>());
                 } catch (const std::exception& e) {
                     LOG(Error) << "Error while running task: " << e.what();
                 }

--- a/src/rpc/rpc_port_load_modbus_serial_client_task.cpp
+++ b/src/rpc/rpc_port_load_modbus_serial_client_task.cpp
@@ -101,7 +101,8 @@ TRPCPortLoadModbusSerialClientTask::TRPCPortLoadModbusSerialClientTask(const Jso
 
 ISerialClientTask::TRunResult TRPCPortLoadModbusSerialClientTask::Run(
     PPort port,
-    TSerialClientDeviceAccessHandler& lastAccessedDevice)
+    TSerialClientDeviceAccessHandler& lastAccessedDevice,
+    const std::list<PSerialDevice>& polledDevices)
 {
     if (std::chrono::steady_clock::now() > ExpireTime) {
         if (Request->OnError) {

--- a/src/rpc/rpc_port_load_modbus_serial_client_task.h
+++ b/src/rpc/rpc_port_load_modbus_serial_client_task.h
@@ -24,7 +24,9 @@ public:
                                        WBMQTT::TMqttRpcServer::TResultCallback onResult,
                                        WBMQTT::TMqttRpcServer::TErrorCallback onError);
 
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRPCPortLoadModbusRequest Request;

--- a/src/rpc/rpc_port_load_raw_serial_client_task.cpp
+++ b/src/rpc/rpc_port_load_raw_serial_client_task.cpp
@@ -41,7 +41,8 @@ TRPCPortLoadRawSerialClientTask::TRPCPortLoadRawSerialClientTask(const Json::Val
 }
 
 ISerialClientTask::TRunResult TRPCPortLoadRawSerialClientTask::Run(PPort port,
-                                                                   TSerialClientDeviceAccessHandler& lastAccessedDevice)
+                                                                   TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                                                   const std::list<PSerialDevice>& polledDevices)
 {
     if (std::chrono::steady_clock::now() > ExpireTime) {
         if (Request->OnError) {

--- a/src/rpc/rpc_port_load_raw_serial_client_task.h
+++ b/src/rpc/rpc_port_load_raw_serial_client_task.h
@@ -21,7 +21,9 @@ public:
                                     WBMQTT::TMqttRpcServer::TResultCallback onResult,
                                     WBMQTT::TMqttRpcServer::TErrorCallback onError);
 
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRPCPortLoadRawRequest Request;

--- a/src/rpc/rpc_port_scan_serial_client_task.cpp
+++ b/src/rpc/rpc_port_scan_serial_client_task.cpp
@@ -197,7 +197,8 @@ TRPCPortScanSerialClientTask::TRPCPortScanSerialClientTask(const Json::Value& re
 }
 
 ISerialClientTask::TRunResult TRPCPortScanSerialClientTask::Run(PPort port,
-                                                                TSerialClientDeviceAccessHandler& lastAccessedDevice)
+                                                                TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                                                const std::list<PSerialDevice>& polledDevices)
 {
     if (std::chrono::steady_clock::now() > ExpireTime) {
         if (Request->OnError) {

--- a/src/rpc/rpc_port_scan_serial_client_task.h
+++ b/src/rpc/rpc_port_scan_serial_client_task.h
@@ -26,7 +26,9 @@ public:
                                  WBMQTT::TMqttRpcServer::TResultCallback onResult,
                                  WBMQTT::TMqttRpcServer::TErrorCallback onError);
 
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRPCPortScanRequest Request;

--- a/src/rpc/rpc_port_setup_serial_client_task.cpp
+++ b/src/rpc/rpc_port_setup_serial_client_task.cpp
@@ -74,7 +74,8 @@ TRPCPortSetupSerialClientTask::TRPCPortSetupSerialClientTask(const Json::Value& 
 }
 
 ISerialClientTask::TRunResult TRPCPortSetupSerialClientTask::Run(PPort port,
-                                                                 TSerialClientDeviceAccessHandler& lastAccessedDevice)
+                                                                 TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                                                 const std::list<PSerialDevice>& polledDevices)
 {
     if (std::chrono::steady_clock::now() > ExpireTime) {
         if (Request->OnError) {

--- a/src/rpc/rpc_port_setup_serial_client_task.h
+++ b/src/rpc/rpc_port_setup_serial_client_task.h
@@ -34,7 +34,9 @@ public:
                                   WBMQTT::TMqttRpcServer::TResultCallback onResult,
                                   WBMQTT::TMqttRpcServer::TErrorCallback onError);
 
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRPCPortSetupRequest Request;

--- a/src/serial_client.cpp
+++ b/src/serial_client.cpp
@@ -105,7 +105,7 @@ void TSerialClient::WaitForPollAndFlush(steady_clock::time_point currentTime, st
             Tasks.swap(tasks);
             lock.unlock();
             for (auto& task: tasks) {
-                if (task->Run(Port, *LastAccessedDevice) == ISerialClientTask::TRunResult::RETRY) {
+                if (task->Run(Port, *LastAccessedDevice, Devices) == ISerialClientTask::TRunResult::RETRY) {
                     retryTasks.push_back(task);
                 }
             }

--- a/src/serial_client.h
+++ b/src/serial_client.h
@@ -61,7 +61,17 @@ public:
 
     virtual ~ISerialClientTask() = default;
 
-    virtual ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) = 0;
+    /**
+     * @brief Executes some code in the serial client thread.
+     *
+     * @param port The port to be used for communication.
+     * @param lastAccessedDevice A reference to the handler for the last accessed device.
+     * @param polledDevices A list of serial devices polled on this port.
+     * @return The result of the task execution as a TRunResult.
+     */
+    virtual ISerialClientTask::TRunResult Run(PPort port,
+                                              TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                              const std::list<PSerialDevice>& polledDevices) = 0;
 };
 
 typedef std::shared_ptr<ISerialClientTask> PSerialClientTask;

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -9,7 +9,8 @@ TWriteChannelSerialClientTask::TWriteChannelSerialClientTask(PRegisterHandler ha
 {}
 
 ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PPort port,
-                                                                 TSerialClientDeviceAccessHandler& lastAccessedDevice)
+                                                                 TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                                                 const std::list<PSerialDevice>& polledDevices)
 {
     if (!Handler->NeedToFlush()) {
         return ISerialClientTask::TRunResult::OK;

--- a/src/write_channel_serial_client_task.h
+++ b/src/write_channel_serial_client_task.h
@@ -15,7 +15,9 @@ public:
 
     ~TWriteChannelSerialClientTask() = default;
 
-    ISerialClientTask::TRunResult Run(PPort port, TSerialClientDeviceAccessHandler& lastAccessedDevice) override;
+    ISerialClientTask::TRunResult Run(PPort port,
+                                      TSerialClientDeviceAccessHandler& lastAccessedDevice,
+                                      const std::list<PSerialDevice>& polledDevices) override;
 
 private:
     PRegisterHandler Handler;


### PR DESCRIPTION
Передаю список устройств, который на порту опрашивается, в обработчики всяких RPC и проч, которые выполняют запросы к порту. Это понадобилось в новых RPC, а тащить из вне не хочется
