### PR TITLE
Fix WB-MDM3 and WB-MAO4/4-20 new pre-release templates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-wb-mqtt-serial (2.242.0-rc2) stable; urgency=medium
+wb-mqtt-serial (2.242.1) stable; urgency=medium
 
   * Add new templates for WB-MDM3 and WB-MAO4 with auto-on channel and remote swooth change support
     [ Maxim Toropov ]
   * Add encoders support to the new WB-MDM3 and WB-MAO4 templates
   * Add short presses dimming step support to the new WB-MDM3 and WB-MAO4 templates
 
- -- Egor Panchenko <egor.panchenko@wirenboard.com>  Mon, 25 May 2026 20:10:00 +0300
+ -- Egor Panchenko <egor.panchenko@wirenboard.com>  Fri, 29 May 2026 15:46:00 +0300
 
 wb-mqtt-serial (2.240.0) stable; urgency=medium
 

--- a/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
@@ -10,10 +10,12 @@
 {% set OUTPUTS_NUMBER = 4 -%}
 {% set ENCODERS_NUMBER = 2 -%}
 {% set ENCODER_CHANGE_STEP_DEFAULT = 1 -%}
+{% set ENCODER_CHANGE_STEP_MIN = 0.1 -%}
 {% set ENCODER_CHANGE_STEP_MAX = 100 -%}
 {% set PRESS_TYPES = ["single", "long", "double", "shortlong"] -%}
 {% set SHORT_PRESS_TYPES = ["single", "double"] -%}
 {% set SHORT_PRESS_CHANGE_STEP_DEFAULT = 1 -%}
+{% set SHORT_PRESS_CHANGE_STEP_MIN = 0.1 -%}
 {% set SHORT_PRESS_CHANGE_STEP_MAX = 100 -%}
 
 {
@@ -301,7 +303,7 @@
                 "reg_type": "holding",
                 "scale": 0.1,
                 "default": {{SHORT_PRESS_CHANGE_STEP_DEFAULT}},
-                "min": 1,
+                "min": {{SHORT_PRESS_CHANGE_STEP_MIN}},
                 "max": {{SHORT_PRESS_CHANGE_STEP_MAX}},
                 "condition": "(input_{{ch_number+1}}_mode!=1)&&((({{action_bind}}_number>=1)&&({{action_bind}}_number<=4))||({{action_bind}}_number==100))&&((({{action_bind}}_action_single>=3)&&({{action_bind}}_action_single<=4))||(({{action_bind}}_action_all>=3)&&({{action_bind}}_action_all<=4)))&&{{encoder_disabled_condition}}"
             },
@@ -603,7 +605,7 @@
                 "title": "Level Change Step (%)",
                 "address": {{392 + encoder_number - 1}},
                 "reg_type": "holding",
-                "min": 1,
+                "min": {{ENCODER_CHANGE_STEP_MIN}},
                 "max": {{ENCODER_CHANGE_STEP_MAX}},
                 "default": {{ENCODER_CHANGE_STEP_DEFAULT}},
                 "scale": 0.1,

--- a/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
@@ -226,7 +226,7 @@
                 "address": {{1160 + ch_number}},
                 "reg_type": "holding",
                 "default": 50,
-                "min": 0,
+                "min": 2,
                 "max": 200,
                 "group": "input_{{ch_number + 1}}_parameters",
                 "order": 3
@@ -575,7 +575,7 @@
                 "address": {{384 + encoder_number - 1}},
                 "reg_type": "holding",
                 "min": 1,
-                "max": 100,
+                "max": 65535,
                 "default": 4,
                 "group": "gg_encoder_{{encoder_number}}",
                 "condition": "encoder_{{encoder_number}}_mode==1",

--- a/templates/config-wb-mao4-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-fw-2.9.json.jinja
@@ -354,7 +354,7 @@
                 "address": {{1160 + ch_number}},
                 "reg_type": "holding",
                 "default": 50,
-                "min": 0,
+                "min": 2,
                 "max": 200,
                 "group": "input_{{ch_number + 1}}_parameters",
                 "order": 3
@@ -755,7 +755,7 @@
                 "address": {{384 + encoder_number - 1}},
                 "reg_type": "holding",
                 "min": 1,
-                "max": 100,
+                "max": 65535,
                 "default": 4,
                 "group": "gg_encoder_{{encoder_number}}",
                 "condition": "encoder_{{encoder_number}}_mode==1",

--- a/templates/config-wb-mdm3-fw-2.12.json.jinja
+++ b/templates/config-wb-mdm3-fw-2.12.json.jinja
@@ -462,7 +462,7 @@
                 "address": {{1160 + ch_number}},
                 "reg_type": "holding",
                 "default": 50,
-                "min": 0,
+                "min": 2,
                 "max": 200,
                 "group": "input_{{ch_number + 1}}_parameters",
                 "order": 3
@@ -491,7 +491,7 @@
                 "address": {{384 + encoder_number - 1}},
                 "reg_type": "holding",
                 "min": 1,
-                "max": 100,
+                "max": 65535,
                 "default": 4,
                 "group": "gg_encoder_{{encoder_number}}",
                 "condition": "encoder_{{encoder_number}}_mode==1",


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Исправлены новые шаблоны для MAO4/4-20 и MDM3:
- Мин. время подавление дребезга 2 мс (как у WB-LED)
- Макс. количество импульсов энкодера на один шаг

А также для MAO4-20:
- Мин. шаг изменения уровня для энкодеров и коротких нажатий 0,1%

___________________________________
**Что поменялось для пользователей:**
В новых шаблонах не будет указанных выше ошибок/неточностей

___________________________________
**Как проверял/а:**
Локально, смотрел логи mqtt-serial