### PR TITLE
Fix firmware version read modbus exception bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.224.0-wb100) stable; urgency=medium
+
+  * Fix firmware version read modbus exception bug
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 31 Mar 2026 11:10:23 +0300
+
 wb-mqtt-serial (2.224.0) stable; urgency=medium
 
   * Use read only configuration parameters for Device/LoadConfig RPC parameter conditions
@@ -9,7 +15,7 @@ wb-mqtt-serial (2.223.0) stable; urgency=medium
   * Add template for Ventmachine Colibri 650 GTC
 
  -- Aleksey Golovchenko <Aleksey.golovchenko@wirenboard.com>  Thu, 05 Feb 2026 18:00:00 +0300
- 
+
 wb-mqtt-serial (2.222.3) stable; urgency=medium
 
   * Fix 64-bit integers precision bug for Device/Load and Device/LoadConfig RPC

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1021,9 +1021,9 @@ namespace Modbus // modbus protocol common utilities
                                               device->GetResponseTimeout(port),
                                               device->GetFrameTimeout(port));
             return value.Get<std::string>();
-        } catch (const TSerialDevicePermanentRegisterException& e) {
-            LOG(Warn) << "Unable to read WB device firmware version [slave_id is "
-                      << device->DeviceConfig()->SlaveId + "]";
+        } catch (const std::runtime_error& e) {
+            LOG(Debug) << "Unable to read WB device firmware version [slave_id is "
+                       << device->DeviceConfig()->SlaveId + "]: " << e.what();
         }
         return std::string();
     }


### PR DESCRIPTION
_____________________
**Что происходит; кому и зачем нужно:**
Бэкпорт фикса в stable, оригинальный PR: https://github.com/wirenboard/wb-mqtt-serial/pull/1112

___________________________________
**Что поменялось для пользователей:**
...

___________________________________
**Как проверял/а:**
Прогнал тесты, запустил на контроллере, убедился, что ничего не взорвалось.