### PR TITLE
change illumination threshold scale to 0.1

### DIFF
--- a/templates/config-mtdx62-mb.json
+++ b/templates/config-mtdx62-mb.json
@@ -96,7 +96,7 @@
         "reg_type": "holding",
         "address": "0x0B",
         "unit": "lux",
-        "scale": 1,
+        "scale": 0.1,
         "min": 0,
         "max": 4200,
         "default": 0,


### PR DESCRIPTION
The template for MTDX62-MB presence sensor had had wrong coefficient for light threshold, fix it.