### PR TITLE
Add read parameters feature for non-Modbus devices to Device/LoadConig RPC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.165.0) stable; urgency=medium
+
+  * Add read parameters featute for non-Modbus devices to Device/LoadConfig RPC
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Wed, 21 May 2025 13:12:16 +0300
+
 wb-mqtt-serial (2.164.3) stable; urgency=medium
 
   * Fix A-OK, Dooya, Somfy and WinDeco meta/error flicker

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -1,8 +1,6 @@
 #include "modbus_device.h"
 #include "modbus_common.h"
 
-#define LOG(logger) logger.Log() << "[modbus] "
-
 namespace
 {
     const TRegisterTypes ModbusRegisterTypes({{Modbus::REG_HOLDING, "holding", "value", U16},
@@ -84,10 +82,13 @@ void TModbusDevice::ReadRegisterRange(PRegisterRange range)
     ResponseTime.AddValue(modbus_range->GetResponseTime());
 }
 
-void TModbusDevice::WriteSetupRegisters()
+void TModbusDevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
 {
     if (EnableWbContinuousRead) {
         Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
+    }
+    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
+        return;
     }
     Modbus::WriteSetupRegisters(*ModbusTraits,
                                 *Port(),

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -59,6 +59,14 @@ PRegisterRange TModbusDevice::CreateRegisterRange() const
     return Modbus::CreateRegisterRange(ResponseTime.GetValue());
 }
 
+void TModbusDevice::PrepareImpl()
+{
+    TSerialDevice::PrepareImpl();
+    if (GetConnectionState() != TDeviceConnectionState::CONNECTED && EnableWbContinuousRead) {
+        Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
+    }
+}
+
 void TModbusDevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value)
 {
     Modbus::WriteRegister(*ModbusTraits,
@@ -82,14 +90,8 @@ void TModbusDevice::ReadRegisterRange(PRegisterRange range)
     ResponseTime.AddValue(modbus_range->GetResponseTime());
 }
 
-void TModbusDevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
+void TModbusDevice::WriteSetupRegisters()
 {
-    if (EnableWbContinuousRead) {
-        Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
-    }
-    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
-        return;
-    }
     Modbus::WriteSetupRegisters(*ModbusTraits,
                                 *Port(),
                                 SlaveId,

--- a/src/devices/modbus_device.h
+++ b/src/devices/modbus_device.h
@@ -69,7 +69,7 @@ public:
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(PRegisterRange range) override;
-    void WriteSetupRegisters() override;
+    void WriteSetupRegisters(TDeviceSetupMode setupMode) override;
 
     void OnEnabledEvent(uint16_t addr, bool res);
 

--- a/src/devices/modbus_device.h
+++ b/src/devices/modbus_device.h
@@ -69,12 +69,10 @@ public:
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(PRegisterRange range) override;
-    void WriteSetupRegisters(TDeviceSetupMode setupMode) override;
-
-    void OnEnabledEvent(uint16_t addr, bool res);
-
     static void Register(TSerialDeviceFactory& factory);
 
 protected:
+    void PrepareImpl() override;
     void WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value) override;
+    void WriteSetupRegisters() override;
 };

--- a/src/devices/modbus_io_device.cpp
+++ b/src/devices/modbus_io_device.cpp
@@ -95,9 +95,12 @@ void TModbusIODevice::ReadRegisterRange(PRegisterRange range)
     ResponseTime.AddValue(modbus_range->GetResponseTime());
 }
 
-void TModbusIODevice::WriteSetupRegisters()
+void TModbusIODevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
 {
     Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
+    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
+        return;
+    }
     Modbus::WriteSetupRegisters(*ModbusTraits,
                                 *Port(),
                                 SlaveId,

--- a/src/devices/modbus_io_device.cpp
+++ b/src/devices/modbus_io_device.cpp
@@ -71,6 +71,14 @@ PRegisterRange TModbusIODevice::CreateRegisterRange() const
     return Modbus::CreateRegisterRange(ResponseTime.GetValue());
 }
 
