### PR TITLE
Update config-wbe2-i-opentherm-fw1.4.json

### DIFF
--- a/templates/config-wbe2-i-opentherm-fw1.4.json
+++ b/templates/config-wbe2-i-opentherm-fw1.4.json
@@ -84,6 +84,7 @@
                 "format": "u16",
                 "scale": 0.1,
                 "offset": -100,
+		"round_to": 0.01,
                 "group": "boiler_state"
             },
             {


### PR DESCRIPTION
include "round_to" into Water Pressure due to optimise view and UI improvement (Devices page)

<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
Оптимизация отображения давления воды на карточке устройства.
**Что происходит; кому и зачем нужно:**


Давление ображается до сотой доли целого
**Что поменялось для пользователей:**


Изненение штатного шаблона и проверка отображения в web интерфейсе
**Как проверял/а:**
