### PR TITLE
Update config-wbe2-i-ebus.json

### DIFF
--- a/templates/config-wbe2-i-ebus.json
+++ b/templates/config-wbe2-i-ebus.json
@@ -75,7 +75,7 @@
                 "group": "boiler_state",
                 "enabled": false
             },
-			 {
+            {
                 "name": "Hot Water Setpoint Max",
                 "address": 211,
                 "reg_type": "input",
@@ -83,31 +83,36 @@
                 "format": "u16",
                 "group": "boiler_state"
             },
-            { "name": "Water Pressure",
+            {
+		"name": "Water Pressure",
                 "address": 212,
                 "reg_type": "input",
                 "type": "pressure",
                 "format": "s16",
-				"scale" :0.001,
+		"round_to": 0.01,
+		"scale" :0.001,
                 "group": "boiler_state"
             },
-            { "name": "Burner Modulation Level",
+            {
+		"name": "Burner Modulation Level (%)",
                 "address": 213,
                 "reg_type": "input",
                 "type": "value",
                 "format": "s16",
-				"scale" :0.1,
+		"scale" :0.1,
                 "units": "%",
                 "group": "boiler_state"
             },
-            { "name": "Invalid Connection",
+            {
+		"name": "Invalid Connection",
                 "address": 214,
                 "reg_type": "input",
                 "type": "value",
                 "format": "u16",
                 "group": "boiler_state"
             },
-            { "name": "Boiler Status",
+            {
+		"name": "Boiler Status",
                 "address": 215,
                 "reg_type": "input",
                 "type": "value",
@@ -355,26 +360,23 @@
                 "Heating Temperature": "Температура подачи отопления",
                 "Heating Return Water Temperature": "Температура обратной воды отопления",
                 "Boiler Outdoor Temperature Sensor": "Уличная температура (датчик котла)",
-				"Hot Water Setpoint Max": "Максимальное значение температуры ГВС",
+		"Hot Water Setpoint Max": "Максимальное значение температуры ГВС",
                 "Water Pressure": "Давление",
-                "Burner Modulation Level" : "Модуляция котла",
+                "Burner Modulation Level (%)" : "Модуляция котла (%)",
                 "Invalid Connection": "Ошибка связи с котлом",
                 "Boiler Status" : "Состояние контуров котла",
                 "Hot Water Setpoint": "Уставка ГВС",
                 "Heating Settings": "Параметры отопления",
                 "FW Version": "Версия прошивки",
-
                 "Room Temperature Sensor": "Датчик комнатной температуры",
                 "Temperature Sensor Type": "Тип датчика температуры",
                 "Heating Setpoint": "Уставка отопления",
                 "Room Temperature": "Комнатная температура",
                 "Room Temperature Setpoint": "Уставка комнатной температуры",
-
                 "Outdoor Temperature Sensor": "Датчик уличной температуры",
                 "Climate Curve Number": "Номер климатической кривой",
                 "Outdoor Temperature": "Уличная температура",
                 "Heating Status": "Статус отопления",
-
                 "Direct Heating Setpoint Control": "Управление уставкой отопления",
                 "Heating Off": "Отопление отключено"
             }


### PR DESCRIPTION
- include "round_to" into Water Pressure due to optimise view and UI improvement (Devices page)
- change "Burner Modulation Level" to "Burner Modulation Level (%)" еo match the field name in OT and EBUS
- minor TAB to SPACE change to better code looking
- minor RETURN insert after brace to better code looking

<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
- Оптимизация отображения давления воды на карточке устройства.
- соответствие отображения в карточках устройств для opentherm и ebus, чтобы не было разночтения
- визуальная оптимизация кода
- визуальная оптимизация кода
**Что происходит; кому и зачем нужно:**


Давление ображается до сотой доли целого
**Что поменялось для пользователей:**


Изненение штатного шаблона и проверка отображения в web интерфейсе
**Как проверял/а:**
