### PR TITLE
Fix WB-MWAC v.2 time sync

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-serial (2.240.2) stable; urgency=medium
+
+  * Fix WB-MWAC v.2 time sync.
+    WB-MWAC does not have timezone information. 
+    To reflect the actual local time in the device, the time is sent as UTC time with local time values.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 29 Apr 2026 21:06:12 +0500
+
 wb-mqtt-serial (2.240.1) stable; urgency=medium
 
   * Remove WB-M1W2 multiple w1 template

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -152,11 +152,15 @@ void TModbusDevice::SyncMWACTime(TPort& port)
         if (std::chrono::duration_cast<std::chrono::hours>(now - LastMWACTimeSync).count() > 24) {
             auto config = WbRegisters::GetRegisterConfig(WbRegisters::MWAC_UNIXTIME_REGISTER_NAME);
             try {
+                const auto nowTimeT = std::chrono::system_clock::to_time_t(now);
+                std::tm localTm{};
+                localtime_r(&nowTimeT, &localTm);
+                const auto deviceTime = timegm(&localTm);
                 Modbus::WriteRegister(*ModbusTraits,
                                       port,
                                       SlaveId,
                                       *config,
-                                      TRegisterValue(std::chrono::system_clock::to_time_t(now)),
+                                      TRegisterValue(deviceTime),
                                       ModbusCache,
                                       DeviceConfig()->RequestDelay,
                                       GetResponseTimeout(port),


### PR DESCRIPTION
WB-MWAC does not have timezone information. To reflect the actual local time in the device, the time is sent as UTC time with local time values.

___________________________________
**Что происходит; кому и зачем нужно:**
Сохраняем время в WB-MWAC в хитром виде. Берём год, месяц, день, час, минуты, секунды в локальном часовом поясе и превращаем их в unixtime, будто у нас UTC. В WB-MWAC нет реализации часовых поясов, но есть расписание, которое должно работать в локальном часовом поясе. Отсюда такие пляски.

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
