### PR TITLE
Fix channel settings negative hex value parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.177.4) stable; urgency=medium
+
+  * Fix channel settings negative hex value parsing
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 10 Jul 2025 13:34:04 +0300
+
 wb-mqtt-serial (2.177.3) stable; urgency=medium
 
   * Port handling refactoring. No functional changes

--- a/test/TSerialClientIntegrationTest.OffValue.dat
+++ b/test/TSerialClientIntegrationTest.OffValue.dat
@@ -10,31 +10,55 @@ Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retain
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 Subscribe: /devices/OnValueTest/controls/Relay 1/on (QoS 0)
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/error: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+Subscribe: /devices/OnValueTest/controls/Relay 2/on (QoS 0)
 Subscribe: /devices/OnValueTest/controls/# (QoS 0)
 (retain) -> /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta: '{"order":1,"readonly":false,"type":"switch"}' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/order: '1' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/#
 >>> LoopOnce()
 Open()
 Sleep(100000)
-fake_serial_device '144': read address '0' value '500'
+fake_serial_device '144': read address '0' value '65535'
 fake_serial_device '144': transfer OK
 fake_serial_device '144': reconnected
-Publish: /devices/OnValueTest/controls/Relay 1: '1' (QoS 1, retained)
+fake_serial_device '144': read address '1' value '0'
+Publish: /devices/OnValueTest/controls/Relay 1: '65535' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/on: '0' (QoS 0, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/on: '0' (QoS 0, retained)
 >>> LoopOnce()
 fake_serial_device '144': write to address '0' value '200'
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
+fake_serial_device '144': write to address '1' value '4294967294'
+Publish: /devices/OnValueTest/controls/Relay 2: '-2' (QoS 1, retained)
 fake_serial_device '144': read address '0' value '200'
+fake_serial_device '144': read address '1' value '4294967294'
+Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 2/on
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 1/on
-Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/order: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta/driver: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta/name: '' (QoS 1, retained)

--- a/test/TSerialClientIntegrationTest.OnValue.dat
+++ b/test/TSerialClientIntegrationTest.OnValue.dat
@@ -10,12 +10,24 @@ Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retain
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 Subscribe: /devices/OnValueTest/controls/Relay 1/on (QoS 0)
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/error: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+Subscribe: /devices/OnValueTest/controls/Relay 2/on (QoS 0)
 Subscribe: /devices/OnValueTest/controls/# (QoS 0)
 (retain) -> /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta: '{"order":1,"readonly":false,"type":"switch"}' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/order: '1' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/#
 >>> LoopOnce()
 Open()
@@ -23,18 +35,30 @@ Sleep(100000)
 fake_serial_device '144': read address '0' value '0'
 fake_serial_device '144': transfer OK
 fake_serial_device '144': reconnected
+fake_serial_device '144': read address '1' value '0'
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/on: '1' (QoS 0, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/on: '1' (QoS 0, retained)
 >>> LoopOnce()
 fake_serial_device '144': write to address '0' value '500'
 Publish: /devices/OnValueTest/controls/Relay 1: '1' (QoS 1, retained)
+fake_serial_device '144': write to address '1' value '4294967295'
+Publish: /devices/OnValueTest/controls/Relay 2: '-1' (QoS 1, retained)
 fake_serial_device '144': read address '0' value '500'
+fake_serial_device '144': read address '1' value '4294967295'
+Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 2/on
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 1/on
-Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/order: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta/driver: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta/name: '' (QoS 1, retained)

--- a/test/TSerialClientIntegrationTest.OnValueError.dat
+++ b/test/TSerialClientIntegrationTest.OnValueError.dat
@@ -10,12 +10,24 @@ Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retain
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 Subscribe: /devices/OnValueTest/controls/Relay 1/on (QoS 0)
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/error: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+Subscribe: /devices/OnValueTest/controls/Relay 2/on (QoS 0)
 Subscribe: /devices/OnValueTest/controls/# (QoS 0)
 (retain) -> /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta: '{"order":1,"readonly":false,"type":"switch"}' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/order: '1' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/readonly: '0' (QoS 1, retained)
 (retain) -> /devices/OnValueTest/controls/Relay 1/meta/type: 'switch' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta: '{"order":2,"readonly":false,"type":"switch"}' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/order: '2' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/readonly: '0' (QoS 1, retained)
+(retain) -> /devices/OnValueTest/controls/Relay 2/meta/type: 'switch' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/#
 >>> LoopOnce()
 Open()
@@ -23,31 +35,44 @@ Sleep(100000)
 fake_serial_device '144': read address '0' value '0'
 fake_serial_device '144': transfer OK
 fake_serial_device '144': reconnected
+fake_serial_device '144': read address '1' value '0'
 Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '0' (QoS 1, retained)
 fake_serial_device: block address '0' for writing
 Publish: /devices/OnValueTest/controls/Relay 1/on: '1' (QoS 0, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/on: '1' (QoS 0, retained)
 >>> LoopOnce()
 fake_serial_device '144': write address '0' failed: 'Serial protocol error: write blocked'
 fake_serial_device '144': transfer FAIL
 Publish: /devices/OnValueTest/controls/Relay 1/meta/error: 'w' (QoS 1, retained)
+fake_serial_device '144': write to address '1' value '4294967295'
+Publish: /devices/OnValueTest/controls/Relay 2: '-1' (QoS 1, retained)
 fake_serial_device '144': read address '0' value '0'
-Publish: /devices/OnValueTest/controls/Relay 1: '0' (QoS 1, retained)
-Publish: /devices/OnValueTest/controls/Relay 1/meta/error: '' (QoS 1, retained)
+fake_serial_device '144': read address '1' value '4294967295'
 >>> LoopOnce()
 fake_serial_device '144': write address '0' failed: 'Serial protocol error: write blocked'
 fake_serial_device '144': transfer FAIL
 fake_serial_device '144': read address '0' value '0'
+fake_serial_device '144': read address '1' value '4294967295'
 fake_serial_device: unblock address '0' for writing
 >>> LoopOnce()
 fake_serial_device '144': write to address '0' value '500'
 Publish: /devices/OnValueTest/controls/Relay 1: '1' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 1/meta/error: '' (QoS 1, retained)
 fake_serial_device '144': read address '0' value '500'
+fake_serial_device '144': read address '1' value '4294967295'
+Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 2/on
+Publish: /devices/OnValueTest/controls/Relay 2/meta: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/order: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/readonly: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 2: '' (QoS 1, retained)
 Unsubscribe -- serial-client-integration-test: /devices/OnValueTest/controls/Relay 1/on
-Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/order: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/readonly: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/type: '' (QoS 1, retained)
+Publish: /devices/OnValueTest/controls/Relay 1: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/controls/Relay 1/meta/error: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta: '' (QoS 1, retained)
 Publish: /devices/OnValueTest/meta/driver: '' (QoS 1, retained)

--- a/test/configs/config-test.json
+++ b/test/configs/config-test.json
@@ -94,8 +94,16 @@
                             "type": "switch",
                             "on_value" : 500,
                             "off_value": 200
+                        },
+                        {
+                            "name" : "Relay 2",
+                            "reg_type" : "fake",
+                            "format": "s32",
+                            "address" : "0x01",
+                            "type": "switch",
+                            "on_value" : "0xffffffff",
+                            "off_value": "0xfffffffe"
                         }
-
                     ]
                 },
                 {

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -1181,14 +1181,20 @@ TEST_F(TSerialClientIntegrationTest, OnValue)
     }
 
     device->Registers[0] = 0;
