### PR TITLE
Feature/mrm2 mini nc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.169.1) stable; urgency=medium
+
+  * Add separate device signature for WB-MRM2-mini/NC
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Wed, 04 Jun 2025 15:19:39 +0300
+
 wb-mqtt-serial (2.169.0) stable; urgency=medium
 
   * Add device/Probe RPC for requesting information about Wiren Board device

--- a/templates/config-wb-mrm2-mini-nc.json.jinja
+++ b/templates/config-wb-mrm2-mini-nc.json.jinja
@@ -5,6 +5,11 @@
     "title": "WB-MRM2-mini-NC_template_title",
     "device_type": "WB-MRM2-mini-NC-inputs",
     "group": "g-wb",
+    "hw": [
+        {
+            "signature": "WB-MRM2-mini/NC"
+        }
+    ],
     "device": {
         "name": "WB-MRM2-mini/NC",
         "id": "wb-mrm2-mini-nc",

--- a/templates/config-wb-mrm2-mini.json.jinja
+++ b/templates/config-wb-mrm2-mini.json.jinja
@@ -10,6 +10,9 @@
     "hw": [
         {
             "signature": "WBMR2m"
+        },
+        {
+            "signature": "WB-MRM2-mini/NO"
         }
     ],
     "device": {


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил отдельную сигнатуру для MRM2-mini/NC, чтобы различать их при сканировании.
Также для MRM2-mini/NO поправил сигнатуру, чтобы совпадала с этикеткой и была похожа с NC. Теперь в шаблоне NO две сигнатуры, чтобы старые устройства не перестали работать.

___________________________________
**Что поменялось для пользователей:**
После выхода с производства NC версий с новой сигнатурой они будет корректно находиться сканированием сразу с нужным шаблоном.

___________________________________
**Как проверял/а:**
![image](https://github.com/user-attachments/assets/11395bc8-9b7d-4773-9300-5c009a01a71d)
