### PR TITLE
Remove duplicate channels from templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ wb-mqtt-serial (2.165.2) stable; urgency=medium
   * Remove duplicate channel from MAP3H fw2 basic template
   * Remove duplicate channel from Network module PING2 for Komfovent C3/C4 template
 
- -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 21 May 2025 18:53:37 +0500
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 22 May 2025 10:42:34 +0500
 
 wb-mqtt-serial (2.165.1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.164.4) stable; urgency=medium
+wb-mqtt-serial (2.165.1) stable; urgency=medium
 
   * Remove duplicate channel from MAP3H fw2 basic template
   * Remove duplicate channel from Network module PING2 for Komfovent C3/C4 template

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.164.4) stable; urgency=medium
+
+  * Remove duplicate channel from MAP3H fw2 basic template
+  * Remove duplicate channel from Network module PING2 for Komfovent C3/C4 template
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 21 May 2025 10:01:02 +0500
+
 wb-mqtt-serial (2.164.3) stable; urgency=medium
 
   * Fix A-OK, Dooya, Somfy and WinDeco meta/error flicker

--- a/templates/config-komfovent.json
+++ b/templates/config-komfovent.json
@@ -1690,15 +1690,6 @@
                 "enabled": false
             },
             {
-                "name": "Supply air fan overheating",
-                "reg_type": "holding",
-                "address": "296:0:1",
-                "type": "switch",
-                "group": "alarms",
-                "readonly": true,
-                "enabled": false
-            },
-            {
                 "name": "Exhaust air fan overheating",
                 "reg_type": "holding",
                 "address": "296:1:1",

--- a/templates/config-map3h-fw2-basic.json
+++ b/templates/config-map3h-fw2-basic.json
@@ -209,21 +209,6 @@
                 "round_to": 0.001,
                 "group": "l3"
             },
-
-
-
-
-            {
-                "name": "U L2-L3",
-                "reg_type": "input",
-                "address": "0x141D",
-                "type": "voltage",
-                "format": "u16",
-                "scale": 0.01,
-                "round_to": 0.1,
-                "error_value": "0xFFFF",
-                "group": "l2"
-            },
             {
                 "name": "U L3-L1",
                 "reg_type": "input",


### PR DESCRIPTION
  * Remove duplicate channel from MAP3H fw2 basic template
  * Remove duplicate channel from Network module PING2 for Komfovent C3/C4 template

Были абсолютно одинаковые объявления каналов. Убрал лишнее

