### PR TITLE
Remove PYEZ1R05J4 from title

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.167.4) stable; urgency=medium
+
+  * config-carel-pj-basic.json and config-carel-pj-basic-deprecated.json: Remove PYEZ1R05J4 from title
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 29 May 2025 15:04:00 +0300
+
 wb-mqtt-serial (2.167.3) stable; urgency=medium
 
   * config-map3ev.json: Add separate signature WB-MAP3EV

--- a/templates/config-carel-pj-basic-deprecated.json
+++ b/templates/config-carel-pj-basic-deprecated.json
@@ -1,5 +1,5 @@
 {
-    "title": "Carel PJ BASIC (PYEZ1R05J4, PYEZ1R05J5)",
+    "title": "Carel PJ BASIC (PYEZ1R05J5)",
     "device_type": "carel_pj_basic",
     "group": "g-refrigeration",
     "deprecated": true,

--- a/templates/config-carel-pj-basic.json
+++ b/templates/config-carel-pj-basic.json
@@ -1,5 +1,5 @@
 {
-    "title": "Carel PJ BASIC (PYEZ1R05J4, PYEZ1R05J5)",
+    "title": "Carel PJ BASIC (PYEZ1R05J5)",
     "device_type": "tpl1_carel_pj_basic",
     "group": "g-refrigeration",
     "device": {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Удалил из двух шаблонов:
config-carel-pj-basic.json
config-carel-pj-basic-deprecated.json
названия шаблона PYEZ1R05J4, т.к. он не поддерживает передачу данных. Тикет, где это исследовали https://wirenboard.youtrack.cloud/issue/FW-948 WB-REF-U-CR не работает с контроллером PYEZ1R05J4

___________________________________
**Что поменялось для пользователей:**
Было:
![image](https://github.com/user-attachments/assets/8e0ee46d-8ea2-4368-9d1d-35f45301e18d)

Стало:
![image](https://github.com/user-attachments/assets/20fa265f-1990-4290-aadc-a944e7f5d1b2)


___________________________________
**Как проверял/а:**
Поменял шаблон на контроллере, перезагрузилл confed, название поменялось, конфиг не сломался.