### PR TITLE
Add "w1-id" control type, fix second stop bit transactions collision …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-serial (2.224.0-wb103) stable; urgency=medium
+
+  * Add "w1-id" control type
+  * Fix second stop bit transactions collision bug
+  * Fix device RPC common device settings bug
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 17 Feb 2026 10:53:23 +0300
+
 wb-mqtt-serial (2.224.0-wb102) stable; urgency=medium
 
   * Fix minimum and maximum values setup in WB-MAI11 template

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -1022,8 +1022,8 @@ namespace Modbus // modbus protocol common utilities
                                               device->GetFrameTimeout(port));
             return value.Get<std::string>();
         } catch (const std::runtime_error& e) {
-            LOG(Debug) << "Unable to read WB device firmware version [slave_id is "
-                       << device->DeviceConfig()->SlaveId + "]: " << e.what();
+            LOG(Warn) << "Unable to read WB device firmware version [slave_id is "
+                      << device->DeviceConfig()->SlaveId + "]: " << e.what();
         }
         return std::string();
     }

--- a/src/port/serial_port.cpp
+++ b/src/port/serial_port.cpp
@@ -231,7 +231,9 @@ std::chrono::microseconds TSerialPort::GetSendTimeBits(size_t bitsNumber) const
 
 uint8_t TSerialPort::ReadByte(const std::chrono::microseconds& timeout)
 {
-    return Base::ReadByte(CalcResponseTimeout(timeout) + GetLinuxLag(Settings.BaudRate) + GetSendTimeBytes(1));
+    auto res = Base::ReadByte(CalcResponseTimeout(timeout) + GetLinuxLag(Settings.BaudRate) + GetSendTimeBytes(1));
+    WaitForSecondStopBit();
+    return res;
 }
 
 TReadFrameResult TSerialPort::ReadFrame(uint8_t* buf,
@@ -240,12 +242,14 @@ TReadFrameResult TSerialPort::ReadFrame(uint8_t* buf,
                                         const std::chrono::microseconds& frameTimeout,
                                         TFrameCompletePred frameComplete)
 {
-    return Base::ReadFrame(buf,
-                           count,
-                           CalcResponseTimeout(responseTimeout) + GetLinuxLag(Settings.BaudRate) +
-                               GetSendTimeBytes(RxTrigBytes),
-                           frameTimeout + std::chrono::milliseconds(15) + GetSendTimeBytes(RxTrigBytes),
-                           frameComplete);
+    auto res = Base::ReadFrame(buf,
+                               count,
+                               CalcResponseTimeout(responseTimeout) + GetLinuxLag(Settings.BaudRate) +
+                                   GetSendTimeBytes(RxTrigBytes),
+                               frameTimeout + std::chrono::milliseconds(15) + GetSendTimeBytes(RxTrigBytes),
+                               frameComplete);
+    WaitForSecondStopBit();
+    return res;
 }
 
 void TSerialPort::WriteBytes(const uint8_t* buf, int count)
@@ -266,6 +270,16 @@ std::string TSerialPort::GetDescription(bool verbose) const
 const TSerialPortSettings& TSerialPort::GetSettings() const
 {
     return Settings;
+}
+
+void TSerialPort::WaitForSecondStopBit()
+{
+    // receiver triggers on the first stop bit, but transmitter may still be sending second stop bit
+    // wait 1 bit time to avoid bus collision issues
+    std::this_thread::sleep_for(GetSendTimeBits(1));
+
+    // update last interaction time after waiting
+    LastInteraction = std::chrono::steady_clock::now();
 }
 
 TSerialPortSettingsGuard::TSerialPortSettingsGuard(PPort port, const TSerialPortConnectionSettings& settings)

--- a/src/port/serial_port.h
+++ b/src/port/serial_port.h
@@ -41,6 +41,8 @@ private:
     TSerialPortConnectionSettings InitialSettings;
     termios OldTermios;
     size_t RxTrigBytes;
+
+    void WaitForSecondStopBit();
 };
 
 using PSerialPort = std::shared_ptr<TSerialPort>;

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -65,14 +65,11 @@ TRPCDeviceHelper::TRPCDeviceHelper(const Json::Value& request,
         }
         ProtocolParams = deviceFactory.GetProtocolParams(protocolName);
         auto config = std::make_shared<TDeviceConfig>("RPC Device", request["slave_id"].asString(), protocolName);