+    device->Registers[1] = 0;
+    device->Registers[2] = 0;
+
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
 
     PublishWaitOnValue("/devices/OnValueTest/controls/Relay 1/on", "1", 0, true);
+    PublishWaitOnValue("/devices/OnValueTest/controls/Relay 2/on", "1", 0, true);
 
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
+
     ASSERT_EQ(500, device->Registers[0]);
+    ASSERT_EQ(-1, device->Registers[1] << 16 | device->Registers[2]);
 }
 
 TEST_F(TSerialClientIntegrationTest, OffValue)
@@ -1204,14 +1210,20 @@ TEST_F(TSerialClientIntegrationTest, OffValue)
     }
 
     device->Registers[0] = 500;
+    device->Registers[1] = 0xFFFF;
+    device->Registers[2] = 0xFFFF;
+
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
 
     PublishWaitOnValue("/devices/OnValueTest/controls/Relay 1/on", "0", 0, true);
+    PublishWaitOnValue("/devices/OnValueTest/controls/Relay 2/on", "0", 0, true);
 
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
+
     ASSERT_EQ(200, device->Registers[0]);
+    ASSERT_EQ(-2, device->Registers[1] << 16 | device->Registers[2]);
 }
 
 TEST_F(TSerialClientIntegrationTest, OnValueError)
@@ -1227,12 +1239,16 @@ TEST_F(TSerialClientIntegrationTest, OnValueError)
     }
 
     device->Registers[0] = 0;
+    device->Registers[1] = 0;
+    device->Registers[2] = 0;
+
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
 
     device->BlockWriteFor(0, true);
 
     PublishWaitOnValue("/devices/OnValueTest/controls/Relay 1/on", "1", 0, true);
+    PublishWaitOnValue("/devices/OnValueTest/controls/Relay 2/on", "1", 0, true);
 
     Note() << "LoopOnce()";
     SerialDriver->LoopOnce();
@@ -1246,6 +1262,7 @@ TEST_F(TSerialClientIntegrationTest, OnValueError)
     SerialDriver->LoopOnce();
 
     ASSERT_EQ(500, device->Registers[0]);
+    ASSERT_EQ(-1, device->Registers[1] << 16 | device->Registers[2]);
 }
 
 TEST_F(TSerialClientIntegrationTest, Round)


### PR DESCRIPTION
- добавил возможность парсинга отрицательных значений параметров каналов, если они записаны как HEX-строка со значением больше `0x7FFFFFFF`
- добавил поддержку любых числовых форматов (вплоть до `uint64`) для параметров канала `on_value` и `off_value`
- доработал тесты параметров канала `on_value` и `off_value`