### PR TITLE
Add short presses step params to MDM3 and MAO4 templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,11 @@
-wb-mqtt-serial (2.242.0-rc1) stable; urgency=medium
+wb-mqtt-serial (2.242.0-rc2) stable; urgency=medium
 
   * Add new templates for WB-MDM3 and WB-MAO4 with auto-on channel and remote swooth change support
     [ Maxim Toropov ]
   * Add encoders support to the new WB-MDM3 and WB-MAO4 templates
+  * Add short presses dimming step support to the new WB-MDM3 and WB-MAO4 templates
 
- -- Egor Panchenko <egor.panchenko@wirenboard.com>  Fri, 22 May 2026 14:40:00 +0300
+ -- Egor Panchenko <egor.panchenko@wirenboard.com>  Mon, 25 May 2026 20:10:00 +0300
 
 wb-mqtt-serial (2.240.0) stable; urgency=medium
 

--- a/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
@@ -11,7 +11,10 @@
 {% set ENCODERS_NUMBER = 2 -%}
 {% set ENCODER_CHANGE_STEP_DEFAULT = 1 -%}
 {% set ENCODER_CHANGE_STEP_MAX = 100 -%}
-{% set PRESS_TYPES = ["single", "long", "double", "shortlong"] %}
+{% set PRESS_TYPES = ["single", "long", "double", "shortlong"] -%}
+{% set SHORT_PRESS_TYPES = ["single", "double"] -%}
+{% set SHORT_PRESS_CHANGE_STEP_DEFAULT = 1 -%}
+{% set SHORT_PRESS_CHANGE_STEP_MAX = 100 -%}
 
 {
     "title": "template_title",
@@ -21,7 +24,7 @@
     "hw": [
         {
             "signature": "WB-MAO4-20mA",
-            "fw": "2.9.0-rc3"
+            "fw": "2.9.0-rc4"
         }
     ],
 {% endif -%}
@@ -229,7 +232,7 @@
                 "order": 3
             },
             {% for press_type in PRESS_TYPES -%}
