### PR TITLE
Add condition dependencies to device template

### DIFF
--- a/src/config_merge_template.cpp
+++ b/src/config_merge_template.cpp
@@ -7,6 +7,7 @@
 
 using namespace std;
 using namespace WBMQTT::JSON;
+using Expressions::TExpressionsCache;
 
 namespace
 {

--- a/src/config_merge_template.h
+++ b/src/config_merge_template.h
@@ -7,8 +7,6 @@ Json::Value MergeDeviceConfigWithTemplate(const Json::Value& deviceData,
                                           const std::string& deviceType,
                                           const Json::Value& deviceTemplate);
 
-typedef std::unordered_map<std::string, std::unique_ptr<Expressions::TAstNode>> TExpressionsCache;
-
 class TJsonParams: public Expressions::IParams
 {
     const Json::Value& Params;
@@ -19,4 +17,4 @@ public:
     std::optional<int32_t> Get(const std::string& name) const override;
 };
 
-bool CheckCondition(const Json::Value& item, const TJsonParams& params, TExpressionsCache* exprs);
+bool CheckCondition(const Json::Value& item, const TJsonParams& params, Expressions::TExpressionsCache* exprs);

--- a/src/config_schema_generator.cpp
+++ b/src/config_schema_generator.cpp
@@ -7,6 +7,7 @@
 #define LOG(logger) ::logger.Log() << "[serial config] "
 
 using namespace WBMQTT::JSON;
+using Expressions::TExpressionsCache;
 
 namespace
 {

--- a/src/expression_evaluator.cpp
+++ b/src/expression_evaluator.cpp
@@ -1,5 +1,6 @@
 #include "expression_evaluator.h"
 
+#include <set>
 #include <stdexcept>
 #include <unordered_map>
 #include <vector>
@@ -485,4 +486,20 @@ bool Expressions::Eval(const Expressions::TAstNode* expr, const IParams& params)
 {
     auto res = EvalImpl(expr, params);
     return res && res.value();
+}
+
+std::vector<std::string> Expressions::GetDependencies(const TAstNode* expression)
+{
+    std::set<std::string> dependencies;
+    if (expression) {
+        if (expression->GetType() == TAstNodeType::Ident) {
+            dependencies.insert(expression->GetValue());
+        } else {
+            auto leftDeps = GetDependencies(expression->GetLeft());
+            dependencies.insert(leftDeps.begin(), leftDeps.end());
+            auto rightDeps = GetDependencies(expression->GetRight());
+            dependencies.insert(rightDeps.begin(), rightDeps.end());
+        }
+    }
+    return std::vector<std::string>(dependencies.begin(), dependencies.end());
 }

--- a/src/expression_evaluator.h
+++ b/src/expression_evaluator.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // EBNF:
@@ -152,4 +153,17 @@ namespace Expressions
      * @return result of expression evaluation
      */
     bool Eval(const TAstNode* expression, const IParams& params);
+
+    /**
+     * @brief Extracts a list of variable dependencies from the given expression AST node.
+     *
+     * This function analyzes the provided abstract syntax tree (AST) node representing an expression
+     * and returns a vector containing the names of all variables or identifiers that the expression depends on.
+     *
+     * @param expression Pointer to the root AST node of the expression to analyze.
+     * @return std::vector<std::string> List of variable names that are dependencies of the expression.
+     */
+    std::vector<std::string> GetDependencies(const TAstNode* expression);
+
+    typedef std::unordered_map<std::string, std::unique_ptr<Expressions::TAstNode>> TExpressionsCache;
 }

--- a/src/rpc/rpc_device_load_config_task.cpp
+++ b/src/rpc/rpc_device_load_config_task.cpp
@@ -397,7 +397,7 @@ TRPCRegisterList CreateRegisterList(const TDeviceProtocolParams& protocolParams,
 void CheckParametersConditions(const Json::Value& templateParams, Json::Value& parameters)
 {
     TJsonParams jsonParams(parameters);
-    TExpressionsCache expressionsCache;
+    Expressions::TExpressionsCache expressionsCache;
     bool check = true;
     while (check) {
         std::unordered_map<std::string, bool> matches;

--- a/test/parser_test/merge_template_res10.json
+++ b/test/parser_test/merge_template_res10.json
@@ -12,11 +12,13 @@
         {
             "address" : "0x0502",
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "name" : "c2"
         },
         {
             "address" : "0x0503",
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "name" : "c3"
         }
     ],
@@ -31,6 +33,7 @@
         {
             "address" : "0x0403",
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "id" : "param3",
             "title" : "p3",
             "value" : 3

--- a/test/parser_test/merge_template_res11.json
+++ b/test/parser_test/merge_template_res11.json
@@ -12,11 +12,13 @@
         {
             "address": "0x0504",
             "condition": "param2==3",
+            "dependencies" : [ "param2" ],
             "name": "c4"
         },
         {
             "address": "0x0505",
             "condition": "param1==2&&param2==3",
+            "dependencies": [ "param1", "param2" ],
             "name": "c5"
         }
     ],

--- a/test/parser_test/merge_template_res13.json
+++ b/test/parser_test/merge_template_res13.json
@@ -23,6 +23,7 @@
         {
             "address" : 10,
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "id" : "param2",
             "required" : true,
             "title" : "p2",

--- a/test/parser_test/merge_template_res9.json
+++ b/test/parser_test/merge_template_res9.json
@@ -12,11 +12,13 @@
         {
             "address" : "0x0502",
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "name" : "c2"
         },
         {
             "address" : "0x0503",
             "condition" : "param1==1",
+            "dependencies" : [ "param1" ],
             "name" : "c3"
         }
     ],

--- a/wb-mqtt-serial-confed-common.schema.json
+++ b/wb-mqtt-serial-confed-common.schema.json
@@ -42,11 +42,6 @@
         }
       }
     },
