### PR TITLE
Fix LED and MRGBW-D templates: use sporadic for output channels (wb-2606)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.248.1-wb100) stable; urgency=medium
+
+  * Fix WB-LED and WB-MRGBW-D fw3 templates: use 'sporadic' type for some output registers
+
+ -- Maxim Toropov <maxim.toropov@wirenboard.com>  Wed, 27 May 2026 18:24:00 +0300
+
 wb-mqtt-serial (2.248.1) stable; urgency=medium
 
   * Fix race condition on gethostbyname() when starting TCP ports

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -1308,6 +1308,7 @@
                 "address": 5,
                 "type": "switch",
                 "reg_type": "coil",
+                "sporadic": true,
                 "condition": "(dimmer_mode==16||dimmer_mode==17||dimmer_mode==18)"
             },
             {

--- a/templates/config-wb-mrgbw-d-fw3.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw3.json.jinja
@@ -2389,6 +2389,7 @@
                 "address": 2003,
                 "type": "range",
                 "reg_type": "holding",
+                "sporadic": true,
                 "min": 0,
                 "max": 100,
                 "error_value": "0xFFFF",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Бекпорт фиксов шаблонов LED и MRGBW-D
https://github.com/wirenboard/wb-mqtt-serial/pull/1183

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
