### PR TITLE
Fix LED and MRGBW-D new templates: sporadic for output channels, encoder default step is 1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.241.1-rc1) stable; urgency=medium
+wb-mqtt-serial (2.241.1) stable; urgency=medium
 
   * Add new templates for WB-LED and WB-MRGB-D with encoders and dimming step support, new 2CCT mode
   * Change switch actions config order to channel -> action in WB-LED template

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-wb-mqtt-serial (2.241.0) stable; urgency=medium
+wb-mqtt-serial (2.241.1-rc1) stable; urgency=medium
 
   * Add new templates for WB-LED and WB-MRGB-D with encoders and dimming step support, new 2CCT mode
   * Change switch actions config order to channel -> action in WB-LED template
     [Egor Panchenko]
   * Add auto-enable registers for WB-LED and WB-MRGB-D fw 3.8
 
- -- Maxim Toropov <maxim.toropov@wirenboard.com>  Mon, 4 May 2026 17:00:00 +0300
+ -- Maxim Toropov <maxim.toropov@wirenboard.com>  Wed, 27 May 2026 16:50:00 +0300
 
 wb-mqtt-serial (2.240.0) stable; urgency=medium
 

--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -1883,6 +1883,7 @@
                 "address": 5,
                 "type": "switch",
                 "reg_type": "coil",
+                "sporadic": true,
                 "condition": "(dimmer_mode==16||dimmer_mode==17||dimmer_mode==18)"
             },
             {

--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -731,7 +731,7 @@
                 "order": 4,
                 "address": {{392 + enc_num - 1}},
                 "reg_type": "holding",
-                "default": 5,
+                "default": 1,
                 "min": 1,
                 "max": 10000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -3130,6 +3130,7 @@
                 "address": 2003,
                 "type": "range",
                 "reg_type": "holding",
+                "sporadic": true,
                 "min": 0,
                 "max": 100,
                 "error_value": "0xFFFF",

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -485,7 +485,7 @@
                 "order": 4,
                 "address": {{392 + enc_num - 1}},
                 "reg_type": "holding",
-                "default": 5,
+                "default": 1,
                 "min": 1,
                 "max": 10000,
                 "condition": "(encoder_{{enc_num}}_mode==1)&&(encoder_{{enc_num}}_ctrl_ch!=0)"


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Фиксы в новых шаблонах WB-LED и WB-MRGBW-D:
- Добавлен пропущенный тип sporadic у регистров выходных каналов
- Исправлено дефолтное значение шага изменения для энкодеров на 1 (в соответствии с прошивкой)

___________________________________
**Что поменялось для пользователей:**
Регистр управления каналами 3 и 4 в WB-LED и регистр управления яркостью канала 4 в WB-MRGBW-D теперь будут опрашиваться по быстрому модбасу
Дефолтное значение шага изменения для энкодеров в шаблоне будет соответствовать тому, что в прошивке

___________________________________
**Как проверял/а:**
Локально на контроллере, смотрел логи mqtt-serial