### PR TITLE
Allow to set max_unchanged_interval to 0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.177.2) stable; urgency=medium
+
+  * Allow to set max_unchanged_interval to 0 for publishing every read value
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 07 Jul 2025 22:09:13 +0500
+
 wb-mqtt-serial (2.177.1) stable; urgency=medium
 
   * Breezart Lux template: Added by the translation of Title for English. Made more understandable the name of the template in Russian, corrected in the documentation.

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,7 +9,7 @@ wb-mqtt-serial (2.177.1) stable; urgency=medium
   * Breezart Lux template: Added by the translation of Title for English. Made more understandable the name of the template in Russian, corrected in the documentation.
 
  -- Alexander Degtyarev <a.degtyarev@wirenboard.com> Mon, 07 Jul 2025 12:20:21 +0400
- 
+
 wb-mqtt-serial (2.177.0) stable; urgency=medium
 
   * Refactor device/LoadConfig RPC

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,7 +8,7 @@ wb-mqtt-serial (2.177.1) stable; urgency=medium
 
   * Breezart Lux template: Added by the translation of Title for English. Made more understandable the name of the template in Russian, corrected in the documentation.
 
- -- Alexander Degtyarev <a.degtyarev@wirenboard.com> Mon, 07 Jul 2025 12:20:21 +0400
+ -- Alexander Degtyarev <a.degtyarev@wirenboard.com>  Mon, 07 Jul 2025 12:20:21 +0400
 
 wb-mqtt-serial (2.177.0) stable; urgency=medium
 

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -720,7 +720,7 @@ PHandlerConfig LoadConfig(const std::string& configFileName,
 
     auto maxUnchangedInterval = DefaultMaxUnchangedInterval;
     Get(Root, "max_unchanged_interval", maxUnchangedInterval);
-    if (maxUnchangedInterval.count() >= 0 && maxUnchangedInterval < MaxUnchangedIntervalLowLimit) {
+    if (maxUnchangedInterval.count() > 0 && maxUnchangedInterval < MaxUnchangedIntervalLowLimit) {
         LOG(Warn) << "\"max_unchanged_interval\" is set to " << MaxUnchangedIntervalLowLimit.count() << " instead of "
                   << maxUnchangedInterval.count();
         maxUnchangedInterval = MaxUnchangedIntervalLowLimit;


### PR DESCRIPTION
  * Allow to set max_unchanged_interval to 0 for publishing every read value

___________________________________
**Что происходит; кому и зачем нужно:**
Разрешаем ставить max_unchanged_interval в 0, чтобы публиковать в MQTT после каждого чтения и события.

___________________________________
**Что поменялось для пользователей:**
Разрешаем ставить max_unchanged_interval в 0, чтобы публиковать в MQTT после каждого чтения и события.

___________________________________
**Как проверял/а:**
