### PR TITLE
Feature/wb mcm8 templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.233.0) stable; urgency=medium
+
+  * Add WB-MCM8-HV template
+  * WB-MCM8 template: add bit mask of input states channel
+
+ -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Sat, 11 Apr 2026 16:57:00 +0300
+
 wb-mqtt-serial (2.232.6) stable; urgency=medium
 
   * Fix WB-LED template: add missing translations

--- a/templates/config-wb-mcm8-hv.json.jinja
+++ b/templates/config-wb-mcm8-hv.json.jinja
@@ -24,7 +24,6 @@
         "id": "{{ device_id }}",
         "max_read_registers": 0,
         "response_timeout_ms": 1,
-        "frame_timeout_ms": 8,
         "enable_wb_continuous_read": true,
 
         "groups": [

--- a/templates/config-wb-mcm8-hv.json.jinja
+++ b/templates/config-wb-mcm8-hv.json.jinja
@@ -1,0 +1,234 @@
+{% set title_en = title_en | default("WB-MCM8-HV (8 discrete 230V AC voltage presence detection inputs)") -%}
+{% set title_ru = title_ru | default("WB-MCM8-HV (8-канальный модуль-детектор наличия сетевого напряжения 230 В)") -%}
+{% set device_type = device_type | default("WB-MCM8-HV") -%}
+{% set group = group | default("g-wb") -%}
+{% set device_name = device_name | default("WB-MCM8-HV") -%}
+{% set device_id = device_id | default("wb-mcm8-hv") -%}
+{% set has_signature = has_signature | default(true) -%}
+
+{% set INPUTS_NUMBER = 8 -%}
+{% set FIRST_INPUT = 1 -%}
+{
+    "title": "template_title",
+    "device_type": "{{ device_type }}",
+    "group": "{{ group }}",
+{% if has_signature %}
+    "hw": [
+        {
+            "signature": "WB-MCM8-HV"
+        }
+    ],
+{% endif %}
+    "device": {
+        "name": "{{ device_name }}",
+        "id": "{{ device_id }}",
+        "max_read_registers": 0,
+        "response_timeout_ms": 1,
+        "frame_timeout_ms": 8,
+        "enable_wb_continuous_read": true,
+
+        "groups": [
+            {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
+            {
+                "title": "Input {{in_num}}",
+                "id": "g_in{{in_num}}"
+            },
+            {
+                "title": "input{{in_num}}_channels",
+                "id": "gg_in{{in_num}}_channels",
+                "group": "g_in{{in_num}}",
+                "ui_options": {
+                    "wb": {
+                        "disable_title": true
+                    }
+                }
+            },
+            {% endfor -%}
+            {
+                "title": "General",
+                "id": "g_general"
+            },
+            {
+                "title": "HW Info",
+                "id": "g_hw_info"
+            }
+        ],
+
+        "parameters": {
+            {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
+            "in{{in_num}}_debounce_ms": {
+                "title": "debounce_time_title",
+                "address": {{20 + in_num - 1}},
+                "reg_type": "holding",
+                "min": 0,
+                "max": 2000,
+                "default": 50,
+                "group": "g_in{{in_num}}",
+                "order": 2
+            },
+            {% endfor -%}
+            "baud_rate": {
+                "title": "Baud rate",
+                "description": "baud_rate_description",
+                "address": 110,
+                "reg_type": "holding",
+                "enum": [96, 192, 384, 576, 1152],
+                "default": 96,
+                "enum_titles": [
+                    "9600",
+                    "19200",
+                    "38400",
+                    "57600",
+                    "115200"
+                ],
+                "group": "g_general",
+                "order": 1
+            }
+        },
+
+        "channels": [
+            {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
+            {
+                "name": "Input {{in_num}}",
+                "reg_type": "discrete",
+                "address": {{in_num - 1}},
+                "type": "switch",
+                "sporadic": true,
+                "group": "gg_in{{in_num}}_channels"
+            },
+            {
+                "name": "Input {{in_num}} counter",
+                "reg_type": "input",
+                "format": "u32",
+                "address": {{60 + (in_num - 1) * 2}},
+                "type": "value",
+                "sporadic": true,
+                "group": "gg_in{{in_num}}_channels"
+            },
+            {% endfor -%}
+            {
+                "name": "Bit mask of input states",
+                "reg_type": "input",
+                "address": 8,
+                "group": "g_general",
+                "sporadic": true,
+                "enabled": false
+            },
+            {
+                "name": "Reset all counters",
+                "reg_type": "holding",
+                "address": 100,
+                "type": "pushbutton",
+                "group": "g_general"
+            },
+            {
+                "name": "Serial",
+                "reg_type": "input",
+                "address": 270,
+                "type": "text",
+                "format": "u32",
+                "group": "g_hw_info"
+            },
+            {
+                "name": "HW Batch Number",
+                "type": "text",
+                "reg_type": "input",
+                "address": 304,
+                "format": "string",
+                "string_data_size": 16,
+                "fw": "1.8.0",
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "FW Version",
+                "reg_type": "input",
+                "address": 250,
+                "type": "text",
+                "format": "string",
+                "string_data_size": 16,
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "Supply voltage",
+                "reg_type": "input",
+                "address": 121,
+                "type": "voltage",
+                "scale": 0.001,
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "Uptime",
+                "reg_type": "input",
+                "address": 104,
+                "format": "u32",
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "Minimum Voltage Since Startup",
+                "reg_type": "input",
+                "address": 122,
+                "scale": 0.001,
+                "type": "voltage",
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "MCU Temperature",
+                "reg_type": "input",
+                "address": 124,
+                "type": "temperature",
+                "format": "s16",
+                "scale": 0.1,
+                "enabled": false,
+                "group": "g_hw_info"
+            },
+            {
+                "name": "MCU Voltage",
+                "reg_type": "input",
+                "address": 123,
+                "scale": 0.001,
+                "type": "voltage",
+                "enabled": false,
+                "group": "g_hw_info"
+            }
+        ],
+        "translations": {
+            "en": {
+                "template_title": "{{ title_en }}",
+                "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
+                "Uptime": "Uptime (s)",
+
+                "debounce_time_title": "Debounce Time (ms)"
+            },
+            "ru": {
+                "template_title": "{{ title_ru }}",
+                {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
+                "Input {{in_num}}": "Вход {{in_num}}",
+                "Input {{in_num}} counter": "Счетчик {{in_num}}",
+                {% endfor -%}
+
+                "General": "Общее",
+                "HW Info": "Данные модуля",
+                "Baud rate": "Скорость обмена",
+                "baud_rate_description": "Перед изменением параметра убедитесь, что связь с устройством установлена. Выберите нужную скорость обмена, сохраните конфигурацию, а затем укажите в настройках порта эту же скорость.",
+
+                "debounce_time_title": "Время подавления дребезга (мс)",
+                "Bit mask of input states": "Битовая маска состояний входов",
+                "Reset all counters": "Сбросить все счетчики",
+                "Serial": "Серийный номер",
+                "HW Batch Number": "Номер партии",
+                "FW Version": "Версия прошивки",
+                "Supply voltage": "Напряжение питания",
+                "Uptime": "Время работы с момента включения (с)",
+                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "MCU Temperature": "Температура МК",
+                "MCU Voltage": "Напряжение питания МК"
+            }
+        }
+    }
+}
+

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -310,6 +310,15 @@
                 "condition": "encoder_3_mode==1"
             },
             {
+                "name": "Bit mask of input states",
+                "reg_type": "input",
+                "address": 8,
+                "group": "g_general",
+                "sporadic": true,
+                "fw": "1.9.0",
+                "enabled": false
+            },
+            {
                 "name": "Reset all counters",
                 "reg_type": "holding",
                 "address": 100,
@@ -438,6 +447,7 @@
                 "lp_hold_time_description": "Если нажатие длится больше указанного времени - считаем его длинным",
                 "secp_waiting_time_description": "Если за указанное время второго нажатия не было - считаем нажатие одиночным. 0 - отключит все нажатия кроме короткого и длинного. Вносит задержку в реакцию на короткое нажатие",
                 "debounce_time_description": "Для детектирования нажатий значение должно быть в 5-10 раз меньше, чем время ожидания второго нажатия. Вносит задержку в реакцию на нажатия",
+                "Bit mask of input states": "Битовая маска состояний входов",
                 "Reset all counters": "Сбросить все счетчики",
                 "Serial": "Серийный номер",
                 "HW Batch Number": "Номер партии",

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -8,6 +8,7 @@
 
 {% set INPUTS_NUMBER = 8 -%}
 {% set FIRST_INPUT = 1 -%}
+{% set NO_SPORADIC_MODE = 0 -%}
 {
     "title": "template_title",
     "device_type": "{{ device_type }}",
@@ -195,7 +196,6 @@
 
         "channels": [
             {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
-            {% set NO_SPORADIC_MODE = 0 -%}
             {% for s_en, s_cond in [
                 ("false", "isDefined(in"~in_num~"_mode)==0||in"~in_num~"_mode=="~NO_SPORADIC_MODE),
                 ("true", "isDefined(in"~in_num~"_mode)&&in"~in_num~"_mode!="~NO_SPORADIC_MODE),
@@ -309,15 +309,27 @@
                 "group": "gg_encoder_channels",
                 "condition": "encoder_3_mode==1"
             },
+            {% set all_sporadic_cond = [] -%}
+            {% set any_no_sporadic_cond = [] -%}
+            {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
+                {% set _ = all_sporadic_cond.append("isDefined(in" ~ in_num ~ "_mode)&&in" ~ in_num ~ "_mode!=" ~ NO_SPORADIC_MODE) -%}
+                {% set _ = any_no_sporadic_cond.append("isDefined(in" ~ in_num ~ "_mode)==0||in" ~ in_num ~ "_mode==" ~ NO_SPORADIC_MODE) -%}
+            {% endfor -%}
+            {% for s_en, s_cond in [
+                ("false", any_no_sporadic_cond | join("||")),
+                ("true", all_sporadic_cond | join("&&")),
+            ] -%}
             {
                 "name": "Bit mask of input states",
                 "reg_type": "input",
                 "address": 8,
                 "group": "g_general",
-                "sporadic": true,
+                "sporadic": {{s_en}},
+                "condition": "{{s_cond}}",
                 "fw": "1.9.0",
                 "enabled": false
             },
+            {% endfor -%}
             {
                 "name": "Reset all counters",
                 "reg_type": "holding",

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -23761,6 +23761,7 @@ WB-MCM16
 	Serial NO  =>  Serial NO
 	Uptime  =>  Uptime
 WB-MCM8
+	Bit mask of input states  =>  Bit mask of input states
 	Encoder 1 angle  =>  Encoder 1 angle
 	Encoder 1 position  =>  Encoder 1 position
 	Encoder 1 revolutions  =>  Encoder 1 revolutions
@@ -23826,6 +23827,33 @@ WB-MCM8
 	Input 8 Single Press Counter  =>  Input 8 Single Press Counter
 	Input 8 counter  =>  Input 8 counter
 	Input 8 freq  =>  Input 8 freq
+	MCU Temperature  =>  MCU Temperature
+	MCU Voltage  =>  MCU Voltage
+	Minimum Voltage Since Startup  =>  Minimum Voltage Since Startup
+	Reset all counters  =>  Reset all counters
+	Serial  =>  Serial
+	Supply voltage  =>  Supply voltage
+	Uptime  =>  Uptime
+WB-MCM8-HV
+	Bit mask of input states  =>  Bit mask of input states
+	FW Version  =>  FW Version
+	HW Batch Number  =>  HW Batch Number
+	Input 1  =>  Input 1
+	Input 1 counter  =>  Input 1 counter
+	Input 2  =>  Input 2
+	Input 2 counter  =>  Input 2 counter
+	Input 3  =>  Input 3
+	Input 3 counter  =>  Input 3 counter
+	Input 4  =>  Input 4
+	Input 4 counter  =>  Input 4 counter
+	Input 5  =>  Input 5
+	Input 5 counter  =>  Input 5 counter
+	Input 6  =>  Input 6
+	Input 6 counter  =>  Input 6 counter
+	Input 7  =>  Input 7
+	Input 7 counter  =>  Input 7 counter
+	Input 8  =>  Input 8
+	Input 8 counter  =>  Input 8 counter
 	MCU Temperature  =>  MCU Temperature
 	MCU Voltage  =>  MCU Voltage
 	Minimum Voltage Since Startup  =>  Minimum Voltage Since Startup
@@ -29075,6 +29103,7 @@ tpl1_dauerhaft_roll_35_45
 	Move up  =>  Move up
 	Stop  =>  Stop
 tpl1_oni_plc_w_acs_0800_imp
+	Bit mask of input states  =>  Bit mask of input states
 	Encoder 1 angle  =>  Encoder 1 angle
 	Encoder 1 position  =>  Encoder 1 position
 	Encoder 1 revolutions  =>  Encoder 1 revolutions


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Добавили шаблон для WB-MCM8-HV; в шаблон для WB-MCM8 добавили канал Bit mask of input states; нужно как разработчикам, так и пользователям

___________________________________
**Что поменялось для пользователей:**
Появилась возможность считывать маску состояний входов для WB-MCM8, добавилась поддержка WB-MCM8-HV

___________________________________
**Как проверял/а:**
стендом на столе: WB8 + WB-MCM8-HV + WB-MCM8