### PR TITLE
WB-MWAC v.2: Leakage Mode control behavior

### DIFF
--- a/templates/config-wb-mwac2_ver2.json.jinja
+++ b/templates/config-wb-mwac2_ver2.json.jinja
@@ -15,9 +15,8 @@
 {% set IN_MODE_FLOOD_SENSOR = 5 -%}
 {
     "title": "WB-MWAC_template_title",
-    "device_type": "WB-MWAC-v2 deprecated",
+    "device_type": "WB-MWAC-v2",
     "group": "g-wb",
-    "deprecated": true,
         "hw": [
         {
             "signature": "WBMWAC-v2"
@@ -612,7 +611,17 @@
                 "reg_type": "coil",
                 "address": 2,
                 "type": "switch",
+                "readonly": true,
                 "sporadic": true,
+                "group": "gg_outputs_channels"
+            },
+            {
+                "name": "Leakage Mode Reset",
+                "reg_type": "coil",
+                "address": 2,
+                "on_value": 0,
+                "type": "pushbutton",
+                "enabled": true,
                 "group": "gg_outputs_channels"
             },
             {
@@ -779,6 +788,7 @@
                 {% endfor -%}
 
                 "Leakage Mode": "Режим \"Протечка\"",
+                "Leakage Mode Reset": "Сброс режима \"Протечка\"",
 
                 "Serial": "Серийный номер",
                 "FW Version": "Версия прошивки",


### PR DESCRIPTION
1. Контрол Leakage Mode сделан readonly, для того чтобы не было возможности включить режим "Протечка" из веб интерфейса и не вводить пользователя в заблуждение.
2. Добавлена кнопка "Сброс режима "Протечка"".
3. Старый шаблон пришлось задепрекейтить, потому что когда делаешь контрол readonly, wb-rules не может писать в топик и это можеть поломать кому-то имеющиеся наработки.