### PR TITLE
WB-MSW: Add safety mode for IR devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.174.1) stable; urgency=medium
+
+  * WB-MSW templates: Add safety mode for IR devices
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Fri, 20 Jun 2025 17:22:00 +0300
+
 wb-mqtt-serial (2.174.0) stable; urgency=medium
 
   * WB-MWAC v.2: deprecate old template, add new, make Leakage Mode control read only, add button to reset it

--- a/templates/config-wb-msw_v3.json
+++ b/templates/config-wb-msw_v3.json
@@ -37,6 +37,11 @@
                 "id": "indication"
             },
             {
+                "title": "Safety Mode",
+                "id": "g_safety",
+                "description": "g_safety_description"
+            },
+            {
                 "title": "IR Commands",
                 "id": "ir_commands"
             },
@@ -135,6 +140,42 @@
                 "default": 10,
                 "group": "motion",
                 "order": 1
+            },
+            "safety_timer_s": {
+                "title": "Safety Poll Timeout (s)",
+                "group": "g_safety",
+                "description": "poll_timeout_description",
+                "address": 955,
+                "order": 1,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 65534,
+                "default": 10
+            },
+            "safety_action": {
+                "title": "Safety Action",
+                "group": "g_safety",
+                "address": 956,
+                "order": 2,
+                "reg_type": "holding",
+                "enum": [0, 1],
+                "default": 0,
+                "enum_titles": [
+                    "No Action",
+                    "Play IR Command"
+                ]
+            },
+            "safety_command": {
+                "title": "Safety Command",
+                "group": "g_safety",
+                "description": "safety_command_description",
+                "address": 957,
+                "order": 3,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 80,
+                "default": 1,
+                "condition": "safety_action==1"
             },
             "baud_rate": {
                 "title": "Baud rate",
@@ -1611,7 +1652,10 @@
                 "CO2 Sensor Software Version": "CO₂ Sensor Software Version",
                 "CO2 MH-Z19 Temperature": "CO₂ MH-Z19 Temperature",
                 "CO2 MH-Z19 Autocalibration Ticks": "CO₂ MH-Z19 Autocalibration Ticks (1 unit is ~7.5 min)",
-                "CO2 MH-Z19 Autocalibration Count": "CO₂ MH-Z19 Autocalibration Count"
+                "CO2 MH-Z19 Autocalibration Count": "CO₂ MH-Z19 Autocalibration Count",
+                "g_safety_description": "Safety mode is activated if there is no Modbus polling within the specified timeout. Supported since firmware 4.32.0",
+                "poll_timeout_description": "Timeout without Modbus polling after which safety mode will be activated",
+                "safety_command_description": "IR Command that will be played in safety mode"
             },
             "ru": {
                 "WB-MSW-v3_template_title": "WB-MSW v.3 (универсальный настенный Modbus-датчик)",
@@ -1788,7 +1832,17 @@
                 "Successful TH Readings": "Успешные запросы к датчику TH",
                 "Erroneous TH Readings": "Ошибочные запросы к датчику TH",
                 "Temperature Without Compensation": "Температура до компенсации",
-                "Humidity Without Compensation": "Влажность до компенсации"
+                "Humidity Without Compensation": "Влажность до компенсации",
+
+                "Safety Mode": "Безопасный режим",
+                "g_safety_description": "Безопасный режим активируется, если в течение указанного времени отсутствует опрос по Modbus. Доступно с версии прошивки 4.32.0",
+                "Safety Poll Timeout (s)": "Таймаут потери связи (с)",
+                "poll_timeout_description": "Время отсутствия опроса, после которого будет активирован безопасный режим",
+                "Safety Action": "Действие в безопасном режиме",
+                "No Action": "Ничего не делать",
+                "Play IR Command": "Воспроизвести ИК-команду",
+                "Safety Command": "ИК-команда",
+                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
             }
         }
     }

--- a/templates/config-wb-msw_v4.json
+++ b/templates/config-wb-msw_v4.json
@@ -40,6 +40,11 @@
                 "id": "ir_commands"
             },
             {
+                "title": "Safety Mode",
+                "id": "g_safety",
+                "description": "g_safety_description"
+            },
+            {
                 "title": "General",
                 "id": "general"
             },
@@ -113,6 +118,42 @@
                 "default": 10,
                 "group": "motion",
                 "order": 1
