### PR TITLE
Set value to "unsupported" for registers with read error in device/Lo…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.232.5) stable; urgency=medium
+
+  * Set value to "unsupported" for registers with read error in device/LoadConfig and device/Load RPC
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 08 Apr 2026 12:30:00 +0300
+
 wb-mqtt-serial (2.232.4) stable; urgency=medium
 
   * Fix emscripten macros for WASM module build, no functional changes

--- a/src/rpc/rpc_device_load_config_task.cpp
+++ b/src/rpc/rpc_device_load_config_task.cpp
@@ -214,9 +214,10 @@ void GetRegisterListParameters(const TRPCRegisterList& registerList, Json::Value
                 continue;
             }
             if (!parameters.isMember(item.Id) && CheckCondition(item.Condition, jsonParams, &expressionsCache)) {
-                parameters[item.Id] = item.Register->IsSupported()
-                                          ? RawValueToJSON(*item.Register->GetConfig(), item.Register->GetValue())
-                                          : UNSUPPORTED_VALUE;
+                parameters[item.Id] =
+                    (item.Register->IsSupported() && !item.Register->GetErrorState().test(TRegister::TError::ReadError))
+                        ? RawValueToJSON(*item.Register->GetConfig(), item.Register->GetValue())
+                        : UNSUPPORTED_VALUE;
                 check = true;
             }
         }

--- a/src/rpc/rpc_device_load_task.cpp
+++ b/src/rpc/rpc_device_load_task.cpp
@@ -13,9 +13,10 @@ namespace
     {
         ReadRegisterList(*port, rpcRequest->Device, registerList);
         for (const auto& item: registerList) {
-            data[item.Id] = item.Register->IsSupported()
-                                ? RawValueToJSON(*item.Register->GetConfig(), item.Register->GetValue())
-                                : UNSUPPORTED_VALUE;
+            data[item.Id] =
+                (item.Register->IsSupported() && !item.Register->GetErrorState().test(TRegister::TError::ReadError))
+                    ? RawValueToJSON(*item.Register->GetConfig(), item.Register->GetValue())
+                    : UNSUPPORTED_VALUE;
             if (item.Register->GetConfig()->AccessType == TRegisterConfig::EAccessType::READ_ONLY) {
                 readonlyList.append(item.Id);
             }


### PR DESCRIPTION
________________________
**Что происходит; кому и зачем нужно:**
При штатной работе wb-mqtt-serial выставляет флаг ошибки чтения для регистров, прочитанное значение которых совпало со значением `error_value` в шаблоне. В случае же, когда это происходит в веб-конфигураторе, данная ситуация никак не обрабатывается и на странице "мониторинга" отображается некорректное значение.

___________________________________
**Что поменялось для пользователей:**
Теперь, если у регистра выставлен флаг ошибки чтения, в ответе на RPC запрос его значение меняется на "unsupported", фронт конфигуратора уже умеет это обрабатывать.

___________________________________
**Как проверял/а:**
Прогнал тесты, обновил самбмодуль в конфигураторе, проверил что теперь все работает правильно.