### PR TITLE
Fix WB-LED template (missing translations)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.232.6) stable; urgency=medium
+
+  * Fix WB-LED template: add missing translations
+
+ -- Maxim Toropov <maxim.toropov@wirenboard.com>  Thu, 09 Apr 2026 16:57:00 +0300
+
 wb-mqtt-serial (2.232.5) stable; urgency=medium
 
   * Set value to "unsupported" for registers with read error in device/LoadConfig and device/Load RPC

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -1651,7 +1651,20 @@
                 "g_safety_description": "Safety mode is activated when there is no modbus polling for the specified time",
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
-                "g_power_up_behaviour_description" : "Setting the behavior of outputs when the device is powered on"
+                "g_power_up_behaviour_description" : "Setting the behavior of outputs when the device is powered on",
+
+                "switch_action": "Switch action",
+                "sw_all_act_title": "All channels",
+                "sw_ch1_act_title": "Channel 1",
+                "sw_ch2_act_title": "Channel 2",
+                "sw_ch3_act_title": "Channel 3",
+                "sw_ch4_act_title": "Channel 4",
+                "sw_ch12_act_title": "Channel 1_2",
+                "sw_ch34_act_title": "Channel 3_4",
+                "sw_ch1234_act_title": "Channel 1_2_3_4",
+                "sw_cct1_act_title": "CCT1 Strip",
+                "sw_cct2_act_title": "CCT2 Strip",
+                "sw_rgb_act_title": "RGB Strip"
             },
             "ru": {
                 "WB-LED_template_title": "WB-LED (4-канальный диммер светодиодных лент)",
@@ -1920,6 +1933,11 @@
                 "Action Saturation" : "Действие с насыщенностью",
                 "Action Brightness" : "Действие с яркостью",
                 "Action Temperature" : "Действие с температурой",
+
+                "Channel 1_2 Brightness": "Яркость каналов 1_2",
+                "Channel 3_4 Brightness": "Яркость каналов 3_4",
+                "Channel 1_2_3_4 Brightness": "Яркость каналов 1_2_3_4",
+                "Channel 1_2_3_4": "Каналы 1_2_3_4",
 
                 "Disabled": "Отключено",
                 "Enabled": "Включено"


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Исправлен шаблон WB-LED - добавлены отсутствующие переводы

___________________________________
**Что поменялось для пользователей:**
Добавлены отсутствующие переводы - человеческие строки вместо псевдонимов

___________________________________
**Как проверял/а:**
Локально, смотрел, чтобы не было ошибок в логах mqtt-serial, чтобы все переводы были на местах