### PR TITLE
Fix WB-MAP SN reading

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.188.2) stable; urgency=medium
+
+  * Fix WB-MAP SN reading
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 05 Sep 2025 17:25:48 +0500
+
 wb-mqtt-serial (2.188.1) stable; urgency=medium
 
   * Fix default response timeout calculation for Modbus devices

--- a/src/rpc/rpc_port_scan_serial_client_task.cpp
+++ b/src/rpc/rpc_port_scan_serial_client_task.cpp
@@ -29,7 +29,7 @@ namespace
     uint32_t GetSnFromRegister(const std::string& deviceModel, uint32_t sn)
     {
         if (std::regex_match(deviceModel, std::regex("^MAP[0-9]{1,2}.*"))) {
-            return sn & 0x00FFFFFF;
+            return sn & 0x01FFFFFF;
         }
         return sn;
     }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Маскировали лишний бит при чтении серийника WB-MAP

___________________________________
**Что поменялось для пользователей:**
Серийники читаются корректно

___________________________________
**Как проверял/а:**
