### PR TITLE
Add configured_device_type to port/Scan response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,10 @@ It's designed to be used on [Wiren Board](https://wirenboard.com/en/) family of 
             // сигнатура прошивки
             "fw_signature": "mr6cG",
 
+            // если устройство настроено для опроса в wb-mqtt-serial,
+            // то в этом параметре передаётся тип устройства из шаблона
+            "configured_device_type": "WB-MR6C",
+
             // список ошибок работы с конкретным устройством
             "errors": [
                 {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.164.0) stable; urgency=medium
+
+  * Add configured_device_type parameter to port/Scan RPC response. 
+    It contains the device type from template if the device is configured in wb-mqtt-serial.conf.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 15 May 2025 08:59:10 +0500
+
 wb-mqtt-serial (2.163.0) stable; urgency=medium
 
   * Add template for Oven MST-24 stepper motor driver

--- a/src/rpc/rpc_port_scan_serial_client_task.cpp
+++ b/src/rpc/rpc_port_scan_serial_client_task.cpp
@@ -96,20 +96,22 @@ namespace
 
     Json::Value GetScannedDeviceDetails(TPort& port,
                                         const ModbusExt::TScannedDevice& scannedDevice,
-                                        ModbusExt::TModbusExtCommand modbusExtCommand)
+                                        ModbusExt::TModbusExtCommand modbusExtCommand,
+                                        const std::list<PSerialDevice>& polledDevices)
     {
         TRegisterReader reader(port, scannedDevice.SlaveId, scannedDevice.Sn, modbusExtCommand);
         Json::Value errorsJson(Json::arrayValue);
-
         Json::Value deviceJson;
+
+        std::string sn = std::to_string(scannedDevice.Sn);
+
         try {
             deviceJson["device_signature"] = GetDeviceSignature(reader);
-            deviceJson["sn"] =
-                std::to_string(GetSnFromRegister(deviceJson["device_signature"].asString(), scannedDevice.Sn));
+            sn = std::to_string(GetSnFromRegister(deviceJson["device_signature"].asString(), scannedDevice.Sn));
         } catch (const std::exception& e) {
             AppendError(errorsJson, READ_DEVICE_SIGNATURE_ERROR_ID, e.what());
-            deviceJson["sn"] = std::to_string(scannedDevice.Sn);
         }
+        deviceJson["sn"] = sn;
 
         try {
             deviceJson["fw_signature"] = reader.Read<std::string>(WbRegisters::FW_SIGNATURE_REGISTER_NAME);
@@ -149,6 +151,27 @@ namespace
             AppendError(errorsJson, READ_FW_VERSION_ERROR_ID, e.what());
         }
 
+        auto stringSlaveId = std::to_string(scannedDevice.SlaveId);
+        auto rawSn = std::to_string(scannedDevice.Sn);
+        for (const auto& polledDevice: polledDevices) {
+            if (polledDevice->DeviceConfig()->SlaveId == stringSlaveId && polledDevice->Protocol()->IsModbus()) {
+                auto snRegister = polledDevice->GetSnRegister();
+                if (snRegister) {
+                    if (snRegister->GetValue().GetType() == TRegisterValue::ValueType::Undefined) {
+                        auto registerRange = polledDevice->CreateRegisterRange();
+                        registerRange->Add(snRegister, std::chrono::milliseconds::max());
+                        polledDevice->ReadRegisterRange(registerRange);
+                    }
+                    if (snRegister->GetValue().GetType() == TRegisterValue::ValueType::Integer) {
+                        if (rawSn == std::to_string(snRegister->GetValue().Get<uint64_t>())) {
+                            deviceJson["configured_device_type"] = polledDevice->DeviceConfig()->DeviceType;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         return deviceJson;
     }
 }
@@ -162,7 +185,7 @@ PRPCPortScanRequest ParseRPCPortScanRequest(const Json::Value& request)
     return res;
 }
 
-void ExecRPCPortScanRequest(TPort& port, PRPCPortScanRequest rpcRequest)
+void ExecRPCPortScanRequest(TPort& port, PRPCPortScanRequest rpcRequest, const std::list<PSerialDevice>& polledDevices)
 {
     if (!rpcRequest->OnResult) {
         return;
@@ -171,16 +194,16 @@ void ExecRPCPortScanRequest(TPort& port, PRPCPortScanRequest rpcRequest)
     port.SkipNoise();
 
     Json::Value replyJSON;
-    std::vector<ModbusExt::TScannedDevice> devices;
+    std::vector<ModbusExt::TScannedDevice> scannedDevices;
     try {
-        ModbusExt::Scan(port, rpcRequest->ModbusExtCommand, devices);
+        ModbusExt::Scan(port, rpcRequest->ModbusExtCommand, scannedDevices);
     } catch (const std::exception& e) {
         replyJSON["error"] = e.what();
     }
 
     replyJSON["devices"] = Json::Value(Json::arrayValue);
-    for (const auto& device: devices) {
-        replyJSON["devices"].append(GetScannedDeviceDetails(port, device, rpcRequest->ModbusExtCommand));
+    for (const auto& device: scannedDevices) {
+        replyJSON["devices"].append(GetScannedDeviceDetails(port, device, rpcRequest->ModbusExtCommand, polledDevices));
     }
 
     rpcRequest->OnResult(replyJSON);
@@ -213,7 +236,7 @@ ISerialClientTask::TRunResult TRPCPortScanSerialClientTask::Run(PPort port,
         }
         lastAccessedDevice.PrepareToAccess(nullptr);
         TSerialPortSettingsGuard settingsGuard(port, Request->SerialPortSettings);
-        ExecRPCPortScanRequest(*port, Request);
+        ExecRPCPortScanRequest(*port, Request, polledDevices);
     } catch (const std::exception& error) {
         if (Request->OnError) {
             Request->OnError(WBMQTT::E_RPC_SERVER_ERROR, std::string("Port IO error: ") + error.what());

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -126,6 +126,13 @@ namespace
         return ToDouble(obj[key], key);
     }
 
+    bool IsSerialNumberChannel(const Json::Value& channel_data)
+    {
+        const std::vector<std::string> serialNames{"Serial", "serial_number", "Serial NO"};
+        return serialNames.end() !=
+               std::find(serialNames.begin(), serialNames.end(), channel_data.get("name", std::string()).asString());
+    }
+
     bool ReadChannelsReadonlyProperty(const Json::Value& register_data,
                                       const std::string& key,
                                       bool templateReadonly,
@@ -385,6 +392,10 @@ namespace
 
         Get(channel_data, "units", channel->Units);
 
+        if (IsSerialNumberChannel(channel_data) && registers.size()) {
+            deviceWithChannels.Device->SetSnRegister(registers[0]->GetConfig());
+        }
+
         deviceWithChannels.Channels.push_back(channel);
     }
 
@@ -454,6 +465,15 @@ namespace
                      const TRegisterTypeMap& typeMap)
     {
         if (channel_data.isMember("enabled") && !channel_data["enabled"].asBool()) {
+            if (IsSerialNumberChannel(channel_data)) {
+                deviceWithChannels.Device->SetSnRegister(LoadRegisterConfig(channel_data,
+                                                                            typeMap,
+                                                                            std::string(),
+                                                                            context.factory,
+                                                                            context.device_base_address,
+                                                                            context.stride)
+                                                             .RegisterConfig);
+            }
             return;
         }
 

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -227,6 +227,9 @@ public:
 
     void AddOnConnectionStateChangedCallback(TDeviceCallback callback);
 
+    PRegister GetSnRegister() const;
+    void SetSnRegister(PRegisterConfig regConfig);
+
     void AddSetupItem(PDeviceSetupItemConfig item);
     const std::vector<PDeviceSetupItem>& GetSetupItems() const;
 
@@ -247,6 +250,7 @@ private:
     std::list<PRegister> Registers;
     std::chrono::steady_clock::time_point LastReadTime;
     std::vector<TDeviceCallback> ConnectionStateChangedCallbacks;
+    PRegister SnRegister;
 
     // map key is setup item address
     std::unordered_map<std::string, PDeviceSetupItem> SetupItemsByAddress;


### PR DESCRIPTION
Добавил в результаты сканирования тип устройства из шаблона, если найденное устройство опрашивается.
Это нужно в дальнейшем для отображения типа в web-интерфейсе 
https://wirenboard.youtrack.cloud/issue/SOFT-5148/MR6C-NC-vsegda-otobrazhayutsya-v-skanirovanii-kak-novye
