### PR TITLE
Fix A-OK, Dooya, Somfy and WinDeco meta/error flicker

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.164.2) stable; urgency=medium
+
+  * Fix A-OK, Dooya, Somfy and WinDeco meta/error flicker
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 19 May 2025 18:01:19 +0500
+
 wb-mqtt-serial (2.164.1) stable; urgency=medium
 
   * Fix changelog, no functional changes

--- a/src/devices/curtains/a_ok_device.cpp
+++ b/src/devices/curtains/a_ok_device.cpp
@@ -156,9 +156,6 @@ std::vector<uint8_t> Aok::TDevice::ExecCommand(const TRequest& request)
 TRegisterValue Aok::TDevice::ReadRegisterImpl(const TRegisterConfig& reg)
 {
     switch (reg.Type) {
-        case COMMAND: {
-            return TRegisterValue{1};
-        }
         case POSITION: {
             return GetCachedResponse(MOTOR_STATUS, 0, MOTOR_STATUS_POSITION_OFFSET * 8, 8);
         }

--- a/src/devices/curtains/dooya_device.cpp
+++ b/src/devices/curtains/dooya_device.cpp
@@ -167,7 +167,7 @@ void Dooya::TDevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegist
             return;
         }
         case PARAM: {
-            uint8_t dataAddress = GetUint32RegisterAddress(reg.GetAddress());
+            uint8_t dataAddress = GetUint32RegisterAddress(reg.GetWriteAddress());
             TRequest req;
             req.Data = MakeRequest(SlaveId, {WRITE, dataAddress, 1, static_cast<uint8_t>(value)});
             req.ResponseSize = RESPONSE_SIZE;
@@ -177,7 +177,7 @@ void Dooya::TDevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegist
             return;
         }
         case COMMAND: {
-            auto data = GetUint32RegisterAddress(reg.GetAddress());
+            auto data = GetUint32RegisterAddress(reg.GetWriteAddress());
             TRequest req;
             uint8_t dataAddress;
             // Command with parameter
@@ -228,9 +228,6 @@ TRegisterValue Dooya::TDevice::ReadRegisterImpl(const TRegisterConfig& reg)
             req.Data = MakeRequest(SlaveId, {READ, static_cast<uint8_t>(addr & 0xFF), 1});
             req.ResponseSize = RESPONSE_SIZE;
             return TRegisterValue{ParseReadResponse(SlaveId, READ, 1, ExecCommand(req))};
-        }
-        case COMMAND: {
-            return TRegisterValue{1};
         }
         case ANGLE: {
             auto addr = 0x06;

--- a/src/devices/curtains/somfy_sdn_device.cpp
+++ b/src/devices/curtains/somfy_sdn_device.cpp
@@ -262,12 +262,12 @@ void Somfy::TDevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegist
                 value >>= 8;
                 data.push_back(value & 0xFF);
             }
-            auto addr = GetUint32RegisterAddress(reg.GetAddress());
+            auto addr = GetUint32RegisterAddress(reg.GetWriteAddress());
             Check(SlaveId, ACK, ExecCommand(MakeRequest(addr, SlaveId, NodeType, data)));
             return;
         }
         case PARAM: {
-            auto requestHeader = GetUint32RegisterAddress(reg.GetAddress());
+            auto requestHeader = GetUint32RegisterAddress(reg.GetWriteAddress());
             auto it = WriteCache.find(requestHeader);
             if (it == WriteCache.end()) {
                 throw TSerialDeviceTransientErrorException("Register " + reg.ToString() +
@@ -331,9 +331,6 @@ TRegisterValue Somfy::TDevice::ReadRegisterImpl(const TRegisterConfig& reg)
         case PARAM: {
             const auto& addr = dynamic_cast<const TSomfyAddress&>(reg.GetAddress());
             return GetCachedResponse(addr.Get(), addr.GetResponseHeader(), reg.GetDataOffset(), reg.GetDataWidth());
-        }
-        case COMMAND: {
-            return TRegisterValue{1};
         }
         case ANGLE: {
             // See 6.5.1 Device Status / Motor Position

--- a/src/devices/curtains/windeco_device.cpp
+++ b/src/devices/curtains/windeco_device.cpp
@@ -105,7 +105,7 @@ void WinDeco::TDevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegi
         return;
     }
     if (reg.Type == COMMAND) {
-        uint8_t addr = GetUint32RegisterAddress(reg.GetAddress());
+        uint8_t addr = GetUint32RegisterAddress(reg.GetWriteAddress());
         CheckCommandResponse(ZoneId, CurtainId, addr, ExecCommand(MakeRequest(ZoneId, CurtainId, addr)));
         return;
     }
@@ -119,8 +119,6 @@ TRegisterValue WinDeco::TDevice::ReadRegisterImpl(const TRegisterConfig& reg)
             return TRegisterValue{ParsePositionResponse(ZoneId, CurtainId, ExecCommand(GetPositionCommand))};
         case PARAM:
             return TRegisterValue{ParseStateResponse(ZoneId, CurtainId, ExecCommand(GetStateCommand))};
-        case COMMAND:
-            return TRegisterValue{1};
     }
     throw TSerialDevicePermanentRegisterException("Unsupported register type");
 }

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -326,8 +326,10 @@ namespace
         }
 
         std::string type_str(Read(channel_data, "type", default_type_str));
