### PR TITLE
Feature/int 386 carel murack fix duplicate channel v2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.169.1) stable; urgency=medium
+
+  * config-carel-mu-rack.json: fix name channels
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Tue, 01 Jul 2025 17:31:00 +0300
+
 wb-mqtt-serial (2.175.3) stable; urgency=medium
 
   * Change device name in mst-24 template to show Rtelligent NT60 support

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.169.1) stable; urgency=medium
+wb-mqtt-serial (2.175.4) stable; urgency=medium
 
   * config-carel-mu-rack.json: fix name channels
 

--- a/templates/config-carel-mu-rack.json
+++ b/templates/config-carel-mu-rack.json
@@ -2109,7 +2109,6 @@
                 "address": 35,
                 "type": "switch",
                 "enabled": false
-
             },
             {
                 "name": "General Discharge Pressure Switch",

--- a/templates/config-carel-mu-rack.json
+++ b/templates/config-carel-mu-rack.json
@@ -2095,18 +2095,21 @@
                 "type": "switch"
             },
             {
-                "name": "Alarm Low Suction Pressure 1",
+                "name": "Alarm General Low Suction Pressure 1",
                 "group": "alarms",
                 "reg_type": "discrete",
                 "address": 44,
-                "type": "switch"
+                "type": "switch",
+                "enabled": false
             },
             {
-                "name": "Alarm Low Suction Pressure 2",
+                "name": "Alarm General Low Suction Pressure 2",
                 "group": "alarms",
                 "reg_type": "discrete",
                 "address": 35,
-                "type": "switch"
+                "type": "switch",
+                "enabled": false
+
             },
             {
                 "name": "General Discharge Pressure Switch",

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -21415,6 +21415,8 @@ carel_mu_rack
 	Alarm Fan 2  =>  Alarm Fan 2
 	Alarm Fan 3  =>  Alarm Fan 3
 	Alarm Fan 4  =>  Alarm Fan 4
+	Alarm General Low Suction Pressure 1  =>  Alarm General Low Suction Pressure 1
+	Alarm General Low Suction Pressure 2  =>  Alarm General Low Suction Pressure 2
 	Alarm High Discharge Pressure  =>  Alarm High Discharge Pressure
 	Alarm High Suction Pressure 1  =>  Alarm High Suction Pressure 1
 	Alarm High Suction Pressure 2  =>  Alarm High Suction Pressure 2


### PR DESCRIPTION
Этот ПР, [копия закрытого ПР](https://github.com/wirenboard/wb-mqtt-serial/pull/928), он был апрувнут, но я что-то напортачил  в мержах, и поломались тесты.
Что происходит; кому и зачем нужно:
[Тикет](https://wirenboard.youtrack.cloud/issue/INT-386/Shablon-Carel-Rack-MRK0000000-soderzhit-povtoryayushiesya-kanaly)
В шаблоне Carel muRack были задублированы каналы Alarm Low Suction Pressure 1 и Alarm Low Suction Pressure 2.
Было:

Alarm Low Suction Pressure 1 адрес 42
Alarm Low Suction Pressure 2 адрес 34
Alarm Low Suction Pressure 1 адрес 44
Alarm Low Suction Pressure 2 адрес 44
Как должно было быть:

Alarm Low Suction Pressure 1 адрес 42
Alarm Low Suction Pressure 2 адрес 34
Alarm General Low Suction Pressure 1 адрес 44
Alarm General Low Suction Pressure 2 адрес  35
Получается переименовал каналы, что запрещается делать, но тк они и не создавались, думаю это допустимо, а не в deprecated уносить с ошибкой и создавать исправленный шаблон.

Что поменялось для пользователей:
Не создавались каналы Alarm General Low Suction Pressure 1 и Alarm General Low Suction Pressure 2, теперь создаются, по умолчанию выключены.
Стало:
image

Как проверял/а:
На вб8 проверил что шаблон без ошибок. Обмен с Carel muRack не проверял. У нас его нет, проверяли у пользователя. Там по холодильникам решили в целом в порядок привести, составить списки что проверяли\что у нас есть. Купим muRack в коллекцию.