### PR TITLE
Generate default config on service start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,4 @@ install:
 	install -Dm0644 wb-mqtt-serial-dummy.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
 
 	install -Dm0755 $(BUILD_DIR)/$(SERIAL_BIN) -t $(DESTDIR)$(PREFIX)/bin
+	install -Dm0755 generate-system-config.sh -t $(DESTDIR)$(PREFIX)/lib/wb-mqtt-serial

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.190.0) stable; urgency=medium
+
+  * Generate default config on service start
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 01 Oct 2025 15:00:00 +0400
+
 wb-mqtt-serial (2.189.0) stable; urgency=medium
 
   * Update device templates for:

--- a/debian/wb-mqtt-serial.postinst
+++ b/debian/wb-mqtt-serial.postinst
@@ -2,34 +2,6 @@
 
 set -e
 
-. /etc/wb_env.sh
-
-wb_source "of"
-
-CONFFILE=/etc/wb-mqtt-serial.conf
-
-if of_machine_match "wirenboard,wirenboard-85x"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb85"
-elif of_machine_match "wirenboard,wirenboard-8xx"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb8"
-elif of_machine_match "wirenboard,wirenboard-720"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb7"
-elif of_machine_match "contactless,imx6ul-wirenboard670"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb67"
-elif of_machine_match "contactless,imx6ul-wirenboard60"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb6"
-elif of_machine_match "contactless,imx28-wirenboard50"; then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb5"
-elif of_machine_match "contactless,imx23-wirenboard41" ||
-     of_machine_match "contactless,imx23-wirenboard32" ||
-     of_machine_match "contactless,imx23-wirenboard28";
-then
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb234"
-else
-    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.default"
-fi
-
-ucf --debconf-ok $BOARD_CONF $CONFFILE
 rm -f /usr/share/wb-mqtt-confed/schemas/wb-mqtt-serial.schema.json
 
 #DEBHELPER#

--- a/debian/wb-mqtt-serial.wb-mqtt-serial.service
+++ b/debian/wb-mqtt-serial.wb-mqtt-serial.service
@@ -9,6 +9,7 @@ Restart=on-failure
 RestartSec=1
 User=root
 ExecStart=/usr/bin/wb-mqtt-serial
+ExecStartPre=/usr/lib/wb-mqtt-serial/generate-system-config.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+CONFFILE=/etc/wb-mqtt-serial.conf
+
+[ -f "$CONFFILE" ] && exit 0
+
+. /usr/lib/wb-utils/wb_env.sh
+
+wb_source "of"
+
+if of_machine_match "wirenboard,wirenboard-85x"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb85"
+elif of_machine_match "wirenboard,wirenboard-8xx"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb8"
+elif of_machine_match "wirenboard,wirenboard-720"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb7"
+elif of_machine_match "contactless,imx6ul-wirenboard670"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb67"
+elif of_machine_match "contactless,imx6ul-wirenboard60"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb6"
+elif of_machine_match "contactless,imx28-wirenboard50"; then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb5"
+elif of_machine_match "contactless,imx23-wirenboard41" ||
+     of_machine_match "contactless,imx23-wirenboard32" ||
+     of_machine_match "contactless,imx23-wirenboard28";
+then
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.wb234"
+else
+    BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.default"
+fi
+
+cp "$BOARD_CONF" "$CONFFILE"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сейчас дефолтный конфиг выбирается на этапе сборке фита, но фит для wb84 и wb85 общий, а конфиги должны быть разные. Поэтому выбирать дефолтный конфиг будем не при установке пакета, а при старте сервиса (если конфиг отсутствует).

___________________________________
**Что поменялось для пользователей:**
* После FR на wb85 будет корректный конфиг сириала.
* При обычном апдейте ничего не поменяется (если конфиг уже существует).
* При последующих обновлениях апт не будет спрашивать что  делать с конфигом, в случае когда дефолтный поменялся в пакете. От этого было больше проблем у пользователей, чем пользы.

___________________________________
**Как проверял/а:**
на вб