### PR TITLE
FW-1291 Shorten encoder Controlled Channel ru title

### DIFF
--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -733,7 +733,7 @@
                 "reg_type": "holding",
                 "default": 5,
                 "min": 1,
-                "max": 10000,
+                "max": 1000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"
             },
             {% set ch_min_br_behavior_conditions = [

--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -2671,7 +2671,7 @@
 
                 "Encoder Connection Type": "Тип подключения энкодера",
                 "Pulses per Step": "Количество импульсов на один шаг",
-                "Controlled Channel": "Управляемый канал диммера",
+                "Controlled Channel": "Управляемый канал",
                 "Step of Value Change": "Шаг изменения значения",
 
                 "No Control": "Управление отключено",

--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -733,7 +733,7 @@
                 "reg_type": "holding",
                 "default": 5,
                 "min": 1,
-                "max": 1000,
+                "max": 10000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"
             },
             {% set ch_min_br_behavior_conditions = [

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -487,7 +487,7 @@
                 "reg_type": "holding",
                 "default": 5,
                 "min": 1,
-                "max": 1000,
+                "max": 10000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"
             },
             {% set ch_min_br_behavior_conditions = [

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -487,7 +487,7 @@
                 "reg_type": "holding",
                 "default": 5,
                 "min": 1,
-                "max": 10000,
+                "max": 1000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"
             },
             {% set ch_min_br_behavior_conditions = [

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -3828,7 +3828,7 @@
 
                 "Encoder Connection Type": "Тип подключения энкодера",
                 "Pulses per Step": "Количество импульсов на один шаг",
-                "Controlled Channel": "Управляемый канал диммера",
+                "Controlled Channel": "Управляемый канал",
                 "Step of Value Change": "Шаг изменения значения",
 
                 "No Control": "Управление отключено",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Сокращён русский title `Controlled Channel` в шаблонах
`config-wb-led-fw-3.8` и `config-wb-mrgbw-d-fw-3.8`: было «Управляемый
канал диммера», стало «Управляемый канал».

Связанные PR:
- [wb-mrgb](https://github.com/wirenboard/wb-mrgb/pull/112)
- [libwbmcu-periph](https://github.com/wirenboard/libwbmcu-periph/pull/267)

___________________________________
**Что поменялось для пользователей:**
В Web UI для WB-LED и WB-MRGBW-D подпись «Управляемый канал диммера»
сокращена до «Управляемый канал».

___________________________________
**Как проверял/а:**
На стенде разработчика.

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
Отдельные тесты не добавлены: правка в одной строке перевода.