### PR TITLE
Fix unexpected publishes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.242.6) stable; urgency=medium
+
+  * Fix unexpected channel publishes if a device has only sporadic channels
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 04 May 2026 19:48:06 +0500
+
 wb-mqtt-serial (2.242.5) stable; urgency=medium
 
   * Rename WB-MCM8-HV to WB-MCM8HV

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -148,7 +148,8 @@ void TSerialPortDriver::OnValueRead(PRegister reg)
         // and pushbutton channels (always publish value "1")
         auto publishPolicy = PublishPolicy;
         if ((reg->GetConfig()->SporadicMode == TRegisterConfig::TSporadicMode::ONLY_EVENTS &&
-             reg->IsExcludedFromPolling()) || it->second->Type == "pushbutton")
+             reg->IsExcludedFromPolling()) ||
+            it->second->Type == "pushbutton")
         {
             publishPolicy.Policy = TPublishParameters::PublishAll;
         }

--- a/src/serial_port_driver.cpp
+++ b/src/serial_port_driver.cpp
@@ -148,8 +148,7 @@ void TSerialPortDriver::OnValueRead(PRegister reg)
         // and pushbutton channels (always publish value "1")
         auto publishPolicy = PublishPolicy;
         if ((reg->GetConfig()->SporadicMode == TRegisterConfig::TSporadicMode::ONLY_EVENTS &&
-             reg->IsExcludedFromPolling()) ||
-            reg->Device()->IsSporadicOnly() || it->second->Type == "pushbutton")
+             reg->IsExcludedFromPolling()) || it->second->Type == "pushbutton")
         {
             publishPolicy.Policy = TPublishParameters::PublishAll;
         }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если у устройства только sporadic каналы, принудительно опрашивается один регистр, чтобы знать, что устройство живо. Значение этого регистра публиковалось при каждом опросе. Сейчас публикуется согласно настройкам.

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
