### PR TITLE
templates: ups v.3: fix reg addr

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.176.1) stable; urgency=medium
+
+  * templates: ups v.3: fix charge counter register address
+
+ -- Evgeny Boger <boger@wirenboard.com>  Fri, 04 Jul 2025 01:30:26 +0300
+
 wb-mqtt-serial (2.176.0) stable; urgency=medium
 
   * Add WB-UPS v.3 template

--- a/templates/config-wb-ups-v3.json.jinja
+++ b/templates/config-wb-ups-v3.json.jinja
@@ -390,6 +390,7 @@
                 "units": "mAh",
                 "reg_type": "holding",
                 "scale": 0.1,
+                "format": "s16",
                 "address": 21,
                 "enabled": false,
                 "group": "gg_debug_charge_discharge"

--- a/templates/config-wb-ups-v3.json.jinja
+++ b/templates/config-wb-ups-v3.json.jinja
@@ -390,7 +390,7 @@
                 "units": "mAh",
                 "reg_type": "holding",
                 "scale": 0.1,
-                "address": 20,
+                "address": 21,
                 "enabled": false,
                 "group": "gg_debug_charge_discharge"
             },


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
___________________________________
**Что происходит; кому и зачем нужно:**

в служебном регистре Charge Counter был перепутан адрес и не учитывался знак
___________________________________
**Что поменялось для пользователей:**

стало работать
___________________________________
**Как проверял/а:**
на железке

![image](https://github.com/user-attachments/assets/ce29a771-0ac3-49fc-8600-e6b8b8efcfa0)
![image](https://github.com/user-attachments/assets/6e94c09f-5692-4378-8fe5-921014c16b66)