+void TModbusIODevice::PrepareImpl()
+{
+    TSerialDevice::PrepareImpl();
+    if (GetConnectionState() != TDeviceConnectionState::CONNECTED) {
+        Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
+    }
+}
+
 void TModbusIODevice::WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value)
 {
     Modbus::WriteRegister(*ModbusTraits,
@@ -95,12 +103,8 @@ void TModbusIODevice::ReadRegisterRange(PRegisterRange range)
     ResponseTime.AddValue(modbus_range->GetResponseTime());
 }
 
-void TModbusIODevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
+void TModbusIODevice::WriteSetupRegisters()
 {
-    Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, *Port(), SlaveId, ModbusCache);
-    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
-        return;
-    }
     Modbus::WriteSetupRegisters(*ModbusTraits,
                                 *Port(),
                                 SlaveId,

--- a/src/devices/modbus_io_device.h
+++ b/src/devices/modbus_io_device.h
@@ -23,10 +23,10 @@ public:
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(PRegisterRange range) override;
-    void WriteSetupRegisters(TDeviceSetupMode setupMode) override;
-
     static void Register(TSerialDeviceFactory& factory);
 
 protected:
+    void PrepareImpl() override;
     void WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value) override;
+    void WriteSetupRegisters() override;
 };

--- a/src/devices/modbus_io_device.h
+++ b/src/devices/modbus_io_device.h
@@ -23,7 +23,7 @@ public:
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(PRegisterRange range) override;
-    void WriteSetupRegisters() override;
+    void WriteSetupRegisters(TDeviceSetupMode setupMode) override;
 
     static void Register(TSerialDeviceFactory& factory);
 

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -97,7 +97,7 @@ void TRPCDeviceHandler::LoadConfig(const Json::Value& request,
 
     std::string deviceType = request["device_type"].asString();
     auto deviceTemplate = Templates->GetTemplate(deviceType);
-    if (deviceTemplate->GetProtocol() != "modbus" || deviceTemplate->WithSubdevices()) {
+    if (deviceTemplate->WithSubdevices()) {
         throw TRPCException("Device \"" + deviceType + "\" is not supported by this RPC",
                             TRPCResultCode::RPC_WRONG_PARAM_VALUE);
     }

--- a/src/rpc/rpc_device_load_config_task.h
+++ b/src/rpc/rpc_device_load_config_task.h
@@ -25,6 +25,7 @@ public:
     const TSerialDeviceFactory& DeviceFactory;
     const std::string DeviceType;
     const Json::Value& DeviceTemplate;
+    const std::string& Protocol;
 
     TRPCDeviceParametersCache& ParametersCache;
     bool ContinuousReadSupported = false;

--- a/src/rpc/rpc_device_load_config_task.h
+++ b/src/rpc/rpc_device_load_config_task.h
@@ -30,10 +30,11 @@ public:
     bool IsWBDevice = false;
 
     TSerialPortConnectionSettings SerialPortSettings;
+    std::string SlaveId;
+
     std::chrono::milliseconds ResponseTimeout = DefaultResponseTimeout;
     std::chrono::milliseconds FrameTimeout = DefaultFrameTimeout;
     std::chrono::milliseconds TotalTimeout = DefaultRPCTotalTimeout;
-    uint8_t SlaveId = 0;
 
     WBMQTT::TMqttRpcServer::TResultCallback OnResult = nullptr;
     WBMQTT::TMqttRpcServer::TErrorCallback OnError = nullptr;

--- a/src/rpc/rpc_device_load_config_task.h
+++ b/src/rpc/rpc_device_load_config_task.h
@@ -26,7 +26,6 @@ public:
 
     PDeviceTemplate DeviceTemplate;
     TRPCDeviceParametersCache& ParametersCache;
-    bool ContinuousReadSupported = false;
     bool IsWBDevice = false;
 
     TSerialPortConnectionSettings SerialPortSettings;

--- a/src/rpc/rpc_device_load_config_task.h
+++ b/src/rpc/rpc_device_load_config_task.h
@@ -23,10 +23,8 @@ public:
                                 TRPCDeviceParametersCache& parametersCache);
 
     const TSerialDeviceFactory& DeviceFactory;
-    const std::string DeviceType;
-    const Json::Value& DeviceTemplate;
-    const std::string& Protocol;
 
+    PDeviceTemplate DeviceTemplate;
     TRPCDeviceParametersCache& ParametersCache;
     bool ContinuousReadSupported = false;
     bool IsWBDevice = false;

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -73,13 +73,13 @@ PRegisterRange TSerialDevice::CreateRegisterRange() const
     return PRegisterRange(new TSameAddressRegisterRange());
 }
 
