### PR TITLE
fix fader_dec_rgb address

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.192.2) stable; urgency=medium
+
+  * fix WB-LED fade dec RGB regs
+
+ -- Nikita Kulikov <n.kulikov@wirenboard.com>  Wed, 08 Oct 2025 12:46:12 +0300
+
 wb-mqtt-serial (2.192.1) stable; urgency=medium
 
   * Fix TModbusRTUWithArbitrationTraits::Transaction method

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -512,7 +512,7 @@
                 "group": "gg_fader_{{inc_dec}}",
                 "title": "RGB Strip {{title}}",
                 "order": {{order[loop.index0]}},
-                "address": {{3012 + loop.index0}},
+                "address": {{3012 + loop.index0 + ptr}},
                 "reg_type": "holding",
                 "default": 1000,
                 "min": 0,


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!
-->
___________________________________
**Что происходит; кому и зачем нужно:**

исправлен расчет адресов регистров скорости затухания RGB ленты
https://wirenboard.youtrack.cloud/issue/FW-1142/Oshibka-parametra-vremya-umensheniya-yarkosti-WB-LED-v-rezhime-RGBW

___________________________________
**Что поменялось для пользователей:**
заработало правильно

___________________________________
**Как проверял/а:**
глазами адреса в сгенерированом json посмотрел