### PR TITLE
Feature/int 386 carel murack fix duplicate channel

### DIFF
--- a/templates/config-carel-mu-rack.json
+++ b/templates/config-carel-mu-rack.json
@@ -2095,14 +2095,14 @@
                 "type": "switch"
             },
             {
-                "name": "Alarm Low Suction Pressure 1",
+                "name": "Alarm General Low Suction Pressure 1",
                 "group": "alarms",
                 "reg_type": "discrete",
                 "address": 44,
                 "type": "switch"
             },
             {
-                "name": "Alarm Low Suction Pressure 2",
+                "name": "Alarm General Low Suction Pressure 2",
                 "group": "alarms",
                 "reg_type": "discrete",
                 "address": 35,

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -21339,6 +21339,8 @@ carel_mu_rack
 	Alarm Fan 2  =>  Alarm Fan 2
 	Alarm Fan 3  =>  Alarm Fan 3
 	Alarm Fan 4  =>  Alarm Fan 4
+	Alarm General Low Suction Pressure 1  =>  Alarm General Low Suction Pressure 1
+	Alarm General Low Suction Pressure 2  =>  Alarm General Low Suction Pressure 2
 	Alarm High Discharge Pressure  =>  Alarm High Discharge Pressure
 	Alarm High Suction Pressure 1  =>  Alarm High Suction Pressure 1
 	Alarm High Suction Pressure 2  =>  Alarm High Suction Pressure 2


### PR DESCRIPTION
**Что происходит; кому и зачем нужно:**
[Тикет](https://wirenboard.youtrack.cloud/issue/INT-386/Shablon-Carel-Rack-MRK0000000-soderzhit-povtoryayushiesya-kanaly)
В шаблоне Carel muRack были задублированы каналы Alarm Low Suction Pressure 1 и Alarm Low Suction Pressure 2.
Было:
```
Alarm Low Suction Pressure 1 адрес 42
Alarm Low Suction Pressure 2 адрес 34
Alarm Low Suction Pressure 1 адрес 44
Alarm Low Suction Pressure 2 адрес 44
```
Как должно было быть:
```
Alarm Low Suction Pressure 1 адрес 42
Alarm Low Suction Pressure 2 адрес 34
Alarm General Low Suction Pressure 1 адрес 44
Alarm General Low Suction Pressure 2 адрес  35
```

Получается переименовал каналы, что запрещается делать, но тк они и не создавались, думаю это допустимо, а не в deprecated уносить с ошибкой и создавать исправленный шаблон.
___________________________________
**Что поменялось для пользователей:**
Не создавались каналы  Alarm General Low Suction Pressure 1 и Alarm General Low Suction Pressure 2, теперь создаются, по умолчанию выключены.
Стало:
![image](https://github.com/user-attachments/assets/d5598334-cae1-4332-9d51-ac755bf11ec8)

___________________________________
**Как проверял/а:**
На вб8 проверил что шаблон без ошибок. Обмен с Carel muRack не проверял. У нас его нет, проверяли у пользователя.