-void TSerialDevice::Prepare(TDeviceSetupMode setupMode)
+void TSerialDevice::Prepare(TDevicePrepareMode prepareMode)
 {
     bool deviceWasDisconnected = (ConnectionState != TDeviceConnectionState::CONNECTED);
     try {
         PrepareImpl();
-        if (deviceWasDisconnected) {
-            WriteSetupRegisters(setupMode);
+        if (prepareMode == TDevicePrepareMode::WITH_SETUP_IF_WAS_DISCONNECTED && deviceWasDisconnected) {
+            WriteSetupRegisters();
         }
     } catch (const TSerialDeviceException& ex) {
         SetTransferResult(false);
@@ -190,11 +190,8 @@ TDeviceConnectionState TSerialDevice::GetConnectionState() const
     return ConnectionState;
 }
 
-void TSerialDevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
+void TSerialDevice::WriteSetupRegisters()
 {
-    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
-        return;
-    }
     for (const auto& setup_item: SetupItems) {
         WriteRegisterImpl(*setup_item->Register->GetConfig(), setup_item->RawValue);
 

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -73,13 +73,13 @@ PRegisterRange TSerialDevice::CreateRegisterRange() const
     return PRegisterRange(new TSameAddressRegisterRange());
 }
 
-void TSerialDevice::Prepare(TDevicePrepare prepareType)
+void TSerialDevice::Prepare(TDeviceSetupMode setupMode)
 {
     bool deviceWasDisconnected = (ConnectionState != TDeviceConnectionState::CONNECTED);
     try {
         PrepareImpl();
-        if (prepareType == TDevicePrepare::WITH_SETUP && deviceWasDisconnected) {
-            WriteSetupRegisters();
+        if (deviceWasDisconnected) {
+            WriteSetupRegisters(setupMode);
         }
     } catch (const TSerialDeviceException& ex) {
         SetTransferResult(false);
@@ -190,8 +190,11 @@ TDeviceConnectionState TSerialDevice::GetConnectionState() const
     return ConnectionState;
 }
 
-void TSerialDevice::WriteSetupRegisters()
+void TSerialDevice::WriteSetupRegisters(TDeviceSetupMode setupMode)
 {
+    if (setupMode == TDeviceSetupMode::WITHOUT_SETUP) {
+        return;
+    }
     for (const auto& setup_item: SetupItems) {
         WriteRegisterImpl(*setup_item->Register->GetConfig(), setup_item->RawValue);
 

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -73,12 +73,12 @@ PRegisterRange TSerialDevice::CreateRegisterRange() const
     return PRegisterRange(new TSameAddressRegisterRange());
 }
 
-void TSerialDevice::Prepare()
+void TSerialDevice::Prepare(TDevicePrepare prepareType)
 {
     bool deviceWasDisconnected = (ConnectionState != TDeviceConnectionState::CONNECTED);
     try {
         PrepareImpl();
-        if (deviceWasDisconnected) {
+        if (prepareType == TDevicePrepare::WITH_SETUP && deviceWasDisconnected) {
             WriteSetupRegisters();
         }
     } catch (const TSerialDeviceException& ex) {

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -170,7 +170,7 @@ enum class TDeviceConnectionState
     DISCONNECTED
 };
 
-enum class TDevicePrepare
+enum class TDeviceSetupMode
 {
     WITH_SETUP,
     WITHOUT_SETUP
@@ -193,7 +193,7 @@ public:
 
     // Prepare to access device (pauses for configured delay by default)
     // i.e. "StartSession". Called before any read/write/etc after communicating with another device
-    void Prepare(TDevicePrepare prepareType = TDevicePrepare::WITH_SETUP);
+    void Prepare(TDeviceSetupMode setupMode = TDeviceSetupMode::WITH_SETUP);
 
     // Ends communication session with the device. Called before communicating with another device
     virtual void EndSession();
@@ -252,7 +252,7 @@ protected:
     virtual void PrepareImpl();
     virtual TRegisterValue ReadRegisterImpl(const TRegisterConfig& reg);
     virtual void WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value);
-    virtual void WriteSetupRegisters();
+    virtual void WriteSetupRegisters(TDeviceSetupMode setupMode);
 
 private:
     PPort SerialPort;

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -170,6 +170,12 @@ enum class TDeviceConnectionState
     DISCONNECTED
 };
 
+enum class TDevicePrepare
+{
+    WITH_SETUP,
+    WITHOUT_SETUP
+};
+
 class TSerialDevice: public std::enable_shared_from_this<TSerialDevice>
 {
 public:
@@ -187,7 +193,7 @@ public:
 
     // Prepare to access device (pauses for configured delay by default)
     // i.e. "StartSession". Called before any read/write/etc after communicating with another device
-    void Prepare();
+    void Prepare(TDevicePrepare prepareType = TDevicePrepare::WITH_SETUP);
 
     // Ends communication session with the device. Called before communicating with another device
     virtual void EndSession();

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -170,9 +170,9 @@ enum class TDeviceConnectionState
     DISCONNECTED
 };
 
-enum class TDeviceSetupMode
+enum class TDevicePrepareMode
 {
-    WITH_SETUP,
+    WITH_SETUP_IF_WAS_DISCONNECTED,
     WITHOUT_SETUP
 };
 
@@ -193,7 +193,7 @@ public:
 
     // Prepare to access device (pauses for configured delay by default)
     // i.e. "StartSession". Called before any read/write/etc after communicating with another device
-    void Prepare(TDeviceSetupMode setupMode = TDeviceSetupMode::WITH_SETUP);
+    void Prepare(TDevicePrepareMode setupMode = TDevicePrepareMode::WITH_SETUP_IF_WAS_DISCONNECTED);
 
     // Ends communication session with the device. Called before communicating with another device
     virtual void EndSession();
@@ -252,7 +252,7 @@ protected:
     virtual void PrepareImpl();
     virtual TRegisterValue ReadRegisterImpl(const TRegisterConfig& reg);
     virtual void WriteRegisterImpl(const TRegisterConfig& reg, const TRegisterValue& value);
-    virtual void WriteSetupRegisters(TDeviceSetupMode setupMode);
+    virtual void WriteSetupRegisters();
 
 private:
     PPort SerialPort;

--- a/wb-mqtt-serial-rpc-device-load-config-request.schema.json
+++ b/wb-mqtt-serial-rpc-device-load-config-request.schema.json
@@ -65,8 +65,15 @@
     "request_data": {
       "properties": {
         "slave_id": {
-          "type": "integer",
-          "minimum": 0
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "device_type": {
           "type": "string"

--- a/wb-mqtt-serial-rpc-device-load-config-request.schema.json
+++ b/wb-mqtt-serial-rpc-device-load-config-request.schema.json
@@ -71,7 +71,8 @@
               "minimum": 0
             },
             {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           ]
         },


### PR DESCRIPTION
Добавил в RPC `Device/LoadConfig` возможность чтения настроек устройств для любых поддерживаемых протоколов (ранее поддерживался только Modbus).
