### PR TITLE
Fix TModbusRTUWithArbitrationTraits::Transaction method

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.192.1) stable; urgency=medium
+
+  * Fix TModbusRTUWithArbitrationTraits::Transaction method
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 07 Oct 2025 17:21:57 +0300
+
 wb-mqtt-serial (2.192.0) stable; urgency=medium
 
   * Add support for WB-MGE v.3.

--- a/src/modbus_ext_common.cpp
+++ b/src/modbus_ext_common.cpp
@@ -723,11 +723,11 @@ namespace ModbusExt // modbus extension protocol declarations
         if (matchSlaveId && (packet[0] != slaveId)) {
             throw Modbus::TUnexpectedResponseError("slave id mismatch");
         }
+        const uint8_t* data = response.data();
         Modbus::TReadResult result;
         result.ResponseTime = res.ResponseTime;
-        result.Pdu.assign(packet + RTU_HEADER_SIZE, response.cbegin() + (res.Count - CRC_SIZE));
+        result.Pdu.assign(packet + RTU_HEADER_SIZE, data + (res.Count - CRC_SIZE));
         result.SlaveId = packet[0];
         return result;
     }
-
 }


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Вызов `std::vector::assign` для получения PDU из ответа от устройства был написан с ошибкой, из-за чего код не собирался компилятором WASM.

___________________________________
**Что поменялось для пользователей:**
Ничего.

___________________________________
**Как проверял/а:**
Прогнал тесты, собрал "обычную" версию сервиса и WASM версию, попрашивал устройства, убедился, что PDU извлекается корректно.