### PR TITLE
Apply preserve_setup_order and max_write_registers=1 to WBIO modbus_i…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.244.1) stable; urgency=medium
+wb-mqtt-serial (2.245.1) stable; urgency=medium
 
   * Apply preserve_setup_order and max_write_registers=1 to WBIO
     modbus_io templates

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-wb-mqtt-serial (2.245.1) stable; urgency=medium
+wb-mqtt-serial (2.246.1) stable; urgency=medium
 
   * Apply preserve_setup_order and max_write_registers=1 to WBIO
     modbus_io templates
 
- -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 07 May 2026 10:25:09 +0300
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 08 May 2026 09:55:28 +0300
 
 wb-mqtt-serial (2.246.0) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.244.1) stable; urgency=medium
+
+  * Apply preserve_setup_order and max_write_registers=1 to WBIO
+    modbus_io templates
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 07 May 2026 10:25:09 +0300
+
 wb-mqtt-serial (2.244.0) stable; urgency=medium
 
   * Add "preserve_setup_order" device template option

--- a/templates/config-wbio-ai-dv-12-20ma.json
+++ b/templates/config-wbio-ai-dv-12-20ma.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "CONF_A1", 

--- a/templates/config-wbio-ai-dv-12-50V.json
+++ b/templates/config-wbio-ai-dv-12-50V.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "CONF_A1_A2", 

--- a/templates/config-wbio-ai-dv-12.json
+++ b/templates/config-wbio-ai-dv-12.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "CONF_A1", 

--- a/templates/config-wbio-di-dr-14.json
+++ b/templates/config-wbio-di-dr-14.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-di-dr-16.json
+++ b/templates/config-wbio-di-dr-16.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-di-dr-8.json
+++ b/templates/config-wbio-di-dr-8.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-di-hvd-16.json
+++ b/templates/config-wbio-di-hvd-16.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-di-hvd-8.json
+++ b/templates/config-wbio-di-hvd-8.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-di-wd-14.json
+++ b/templates/config-wbio-di-wd-14.json
@@ -9,6 +9,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-dio-ttl-8.json
+++ b/templates/config-wbio-dio-ttl-8.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-do-hs-8.json
+++ b/templates/config-wbio-do-hs-8.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-do-r10a-8.json
+++ b/templates/config-wbio-do-r10a-8.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-do-r10r-4.json
+++ b/templates/config-wbio-do-r10r-4.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-do-r1g-16.json
+++ b/templates/config-wbio-do-r1g-16.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",

--- a/templates/config-wbio-do-ssr-8.json
+++ b/templates/config-wbio-do-ssr-8.json
@@ -10,6 +10,8 @@
         "max_read_registers": 0,
         "response_timeout_ms": 40,
         "frame_timeout_ms": 8,
+        "preserve_setup_order": true,
+        "max_write_registers": 1,
         "setup": [
             {
                 "title": "IODIR",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил `preserve_setup_order` в шаблоны wbio, т.к. порядок записи регистров там важен.

___________________________________
**Что поменялось для пользователей:**
Ничего, т.к. настройки в шаблонах совпадали с дефолтными, т.е. устройства работали правильно.

___________________________________
**Как проверял/а:**
На столе