### PR TITLE
FW-1336 Шаблоны MDM3 и MAO4 для диммирования короткими нажатиями

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.242.0) stable; urgency=medium
+
+  * Add short press dimming step controls for WB-MDM3, WB-MAO4 and WB-MAO4-20mA
+
+ -- Egor Panchenko <egor.panchenko@wirenboard.com>  Fri, 8 May 2026 21:00:00 +0300
+
 wb-mqtt-serial (2.241.0) stable; urgency=medium
 
   * Add new templates for WB-MDM3 and WB-MAO4 with auto-on channel and remote swooth change support

--- a/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
@@ -388,6 +388,17 @@
                 "max": 500,
                 "group": "gg_output_{{ ch_number }}_rates"
             },
+            {
+                "id": "action{{ch_number}}_short_press_step",
+                "title": "Short Press Step (0.1%)",
+                "description": "short_press_step_description",
+                "address": {{976 + ch_number - 1}},
+                "reg_type": "holding",
+                "default": 10,
+                "min": 1,
+                "max": 1000,
+                "group": "gg_output_{{ ch_number }}_rates"
+            },
             {% endfor -%}
             {
                 "id": "safety_timer_s",
@@ -741,6 +752,7 @@
                 "decrement_rate_description": "When level is changed abruptly or channel is turned off, level will decrease smoothly with specified rate. If set to 0, level will decrease instantly",
                 "increment_rate_description": "When level is changed abruptly or channel is turned on, level will increase smoothly with specified rate. If set to 0, level will increase instantly",
                 "action_repeat_time_description": "When button is held for a long time, level will change with specified rate.",
+                "short_press_step_description": "When a short press action increases or decreases level, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except single and long. Adds a delay to the response to a single press",
@@ -826,9 +838,11 @@
                 "Decrement Rate (ms/%)": "Темп изменения уровня в сторону уменьшения (мс/%)",
                 "Increment Rate (ms/%)": "Темп изменения уровня в сторону увеличения (мс/%)",
                 "Changing Rate for Long Press Actions (ms/%)": "Темп изменения уровня при долгих нажатиях (мс/%)",
+                "Short Press Step (0.1%)": "Шаг изменения уровня коротким нажатием (0,1%)",
                 "decrement_rate_description": "При скачкообразном изменении уровня или выключении канала, уровень будет плавно уменьшаться с заданным темпом. При значении 0, уровень уменьшится мгновенно",
                 "increment_rate_description": "При скачкообразном изменении уровня или включении канала, уровень будет плавно увеличиваться с заданным темпом. При значении 0, уровень увеличится мгновенно",
                 "action_repeat_time_description": "При удержании кнопки уровень будет изменяться с заданным темпом",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения уровень канала меняется на этот шаг через фейдер",
 
                 "Safety Mode": "Безопасный режим",
                 "g_safety_description": "Настройка поведения устройства в случае потери связи с контроллером",

--- a/templates/config-wb-mao4-20ma.json.jinja
+++ b/templates/config-wb-mao4-20ma.json.jinja
@@ -387,6 +387,18 @@
                 "max": 500,
                 "group": "gg_output_{{ ch_number }}_rates"
             },