-        if (ProtocolParams.protocol->IsModbus()) {
-            config->MaxRegHole = Modbus::MAX_HOLE_CONTINUOUS_16_BIT_REGISTERS;
-            config->MaxBitHole = Modbus::MAX_HOLE_CONTINUOUS_1_BIT_REGISTERS;
-            config->MaxReadRegisters = Modbus::MAX_READ_REGISTERS;
-        }
+        bool isWbDevice = !DeviceTemplate->GetHardware().empty() ||
+                          DeviceTemplate->GetTemplate()["enable_wb_continuous_read"].asBool();
+        LoadCommonDeviceParameters(*config, DeviceTemplate->GetTemplate(), isWbDevice);
         Device = ProtocolParams.factory->CreateDevice(DeviceTemplate->GetTemplate(), config, ProtocolParams.protocol);
-        Device->SetWbDevice(!DeviceTemplate->GetHardware().empty() ||
-                            DeviceTemplate->GetTemplate()["enable_wb_continuous_read"].asBool());
+        Device->SetWbDevice(isWbDevice);
     } else {
         Device = params.Device;
         DeviceTemplate = templates->GetTemplate(Device->DeviceConfig()->DeviceType);

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -532,43 +532,6 @@ namespace
         }
     }
 
-    void LoadCommonDeviceParameters(TDeviceConfig& device_config, const Json::Value& device_data, bool isWbDevice)
-    {
-        if (device_data.isMember("password")) {
-            device_config.Password.clear();
-            for (const auto& passwordItem: device_data["password"]) {
-                device_config.Password.push_back(static_cast<uint8_t>(ToUint64(passwordItem, "password item")));
-            }
-        }
-
-        if (device_data.isMember("delay_ms")) {
-            LOG(Warn) << "\"delay_ms\" is not supported, use \"frame_timeout_ms\" instead";
-        }
-
-        if (isWbDevice) {
-            device_config.MaxWriteRegisters = Modbus::MAX_WRITE_REGISTERS;
-        }
-
-        Get(device_data, "frame_timeout_ms", device_config.FrameTimeout);
-        if (device_config.FrameTimeout.count() < 0) {
-            device_config.FrameTimeout = DefaultFrameTimeout;
-        }
-        Get(device_data, "response_timeout_ms", device_config.ResponseTimeout);
-        Get(device_data, "device_timeout_ms", device_config.DeviceTimeout);
-        Get(device_data, "device_max_fail_cycles", device_config.DeviceMaxFailCycles);
-        Get(device_data, "max_write_fail_time_s", device_config.MaxWriteFailTime);
-        Get(device_data, "max_reg_hole", device_config.MaxRegHole);
-        Get(device_data, "max_bit_hole", device_config.MaxBitHole);
-        Get(device_data, "max_read_registers", device_config.MaxReadRegisters);
-        Get(device_data, "min_read_registers", device_config.MinReadRegisters);
-        Get(device_data, "max_write_registers", device_config.MaxWriteRegisters);
-        Get(device_data, "guard_interval_us", device_config.RequestDelay);
-        Get(device_data, "stride", device_config.Stride);
-        Get(device_data, "shift", device_config.Shift);
-        Get(device_data, "access_level", device_config.AccessLevel);
-        Get(device_data, "min_request_interval", device_config.MinRequestInterval);
-    }
-
     void LoadDevice(PPortConfig port_config,
                     const Json::Value& device_data,
                     const std::string& default_id,
@@ -1041,6 +1004,43 @@ const std::string& IDeviceFactory::GetCustomChannelSchemaRef() const
 const IRegisterAddressFactory& IDeviceFactory::GetRegisterAddressFactory() const
 {
     return *RegisterAddressFactory;
+}
+
+void LoadCommonDeviceParameters(TDeviceConfig& device_config, const Json::Value& device_data, bool isWbDevice)
+{
+    if (device_data.isMember("password")) {
+        device_config.Password.clear();
+        for (const auto& passwordItem: device_data["password"]) {
+            device_config.Password.push_back(static_cast<uint8_t>(ToUint64(passwordItem, "password item")));
+        }
+    }
+
+    if (device_data.isMember("delay_ms")) {
+        LOG(Warn) << "\"delay_ms\" is not supported, use \"frame_timeout_ms\" instead";
+    }
+
+    if (isWbDevice) {
+        device_config.MaxWriteRegisters = Modbus::MAX_WRITE_REGISTERS;
+    }
+
+    Get(device_data, "frame_timeout_ms", device_config.FrameTimeout);
+    if (device_config.FrameTimeout.count() < 0) {
+        device_config.FrameTimeout = DefaultFrameTimeout;
+    }
+    Get(device_data, "response_timeout_ms", device_config.ResponseTimeout);
+    Get(device_data, "device_timeout_ms", device_config.DeviceTimeout);
+    Get(device_data, "device_max_fail_cycles", device_config.DeviceMaxFailCycles);
+    Get(device_data, "max_write_fail_time_s", device_config.MaxWriteFailTime);
+    Get(device_data, "max_reg_hole", device_config.MaxRegHole);
+    Get(device_data, "max_bit_hole", device_config.MaxBitHole);
+    Get(device_data, "max_read_registers", device_config.MaxReadRegisters);
+    Get(device_data, "min_read_registers", device_config.MinReadRegisters);
+    Get(device_data, "max_write_registers", device_config.MaxWriteRegisters);
+    Get(device_data, "guard_interval_us", device_config.RequestDelay);
+    Get(device_data, "stride", device_config.Stride);
+    Get(device_data, "shift", device_config.Shift);
+    Get(device_data, "access_level", device_config.AccessLevel);
+    Get(device_data, "min_request_interval", device_config.MinRequestInterval);
 }
 
 PDeviceConfig LoadDeviceConfig(const Json::Value& dev,

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -167,6 +167,8 @@ struct TDeviceProtocolParams
     std::shared_ptr<IDeviceFactory> factory;
 };
 
+void LoadCommonDeviceParameters(TDeviceConfig& device_config, const Json::Value& device_data, bool isWbDevice);
+
 PDeviceConfig LoadDeviceConfig(const Json::Value& dev,
                                PProtocol protocol,
                                const TDeviceConfigLoadParams& parameters,

--- a/wb-mqtt-serial-confed-common.schema.json
+++ b/wb-mqtt-serial-confed-common.schema.json
@@ -721,7 +721,7 @@
       "title": "Control type",
       "enum": [
         "switch", "wo-switch", "pushbutton", "range", "rgb", "text",
-        "value", "temperature", "rel_humidity",
+        "w1-id", "value", "temperature", "rel_humidity",
         "atmospheric_pressure", "rainfall", "wind_speed", "power",
         "power_consumption", "voltage", "water_flow",
         "water_consumption", "resistance", "concentration",
@@ -736,6 +736,7 @@
           "range",
           "rgb",
           "text",
+          "1-wire device identifier",
           "value",
           "temperature (deprecated, use value with units)",
           "rel_humidity (deprecated, use value with units)",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Бэкпорт нового типа контролов (w1-id) и фикса проблемы с двумя стопбитами в stable:
1 - https://github.com/wirenboard/wb-mqtt-serial/pull/1082 
2 - https://github.com/wirenboard/wb-mqtt-serial/pull/1136

___________________________________
**Что поменялось для пользователей:**
...

___________________________________
**Как проверял/а:**
Прогнал тесты, проверил на железе.