### PR TITLE
Fix default config generation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.232.2) stable; urgency=medium
 
-  * Move default config generation to wb-configs-early
+  * Fix default config generation during first boot
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 24 Mar 2026 18:15:02 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.232.2) stable; urgency=medium
+
+  * Move default config generation to wb-configs-early
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 24 Mar 2026 18:15:02 +0300
+
 wb-mqtt-serial (2.232.1) stable; urgency=medium
 
   * Fix build with gcc14

--- a/debian/wb-mqtt-serial.wb-mqtt-serial.service
+++ b/debian/wb-mqtt-serial.wb-mqtt-serial.service
@@ -9,7 +9,6 @@ Restart=on-failure
 RestartSec=1
 User=root
 ExecStart=/usr/bin/wb-mqtt-serial
-ExecStartPre=/usr/lib/wb-mqtt-serial/generate-system-config.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/wb-mqtt-serial.wbconfigs
+++ b/wb-mqtt-serial.wbconfigs
@@ -1,2 +1,3 @@
+/usr/lib/wb-mqtt-serial/generate-system-config.sh
 wb_move /etc/wb-mqtt-serial.conf
 wb_move /etc/wb-mqtt-serial.conf.d


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

Из за того, что переместили генерацию конфига из пост-инсталл скрипта на старт сервиса, получается, что при первом запуске wb-configs-early не может сделать симлинк, так как конфига еще не существует. В других сервисах (где не сделана та же схема), конфиги раскладываются на этапе сборки рутфс и при первом запуске все симлинки на месте
Жалоб от юзеров особо не было, но проявилось в виде бага в пакете демо-чемодана: после его установки чемоданные конфиги не подхватываются до первого ребута, так как конфигс не сделал симлинки.

https://github.com/wirenboard/wb-mqtt-serial/pull/1000
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
локально сделала фит, проверила