### PR TITLE
Fix device/SetPoll RPC reply format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.184.1) stable; urgency=medium
+
+  * Fix device/SetPoll RPC reply format
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 14 Aug 2025 14:03:17 +0300
+
 wb-mqtt-serial (2.184.0) stable; urgency=medium
 
   * Add device/SetPoll RPC for device poll suspending and resuming

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -256,7 +256,7 @@ Json::Value TRPCDeviceHandler::SetPoll(const Json::Value& request)
         LOG(Warn) << e.what();
         throw TRPCException(e.what(), TRPCResultCode::RPC_WRONG_PARAM_VALUE);
     }
-    return Json::Value();
+    return Json::Value(Json::objectValue);
 }
 
 TRPCRegisterList CreateRegisterList(const TDeviceProtocolParams& protocolParams,


### PR DESCRIPTION
Изменил формат ответа для RPC `device/SetPoll` (теперь вместо `null` в ответе лежит пустой объект `{}`). С ответом `null` парсер ответов в `python-mqtt-rpc` вызывает исключение вот тут:
https://github.com/wirenboard/python-mqtt-rpc/blob/06b4b048b459ea445b7b120a40482c1a59c181e2/mqttrpc/protocol.py#L272-L275