+            {
+                "id": "action{{ch_number}}_short_press_step",
+                "title": "Short Press Step (0.1%)",
+                "description": "short_press_step_description",
+                "address": {{976 + ch_number - 1}},
+                "reg_type": "holding",
+                "fw": "2.9.0",
+                "default": 10,
+                "min": 1,
+                "max": 1000,
+                "group": "gg_output_{{ ch_number }}_rates"
+            },
             {% endfor -%}
             {
                 "id": "safety_timer_s",
@@ -712,6 +724,7 @@
                 "decrement_rate_description": "When level is changed abruptly or channel is turned off, level will decrease smoothly with specified rate. If set to 0, level will decrease instantly",
                 "increment_rate_description": "When level is changed abruptly or channel is turned on, level will increase smoothly with specified rate. If set to 0, level will increase instantly",
                 "action_repeat_time_description": "When button is held for a long time, level will change with specified rate.",
+                "short_press_step_description": "When a short press action increases or decreases level, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except single and long. Adds a delay to the response to a single press",
@@ -791,9 +804,11 @@
                 "Decrement Rate (ms/%)": "Темп изменения уровня в сторону уменьшения (мс/%)",
                 "Increment Rate (ms/%)": "Темп изменения уровня в сторону увеличения (мс/%)",
                 "Changing Rate for Long Press Actions (ms/%)": "Темп изменения уровня при долгих нажатиях (мс/%)",
+                "Short Press Step (0.1%)": "Шаг изменения уровня коротким нажатием (0,1%)",
                 "decrement_rate_description": "При скачкообразном изменении уровня или выключении канала, уровень будет плавно уменьшаться с заданным темпом. При значении 0, уровень уменьшится мгновенно",
                 "increment_rate_description": "При скачкообразном изменении уровня или включении канала, уровень будет плавно увеличиваться с заданным темпом. При значении 0, уровень увеличится мгновенно",
                 "action_repeat_time_description": "При удержании кнопки уровень будет изменяться с заданным темпом",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения уровень канала меняется на этот шаг через фейдер",
 
                 "Safety Mode": "Безопасный режим",
                 "g_safety_description": "Настройка поведения устройства в случае потери связи с контроллером",

--- a/templates/config-wb-mao4-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-fw-2.9.json.jinja
@@ -276,6 +276,18 @@
                 "max": 500,
                 "order": 5
             },
+            {
+                "id": "action{{ch_number}}_short_press_step",
+                "title": "Short Press Step (%)",
+                "description": "short_press_step_description",
+                "group": "output{{ch_number}}",
+                "address": {{976 + ch_number - 1}},
+                "reg_type": "holding",
+                "default": 1,
+                "min": 1,
+                "max": 100,
+                "order": 6
+            },
             {% endfor -%}
             {% for ch_number in range(0, INPUTS_NUMBER) -%}
             {
@@ -904,6 +916,7 @@
                 "increase_rate_description": "During smooth transitions, channel level will be decreased by 1% every specified period of time. If set to 0, level will increase instantly",
                 "decrease_rate_description": "During smooth transitions, channel level will be increased by 1% every specified period of time. If set to 0, level will decrease instantly",
                 "action_repeat_time_description": "During long-lasting actions channel level will be changed by 1% every specified period of time",
+                "short_press_step_description": "When a short press action increases or decreases brightness, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except short and long. Adds a delay to the response to a short press",
@@ -977,6 +990,7 @@
                 "Dimming level decrement rate (ms/%)": "Темп уменьшения уровня яркости (мс/%)",
                 "Dimming level increment rate (ms/%)": "Темп увеличения уровня яркости (мс/%)",
                 "Action repeat time (ms)": "Длительность периода повторения действий (мс)",
+                "Short Press Step (%)": "Шаг изменения яркости коротким нажатием (%)",
 
                 "level_1_voltage_description": "Задает границу диапазона напряжения, соответствующую 1% уровня диммирования",
                 "level_100_voltage_description": "Задает границу диапазона напряжения, соответствующую 100% уровня диммирования",
@@ -1044,7 +1058,8 @@
 
                 "decrease_rate_description": "Во время плавных переходов, выходной уровень будет уменьшаться на 1% через указанный период времени. При 0 значении, уровень уменьшится мгновенно",
                 "increase_rate_description": "Во время плавных переходов, выходной уровень будет увеличиваться на 1% через указанный период времени. При 0 значении, уровень увеличится мгновенно",
-                "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени"
+                "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения яркость канала меняется на этот шаг через фейдер"
             }
         }
     }

--- a/templates/config-wb-mao4.json.jinja
+++ b/templates/config-wb-mao4.json.jinja
@@ -285,6 +285,19 @@
                 "max": 500,
                 "order": 5
             },