+            },
+            "safety_timer_s": {
+                "title": "Safety Poll Timeout (s)",
+                "group": "g_safety",
+                "description": "poll_timeout_description",
+                "address": 955,
+                "order": 1,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 65534,
+                "default": 10
+            },
+            "safety_action": {
+                "title": "Safety Action",
+                "group": "g_safety",
+                "address": 956,
+                "order": 2,
+                "reg_type": "holding",
+                "enum": [0, 1],
+                "default": 0,
+                "enum_titles": [
+                    "No Action",
+                    "Play IR Command"
+                ]
+            },
+            "safety_command": {
+                "title": "Safety Command",
+                "group": "g_safety",
+                "description": "safety_command_description",
+                "address": 957,
+                "order": 3,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 80,
+                "default": 1,
+                "condition": "safety_action==1"
             },
             "baud_rate": {
                 "title": "Baud rate",
@@ -1573,7 +1614,10 @@
                 "CO2 Sensor Installed": "CO₂ Sensor Installed",
                 "CO2 Sensor Type": "CO₂ Sensor Type",
                 "CO2 Sensor Software Version": "CO₂ Sensor Software Version",
-                "VOC Equivalent CO2 Concentration": "VOC Equivalent CO₂ Concentration (eCO₂)"
+                "VOC Equivalent CO2 Concentration": "VOC Equivalent CO₂ Concentration (eCO₂)",
+                "g_safety_description": "Safety mode is activated if there is no Modbus polling within the specified timeout. Supported since firmware 4.32.0",
+                "poll_timeout_description": "Timeout without Modbus polling after which safety mode will be activated",
+                "safety_command_description": "IR Command that will be played in safety mode"
             },
             "ru": {
                 "WB-MSW-v4_template_title": "WB-MSW v.4 (универсальный настенный Modbus-датчик)",
@@ -1748,7 +1792,17 @@
                 "Successful TH Readings": "Успешные запросы к датчику TH",
                 "Erroneous TH Readings": "Ошибочные запросы к датчику TH",
                 "Temperature Without Compensation": "Температура до компенсации",
-                "Humidity Without Compensation": "Влажность до компенсации"
+                "Humidity Without Compensation": "Влажность до компенсации",
+
+                "Safety Mode": "Безопасный режим",
+                "g_safety_description": "Безопасный режим активируется, если в течение указанного времени отсутствует опрос по Modbus. Доступно с версии прошивки 4.32.0",
+                "Safety Poll Timeout (s)": "Таймаут потери связи (с)",
+                "poll_timeout_description": "Время отсутствия опроса, после которого будет активирован безопасный режим",
+                "Safety Action": "Действие в безопасном режиме",
+                "No Action": "Ничего не делать",
+                "Play IR Command": "Воспроизвести ИК-команду",
+                "Safety Command": "ИК-команда",
+                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
             }
         }
     }

--- a/templates/config-wb-msw_v4_lora.json
+++ b/templates/config-wb-msw_v4_lora.json
@@ -36,6 +36,11 @@
                 "id": "ir_commands"
             },
             {
+                "title": "Safety Mode",
+                "id": "g_safety",
+                "description": "g_safety_description"
+            },
+            {
                 "title": "General",
                 "id": "general"
             },
@@ -98,6 +103,42 @@
                 "default": 10,
                 "group": "motion",
                 "order": 1
+            },
+            "safety_timer_s": {
+                "title": "Safety Poll Timeout (s)",
+                "group": "g_safety",
+                "description": "poll_timeout_description",
+                "address": 955,
+                "order": 1,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 65534,
+                "default": 10
+            },
+            "safety_action": {
+                "title": "Safety Action",
+                "group": "g_safety",
+                "address": 956,
+                "order": 2,
+                "reg_type": "holding",
+                "enum": [0, 1],
+                "default": 0,
+                "enum_titles": [
+                    "No Action",
+                    "Play IR Command"
+                ]
+            },
+            "safety_command": {
+                "title": "Safety Command",
+                "group": "g_safety",
+                "description": "safety_command_description",
+                "address": 957,
+                "order": 3,
+                "reg_type": "holding",
+                "min": 1,
+                "max": 80,
+                "default": 1,
+                "condition": "safety_action==1"
             },
             "baud_rate": {
                 "title": "Baud rate",
@@ -1545,7 +1586,10 @@
                 "CO2 Sensor Installed": "CO₂ Sensor Installed",
                 "CO2 Sensor Type": "CO₂ Sensor Type",
                 "CO2 Sensor Software Version": "CO₂ Sensor Software Version",
-                "VOC Equivalent CO2 Concentration": "VOC Equivalent CO₂ Concentration (eCO₂)"
+                "VOC Equivalent CO2 Concentration": "VOC Equivalent CO₂ Concentration (eCO₂)",
+                "g_safety_description": "Safety mode is activated if there is no Modbus polling within the specified timeout. Supported since firmware 4.32.0",
+                "poll_timeout_description": "Timeout without Modbus polling after which safety mode will be activated",
+                "safety_command_description": "IR Command that will be played in safety mode"
             },
             "ru": {
                 "WB-MSW-v4_template_title": "WB-MSW-LORA v.4 (универсальный настенный Modbus-датчик)",
@@ -1720,7 +1764,17 @@
                 "Successful TH Readings": "Успешные запросы к датчику TH",
                 "Erroneous TH Readings": "Ошибочные запросы к датчику TH",
                 "Temperature Without Compensation": "Температура до компенсации",
-                "Humidity Without Compensation": "Влажность до компенсации"
+                "Humidity Without Compensation": "Влажность до компенсации",
+
+                "Safety Mode": "Безопасный режим",
+                "g_safety_description": "Безопасный режим активируется, если в течение указанного времени отсутствует опрос по Modbus. Доступно с версии прошивки 4.32.0",
+                "Safety Poll Timeout (s)": "Таймаут потери связи (с)",
+                "poll_timeout_description": "Время отсутствия опроса, после которого будет активирован безопасный режим",
+                "Safety Action": "Действие в безопасном режиме",
+                "No Action": "Ничего не делать",
+                "Play IR Command": "Воспроизвести ИК-команду",
+                "Safety Command": "ИК-команда",
+                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
             }
         }
     }


### PR DESCRIPTION

___________________________________
**Что происходит; кому и зачем нужно:**
Добавлен безопасный режим через библиотеку libwbmcu-periph для устройств WB-MSW с ИК-приемопередатчиком.

___________________________________
**Что поменялось для пользователей:**
Появились новые регистры для настройки безопасного режима.

___________________________________
**Как проверял/а:**
Настраивал ИК-команду на включение телевизора при потере связи