### PR TITLE
Add MDM3 PLL status templates

### DIFF
--- a/templates/config-wb-mdm3-fw-2.12.json.jinja
+++ b/templates/config-wb-mdm3-fw-2.12.json.jinja
@@ -691,7 +691,12 @@
                 "name": "AC on L-N",
                 "reg_type": "input",
                 "address": 97,
-                "type": "switch",
+                "enum": [0, 1, 2],
+                "enum_titles": [
+                    "No voltage",
+                    "Voltage stable",
+                    "Voltage unstable"
+                ],
                 "group": "gg_general_channels"
             },
             {
@@ -856,6 +861,9 @@
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "AC on L-N": "Напряжение на клеммах L-N",
+                "No voltage": "Нет напряжения",
+                "Voltage stable": "Напряжение стабильно",
+                "Voltage unstable": "Напряжение нестабильно",
                 "Overcurrent": "Перегрузка по току",
                 "Channel 1 Raw Duty (us)": "Сырое задание для канала 1 (мкс)",
                 "Channel 2 Raw Duty (us)": "Сырое задание для канала 2 (мкс)",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

Для WB-MDM3 добавляется человекочитаемый статус ФАПЧ/наличия напряжения на L-N из регистра 97.

В шаблоне `WB-MDM3-since-fw-2.12` старый канал был `switch`, из-за чего значение 2 ("напряжение нестабильно") не отображалось как отдельное состояние. Теперь канал использует enum:
0 - нет напряжения
1 - напряжение стабильно
2 - напряжение нестабильно

___________________________________
**Что поменялось для пользователей:**

В шаблоне WB-MDM3 для прошивки 2.12 состояние напряжения L-N будет отображаться тремя понятными состояниями вместо boolean-канала.

___________________________________
**Как проверял/а:**

`make dump-templates`

`python3 -m json.tool build/templates/config-wb-mdm3-fw-2.12.json >/dev/null`

Schema validation для сгенерированного `config-wb-mdm3-fw-2.12.json`.

Проверено на стенде разработчика: новый шаблон применился, канал `AC on L-N` стал `value`, в meta появились enum 0/1/2 с ru/en переводами.