+            {
+                "id": "action{{ch_number}}_short_press_step",
+                "title": "Short Press Step (%)",
+                "description": "short_press_step_description",
+                "group": "output{{ch_number}}",
+                "address": {{976 + ch_number - 1}},
+                "reg_type": "holding",
+                "fw": "2.9.0",
+                "default": 1,
+                "min": 1,
+                "max": 100,
+                "order": 6
+            },
             {% endfor -%}
             {% for ch_number in range(0, INPUTS_NUMBER) -%}
             {
@@ -906,6 +919,7 @@
                 "increase_rate_description": "During smooth transitions, channel level will be decreased by 1% every specified period of time. If set to 0, level will increase instantly",
                 "decrease_rate_description": "During smooth transitions, channel level will be increased by 1% every specified period of time. If set to 0, level will decrease instantly",
                 "action_repeat_time_description": "During long-lasting actions channel level will be changed by 1% every specified period of time",
+                "short_press_step_description": "When a short press action increases or decreases brightness, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except short and long. Adds a delay to the response to a short press",
@@ -973,6 +987,7 @@
                 "Dimming level decrement rate (ms/%)": "Темп уменьшения уровня яркости (мс/%)",
                 "Dimming level increment rate (ms/%)": "Темп увеличения уровня яркости (мс/%)",
                 "Action repeat time (ms)": "Длительность периода повторения действий (мс)",
+                "Short Press Step (%)": "Шаг изменения яркости коротким нажатием (%)",
 
                 "level_1_voltage_description": "Задает границу диапазона напряжения, соответствующую 1% уровня диммирования",
                 "level_100_voltage_description": "Задает границу диапазона напряжения, соответствующую 100% уровня диммирования",
@@ -1040,7 +1055,8 @@
 
                 "decrease_rate_description": "Во время плавных переходов, выходной уровень будет уменьшаться на 1% через указанный период времени. При 0 значении, уровень уменьшится мгновенно",
                 "increase_rate_description": "Во время плавных переходов, выходной уровень будет увеличиваться на 1% через указанный период времени. При 0 значении, уровень увеличится мгновенно",
-                "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени"
+                "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения яркость канала меняется на этот шаг через фейдер"
             }
         }
     }

--- a/templates/config-wb-mdm3-fw-2.12.json.jinja
+++ b/templates/config-wb-mdm3-fw-2.12.json.jinja
@@ -506,6 +506,18 @@
                 "max": 500,
                 "order": 7
             },
+            {
+                "id": "action{{ch_number + 1}}_short_press_step",
+                "title": "Short Press Step (%)",
+                "description": "short_press_step_description",
+                "group": "channel_{{ch_number + 1}}",
+                "address": {{976 + ch_number}},
+                "reg_type": "holding",
+                "default": 1,
+                "min": 1,
+                "max": 100,
+                "order": 8
+            },
             {% endfor -%}
 
             {
@@ -749,6 +761,7 @@
                 "increase_rate_description": "During smooth transitions, channel level will be decreased by 1% every specified period of time",
                 "decrease_rate_description": "During smooth transitions, channel level will be increased by 1% every specified period of time",
                 "action_repeat_time_description": "During long-lasting actions channel level will be changed by 1% every specified period of time",
+                "short_press_step_description": "When a short press action increases or decreases brightness, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except short and long. Adds a delay to the response to a short press",
@@ -846,6 +859,7 @@
                 "Second Press Waiting Time (ms)": "Время ожидания второго нажатия (мс)",
                 "Debounce Time (ms)": "Время подавления дребезга (мс)",
                 "Action Repeat Time (ms)": "Длительность периода повторения действий (мс)",
+                "Short Press Step (%)": "Шаг изменения яркости коротким нажатием (%)",
 
                 "input_mode_description": "Режим работы входа по умолчанию - кнопка без фиксации. Работа в режиме выключателя с фиксацией поддерживается",
 
@@ -856,6 +870,7 @@
                 "decrease_rate_description": "Во время плавных переходов, выходной уровень будет уменьшаться на 1% через указанный период времени",
                 "increase_rate_description": "Во время плавных переходов, выходной уровень будет увеличиваться на 1% через указанный период времени",
                 "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения яркость канала меняется на этот шаг через фейдер",
 
                 "Safety Mode": "Безопасный режим",
                 "g_safety_description": "Настройка поведения устройства в случае потери связи с контроллером",

--- a/templates/config-wb-mdm3.json.jinja
+++ b/templates/config-wb-mdm3.json.jinja
@@ -524,6 +524,19 @@
                 "max": 500,
                 "order": 7
             },
