### PR TITLE
Fix Modbus default response timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.188.1) stable; urgency=medium
+
+  * Fix default response timeout calculation for Modbus devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 04 Sep 2025 17:40:51 +0500
+
 wb-mqtt-serial (2.188.0) stable; urgency=medium
 
   * WB-UPS v.3 template: add parallel mode support

--- a/src/modbus_base.cpp
+++ b/src/modbus_base.cpp
@@ -185,7 +185,7 @@ TReadFrameResult Modbus::TModbusRTUTraits::ReadFrame(TPort& port,
 {
     auto rc = port.ReadFrame(response.data(),
                              response.size(),
-                             responseTimeout + frameTimeout,
+                             responseTimeout,
                              frameTimeout,
                              ExpectNBytes(response.size()));
     // RTU response should be at least 3 bytes: 1 byte slave_id, 2 bytes CRC
@@ -311,7 +311,7 @@ TReadFrameResult Modbus::TModbusTCPTraits::ReadFrame(TPort& port,
         if (response.size() < MBAP_SIZE) {
             response.resize(MBAP_SIZE);
         }
-        auto rc = port.ReadFrame(response.data(), MBAP_SIZE, responseTimeout + frameTimeout, frameTimeout);
+        auto rc = port.ReadFrame(response.data(), MBAP_SIZE, responseTimeout, frameTimeout);
 
         if (rc.Count < MBAP_SIZE) {
             throw Modbus::TMalformedResponseError("Can't read full MBAP");

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -533,7 +533,7 @@ namespace ModbusExt // modbus extension protocol declarations
     {
         auto rc = port.ReadFrame(res.data(),
                                  res.size(),
-                                 responseTimeout + frameTimeout,
+                                 responseTimeout,
                                  frameTimeout,
                                  ExpectNBytes(res.size()));
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При выполении modbus запроса зачем-то к таймауту ответа прибавлялся FrameTimeout. Если таймаут ответа не был указан в шаблоне и настройках, дожен был использоваться таймаут по умолчанию = 500мс. Он определяется в TPort::ReadFrame, если переданный ResonseTimeout отрицательный (т.е. не задан). Из-за прибавления FrameTimeout эта логика не работала, и таймаут ответа был равен FrameTimeout.
Ни в одном протоколе нет такого прибавления. Убрал, чтобы работала логика выбора таймаута по умолчанию.


___________________________________
**Что поменялось для пользователей:**
Выбирается корректный таймаут.

___________________________________
**Как проверял/а:**
Сделал произвольное модбас устройство и посмотрел логи