-    "device_name": {
-      "description" : "Device name to be displayed in UI",
-      "minLength" : 1,
-      "type" : "string"
-    },
     "deviceProperties": {
       "properties": {
         "enabled": {
@@ -57,8 +52,10 @@
           "propertyOrder": 1
         },
         "name" : {
-          "$ref" : "#/definitions/device_name",
+          "type" : "string",
           "title" : "Device name",
+          "description" : "Device name to be displayed in UI",
+          "minLength" : 1,
           "propertyOrder": 3
         },
         "id": {
@@ -150,7 +147,7 @@
           "title": "Frame timeout (ms)",
           "description": "frame_timeout_description",
           "minimum": -1,
-          "default": -1,
+          "default": 20,
           "propertyOrder": 108
         },
         "force_frame_timeout": {
@@ -166,7 +163,7 @@
           "title": "Response timeout (ms)",
           "description": "response_timeout_description",
           "minimum": -1,
-          "default": -1,
+          "default": 500,
           "propertyOrder": 110
         },
         "device_timeout_ms": {
@@ -1356,9 +1353,9 @@
       "read_period_description": "This option specifies the desired period between two consecutive reads of the channel. Short periods may not be maintained due to port bandwidth limitations",
       "broadcast_description": "Requests are sent without specifying exact id of the device. Use the mode if only one device is connected",
       "frame_timeout_description": "Specifies minimum inter-frame delay. For some protocols this value is used to split incoming data into frames.",
-      "response_timeout_description": "Specifies maximum device's response time. Zero means no timeout. If not set, the default timeout (500ms) is used. If port's appropriate parameter is bigger, this one is overwritten.",
-      "device_timeout_description": "Specifies timeout for device connection. If not set, default value 3000ms is used. Value -1 disables device reconnect. Zero means instant timeout.",
-      "device_max_fail_cycles_desc": "Defines number of device polling cycles with all failed registers before marking device as disconnected. Default value is 2. Value -1 disables device reconnect. Zero means instant timeout.",
+      "response_timeout_description": "Specifies maximum device's response time. If port's appropriate parameter is bigger, this one is overwritten.",
+      "device_timeout_description": "Specifies timeout for device connection. Value -1 disables device reconnect. Zero means instant timeout.",
+      "device_max_fail_cycles_desc": "Defines number of device polling cycles with all failed registers before marking device as disconnected. Value -1 disables device reconnect. Zero means instant timeout.",
       "string_data_size_description": "For the modbus protocol, strings are read one character per register from the low byte. The parameter specifies the number of characters",
       "rate_limit_desc": "To reduce the load on the processor, it is not recommended to specify more than 100 reads for WB6 and 800 for WB7",
       "sporadic_description": "If a protocol allows, the register is excluded from periodic polling. Its change is sent by a special event",
@@ -1398,9 +1395,9 @@
       "Device timeout (ms)": "Время ожидания устройства (мс)",
       "Device max fail cycles": "Максимальное число неудачных циклов опроса",
       "frame_timeout_description": "Задаёт минимальную задержку между сообщениями. В некоторых протоколах это значение используется для определения границ сообщений.",
-      "response_timeout_description": "Задаёт максимальное время ответа устройства. По умолчанию 500 мс. Если соответствующий параметр порта больше, то используется значение порта.",
-      "device_timeout_description": "Задаёт время ожидания устройства. По умолчанию 3000 мс. Запрещает переподключение, если установлено -1.",
-      "device_max_fail_cycles_desc": "Число неудачных циклов опроса устройства после которых оно считается отключенным. По умолчанию 2. Запрещает переподключение, если установлено -1.",
+      "response_timeout_description": "Задаёт максимальное время ответа устройства. Если соответствующий параметр порта больше, то используется значение порта.",
+      "device_timeout_description": "Задаёт время ожидания устройства. Запрещает переподключение, если установлено -1.",
+      "device_max_fail_cycles_desc": "Число неудачных циклов опроса устройства после которых оно считается отключенным. Запрещает переподключение, если установлено -1.",
       "Setup command": "Команда настройки",
       "Command name": "Название команды",
       "Used for logging/debugging purposes only": "Используется только для диагностических сообщений",

--- a/wb-mqtt-serial-device-template.schema.json
+++ b/wb-mqtt-serial-device-template.schema.json
@@ -57,27 +57,25 @@
     },
 
     "group": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "order": {
-              "type": "integer"
-            },
-            "description": {
-              "type": "string"
-            }
-          },
-          "required": ["title", "id"]
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
         },
-        { "$ref": "#/definitions/group_condition" }
-      ]
+        "id": {
+          "type": "string"
+        },
+        "order": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        }
+      },
+      "required": ["title", "id"]
     },
 
     "groups": {
@@ -125,6 +123,9 @@
             },
             "readonly": {
               "type": "boolean"
+            },
+            "description": {
+              "type": "string"
             }
           },
           "required": ["title"]


### PR DESCRIPTION
* Add condition dependencies to device template when sending it to homeui
* Fix default values in schema

__________________________________
**Что происходит; кому и зачем нужно:**

При запросе шаблона устройства из homeui для каждого condition вычисляю и сохраняю список параметров, который в нём используется. На стороне фронта этот список используется для ускорения вычисления значения условия. Не хочу разбор условий тащить в фронт, а тут он и так делается. 

Ещё немного поправил схему, указао корректные зрачения по умолчанию, убрал лишнюю вложенность

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