+            {
+                "id": "action{{ch_number + 1}}_short_press_step",
+                "title": "Short Press Step (%)",
+                "description": "short_press_step_description",
+                "group": "channel_{{ch_number + 1}}",
+                "address": {{976 + ch_number}},
+                "reg_type": "holding",
+                "fw": "2.12.0",
+                "default": 1,
+                "min": 1,
+                "max": 100,
+                "order": 8
+            },
             {% endfor -%}
 
             {
@@ -742,6 +755,7 @@
                 "increase_rate_description": "During smooth transitions, channel level will be decreased by 1% every specified period of time",
                 "decrease_rate_description": "During smooth transitions, channel level will be increased by 1% every specified period of time",
                 "action_repeat_time_description": "During long-lasting actions channel level will be changed by 1% every specified period of time",
+                "short_press_step_description": "When a short press action increases or decreases brightness, channel level changes by this step through the fader",
 
                 "input_hold_time_description": "Presses that last longer than the specified time are counted as long presses",
                 "input_double_time_description": "If there is no second press during the specified time then press is single. 0 - disables all presses except short and long. Adds a delay to the response to a short press",
@@ -833,6 +847,7 @@
                 "Second Press Waiting Time (ms)": "Время ожидания второго нажатия (мс)",
                 "Debounce Time (ms)": "Время подавления дребезга (мс)",
                 "Action Repeat Time (ms)": "Длительность периода повторения действий (мс)",
+                "Short Press Step (%)": "Шаг изменения яркости коротким нажатием (%)",
 
                 "input_mode_description": "Режим работы входа по умолчанию - кнопка без фиксации. Работа в режиме выключателя с фиксацией доступна с версии прошивки 2.8.0",
 
@@ -843,6 +858,7 @@
                 "decrease_rate_description": "Во время плавных переходов, выходной уровень будет уменьшаться на 1% через указанный период времени",
                 "increase_rate_description": "Во время плавных переходов, выходной уровень будет увеличиваться на 1% через указанный период времени",
                 "action_repeat_time_description": "Во время долгих действий, выходной уровень будет изменяться на 1% через указанный период времени",
+                "short_press_step_description": "При коротком нажатии с действием увеличения или уменьшения яркость канала меняется на этот шаг через фейдер",
 
                 "Safety Mode": "Безопасный режим",
                 "g_safety_description": "Настройка поведения устройства в случае потери связи с контроллером",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Обновить шаблоны MDM3 и MAO4/MAO4-20mA под диммирование короткими нажатиями.

Firmware-часть FW-1336 добавляет per-channel Modbus-настройку шага короткого нажатия. Пользовательские настройки должны быть доступны через MQTT/WB UI тем же образом, что и остальные параметры диммеров.

Что сделано:
- добавлены настройки `Short Press Step` для MDM3, MAO4 и MAO4-20mA;
- адреса настроек соответствуют firmware-блоку `0x03D0` (`976`) и идут per-channel;
- для MDM3/MAO4 шкала оставлена в процентах `1..100`, default `1`;
- для MAO4-20mA шкала задана в `0.1%`: `1..1000`, default `10`;
- добавлены en/ru переводы и описания;
- changelog обновлен с записью `add`.

Связанные PR:
- Shared dimmer logic: https://github.com/wirenboard/libwbmcu-periph/pull/258
- MDM3 firmware: https://github.com/wirenboard/wb-md/pull/66
- MAO4 firmware: https://github.com/wirenboard/wb-mao4/pull/42

___________________________________
**Что поменялось для пользователей:**
В шаблонах появились настройки шага короткого нажатия для MDM3, MAO4 и MAO4-20mA.

___________________________________
**Как проверял/а:**
- `make templates`
- вручную проверены сгенерированные controls в `build/templates/config-wb-mdm3-fw-2.12.json`, `build/templates/config-wb-mao4-fw-2.9.json`, `build/templates/config-wb-mao4-20ma-fw-2.9.json`
- `git diff --check` в `wb-mqtt-serial`

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
Отдельных unit-тестов нет: изменение декларативное, проверено рендерингом шаблонов через `make templates`.