-        if (type_str == "wo-switch") {
-            type_str = "switch";
+        if (type_str == "wo-switch" || type_str == "pushbutton") {
+            if (type_str == "wo-switch") {
+                type_str = "switch";
+            }
             for (auto& reg: registers) {
                 reg->GetConfig()->AccessType = TRegisterConfig::EAccessType::WRITE_ONLY;
             }

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -348,19 +348,21 @@ void TDeviceTemplate::ValidateParameterAddresses(const Json::Value& parameters)
     std::string error;
     for (const auto& parameter: parameters) {
         std::string id = parameter["id"].asString();
-        Json::Value address = parameter["address"];
-        Json::Value writeAddress = parameter["write_address"];
+        Json::Value address = parameter[SerialConfig::ADDRESS_PROPERTY_NAME];
+        Json::Value writeAddress = parameter[SerialConfig::WRITE_ADDRESS_PROPERTY_NAME];
         auto addressIt = addressMap.find(id);
         if (addressIt != addressMap.end() && addressIt->second != address) {
-            error = "Parameter \"" + id + "\" has several declarations with different \"address\" values (" +
-                    addressIt->second.asString() + " and " + address.asString() + "). ";
+            error = "Parameter \"" + id + "\" has several declarations with different \"" +
+                    SerialConfig::ADDRESS_PROPERTY_NAME + "\" values (" + addressIt->second.asString() + " and " +
+                    address.asString() + "). ";
             break;
         }
         addressMap[id] = address;
         auto writeAddressIt = writeAddressMap.find(id);
         if (writeAddressIt != writeAddressMap.end() && writeAddressIt->second != writeAddress) {
-            error = "Parameter \"" + id + "\" has several declarations with different \"write_address\" values (" +
-                    writeAddressIt->second.asString() + " and " + writeAddress.asString() + "). ";
+            error = "Parameter \"" + id + "\" has several declarations with different \"" +
+                    SerialConfig::WRITE_ADDRESS_PROPERTY_NAME + "\" values (" + writeAddressIt->second.asString() +
+                    " and " + writeAddress.asString() + "). ";
             break;
         }
         writeAddressMap[id] = writeAddress;


### PR DESCRIPTION
https://wirenboard.youtrack.cloud/issue/SOFT-5390/Migaet-sostoyanie-podklyuchennosti-motorov-shtor

В каналах были регистры с типом command и типом канала pushbutton. Чтение таких регистров всегда возвращало 1. Реального чтения не происходило. Из-за этого wb-mqtt-serial считал, что мотор есть на шине и отвечает. Если же мотора не было, сначала читалась позиция, по ошибке wb-mqtt-serial понимал, что мотора нет, потом читал ренистры command, получал ответ и считал, что мотор появился, и так по кругу.

Убрал чтение 1
Сделал каналы pushbutton WRITE_ONLY, чтобы исключить их из цикла чтения