-            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_')  %}
+            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_') -%}
             {
                 "id": "{{action_bind}}_number",
                 "title": "Output Number",
@@ -284,6 +287,23 @@
                 "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_') }}_press_action",
                 "order": 2,
                 "condition": "{{ action_bind }}_number==100&&{{encoder_disabled_condition}}"
+            },
+            {% endfor -%}
+            {# Шаг диммирования для коротких нажатий -#}
+            {% for press_type in SHORT_PRESS_TYPES -%}
+            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_')  -%}
+            {
+                "id": "input_{{ch_number+1}}_{{press_type}}_press_changing_step",
+                "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_')}}_press_action",
+                "title": "Level Change Step (%)",
+                "order": 3,
+                "address": {{1200 + ch_number + loop.index0 * 20}},
+                "reg_type": "holding",
+                "scale": 0.1,
+                "default": {{SHORT_PRESS_CHANGE_STEP_DEFAULT}},
+                "min": 1,
+                "max": {{SHORT_PRESS_CHANGE_STEP_MAX}},
+                "condition": "(input_{{ch_number+1}}_mode!=1)&&((({{action_bind}}_number>=1)&&({{action_bind}}_number<=4))||({{action_bind}}_number==100))&&((({{action_bind}}_action_single>=3)&&({{action_bind}}_action_single<=4))||(({{action_bind}}_action_all>=3)&&({{action_bind}}_action_all<=4)))&&{{encoder_disabled_condition}}"
             },
             {% endfor -%}
             {% for sw_act in ["off", "on"] -%}

--- a/templates/config-wb-mao4-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-fw-2.9.json.jinja
@@ -11,7 +11,10 @@
 {% set ENCODERS_NUMBER = 1 -%}
 {% set ENCODER_CHANGE_STEP_DEFAULT = 1 -%}
 {% set ENCODER_CHANGE_STEP_MAX = 100 -%}
-{% set PRESS_TYPES = ["short", "long", "double", "short long"] %}
+{% set PRESS_TYPES = ["short", "long", "double", "short long"] -%}
+{% set SHORT_PRESS_TYPES = ["short", "double"] -%}
+{% set SHORT_PRESS_CHANGE_STEP_DEFAULT = 1 -%}
+{% set SHORT_PRESS_CHANGE_STEP_MAX = 100 -%}
 {% set LIGHT_SCENES_NUMBER = 8 -%}
 
 {
@@ -22,7 +25,7 @@
     "hw": [
         {
             "signature": "WBMAO4",
-            "fw": "2.9.0-rc3"
+            "fw": "2.9.0-rc4"
         }
     ],
 {% endif %}
@@ -357,7 +360,7 @@
                 "order": 3
             },
             {% for press_type in PRESS_TYPES -%}
-            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_')  %}
+            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_') -%}
             {
                 "id": "{{action_bind}}_number",
                 "title": "Output Number",
@@ -430,6 +433,22 @@
                 "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_') }}_press_action",
                 "order": 2,
                 "condition": "{{ action_bind }}_number>=32&&{{ action_bind }}_number<=39&&{{encoder_disabled_condition}}"
+            },
+            {% endfor -%}
+            {# Шаг диммирования для коротких нажатий -#}
+            {% for press_type in SHORT_PRESS_TYPES -%}
+            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_')  -%}
+            {
+                "id": "input_{{ch_number+1}}_{{press_type}}_press_changing_step",
+                "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_')}}_press_action",
+                "title": "Level Change Step (%)",
+                "order": 3,
+                "address": {{1200 + ch_number + loop.index0 * 20}},
+                "reg_type": "holding",
+                "default": {{SHORT_PRESS_CHANGE_STEP_DEFAULT}},
+                "min": 1,
+                "max": {{SHORT_PRESS_CHANGE_STEP_MAX}},
+                "condition": "(input_{{ch_number+1}}_mode!=1)&&((({{action_bind}}_number>=1)&&({{action_bind}}_number<=4))||({{action_bind}}_number==100))&&((({{action_bind}}_action_single>=3)&&({{action_bind}}_action_single<=4))||(({{action_bind}}_action_all>=3)&&({{action_bind}}_action_all<=4)))&&{{encoder_disabled_condition}}"
             },
             {% endfor -%}
             {% for sw_act in ["off", "on"] -%}

--- a/templates/config-wb-mdm3-fw-2.12.json.jinja
+++ b/templates/config-wb-mdm3-fw-2.12.json.jinja
@@ -4,6 +4,9 @@
 {% set ENCODER_CHANGE_STEP_DEFAULT = 1 -%}
 {% set ENCODER_CHANGE_STEP_MAX = 100 -%}
 {% set PRESS_TYPES = ["single", "long", "double", "shortlong"] -%}
+{% set SHORT_PRESS_TYPES = ["single", "double"] -%}
+{% set SHORT_PRESS_CHANGE_STEP_DEFAULT = 1 -%}
+{% set SHORT_PRESS_CHANGE_STEP_MAX = 100 -%}
 
 {
     "title": "WB-MDM3_template_title",
@@ -12,7 +15,7 @@
     "hw": [
         {
             "signature": "WBMD3",
-            "fw": "2.12.0-rc3"
+            "fw": "2.12.0-rc4"
         }
     ],
     "device": {
@@ -246,6 +249,24 @@
                 "group": "input_{{ ch_number + 1 }}_{{ press_type | replace(' ', '_') }}_press_action",
                 "order": 2,
                 "condition": "{{action_bind}}_number==100&&{{encoder_disabled_condition}}"
+            },
+            {% endfor -%}
+            {# Шаг диммирования для коротких нажатий -#}
+            {% for press_type in SHORT_PRESS_TYPES -%}
+            {% set action_bind = ("input {} {} press output".format(ch_number + 1, press_type))|replace(' ', '_')  -%}
+            {% set cond_enc_num = (ch_number // 2) + 1 -%}
+            {% set encoder_disabled_condition = "(encoder_" ~ cond_enc_num ~ "_mode==0)" if cond_enc_num <= ENCODERS_NUMBER else "(1==1)" -%}
+            {
+                "id": "input_{{ch_number+1}}_{{press_type}}_press_changing_step",
+                "group": "input_{{ch_number + 1}}_{{press_type | replace(' ', '_')}}_press_action",
+                "title": "Level Change Step (%)",
+                "order": 3,
+                "address": {{1200 + ch_number + loop.index0 * 20}},
+                "reg_type": "holding",
+                "default": {{SHORT_PRESS_CHANGE_STEP_DEFAULT}},
+                "min": 1,
+                "max": {{SHORT_PRESS_CHANGE_STEP_MAX}},
+                "condition": "(input_{{ch_number+1}}_mode!=1)&&((({{action_bind}}_number>=1)&&({{action_bind}}_number<=3))||({{action_bind}}_number==100))&&((({{action_bind}}_action_single>=3)&&({{action_bind}}_action_single<=4))||(({{action_bind}}_action_all>=3)&&({{action_bind}}_action_all<=4)))&&{{encoder_disabled_condition}}"
             },
             {% endfor -%}
             {% for sw_act in ["off", "on"] -%}


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Добавлены параметры шага диммирования для коротких нажатий (одиночное и двойное) в новые шаблоны WB-MAO4 и WB-MDM3

___________________________________
**Что поменялось для пользователей:**
Появилась возможность задавать шаг диммирования для коротких нажатий

___________________________________
**Как проверял/а:**
На устройствах WB-MAO4, WB-MAO4-20 и WB-MDM3 на столе.
Смотрел логи wb-mqtt-serial.