### PR TITLE
Fix working with multiple WB-MGE v.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.224.0-wb106) stable; urgency=medium
+
+  * Fix race condition on gethostbyname() when starting TCP ports
+  * Improve log when port closed due to repetitive errors
+
+ -- Maxim Toropov <maxim.toropov@wirenboard.com>  Thu, 14 May 2026 16:23:00 +0300
+
 wb-mqtt-serial (2.224.0-wb105) stable; urgency=medium
 
   * Add new template for WB-M1W2 v.3 with multiple sensors per channel feature (fw4.35)

--- a/src/port/port.cpp
+++ b/src/port/port.cpp
@@ -92,7 +92,9 @@ void TPortOpenCloseLogic::CloseIfNeeded(PPort port, bool allPreviousDataExchange
     }
 
     if ((currentTime - LastSuccessfulCycle > Settings.MaxFailTime) && RemainingFailCycles == 0) {
-        Warn.Log() << port->GetDescription() << ": closed due to repetitive errors";
+        Warn.Log() << port->GetDescription() << ": got more than " << Settings.ConnectionMaxFailCycles
+                   << " consecutive failures during last " << Settings.MaxFailTime.count() << " ms."
+                   << " Try to recover, close and reopen port. Check if devices on the bus are powered";
         port->Close();
     }
 }

--- a/src/port/tcp_port.cpp
+++ b/src/port/tcp_port.cpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,21 +42,20 @@ void TTcpPort::Open()
         throw TSerialDeviceException("port is already open");
     }
 
-    struct hostent* server = gethostbyname(Settings.Address.c_str());
-    if (!server) {
-        throw TSerialDeviceException("no such host: " + Settings.Address);
+    struct addrinfo hints = {};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo* rawResult = nullptr;
+    auto rc = getaddrinfo(Settings.Address.c_str(), std::to_string(Settings.Port).c_str(), &hints, &rawResult);
+    if (rc != 0 || !rawResult) {
+        throw TSerialDeviceException("no such host: " + Settings.Address + ": " + gai_strerror(rc));
     }
+    std::unique_ptr<struct addrinfo, decltype(&freeaddrinfo)> addrInfo(rawResult, &freeaddrinfo);
 
-    Fd = socket(AF_INET, SOCK_STREAM, 0);
+    Fd = socket(addrInfo->ai_family, addrInfo->ai_socktype, addrInfo->ai_protocol);
     if (Fd < 0) {
         throw TSerialDeviceErrnoException("cannot open tcp port: ", errno);
     }
-
-    struct sockaddr_in serv_addr;
-    memset((char*)&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET;
-    memmove((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr, server->h_length);
-    serv_addr.sin_port = htons(Settings.Port);
 
     // set socket to non-blocking state
     auto arg = fcntl(Fd, F_GETFL, NULL);
@@ -71,7 +71,7 @@ void TTcpPort::Open()
     }
 
     try {
-        if (connect(Fd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
+        if (connect(Fd, addrInfo->ai_addr, addrInfo->ai_addrlen) < 0) {
             if (errno != EINPROGRESS) {
                 throw std::runtime_error("connect error: " + FormatErrno(errno));
             }


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Бекпорт https://github.com/wirenboard/wb-mqtt-serial/pull/1175

___________________________________
**Что поменялось для пользователей:**
Работа с несколькими шлюзами TCP / Modbus TCP станет стабильной

___________________________________
**Как проверял/а:**
Локально, собрал стенд с 3мя WB-MGE v.3 и подключенными за ними устройствами (WB-MR6C v.3, WB-MRWM2, WB-LED).
Проверял на WB 7 с wb-2602, устанавливал пакет, собранный на Jenkins