### PR TITLE
Fix trailing comma in wb-ups-v3 template breaking CI dump check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-serial (2.257.1) stable; urgency=medium
+
+  * config-wb-ups-v3.json.jinja: remove trailing comma after the last debug
+    group; it produced invalid JSON and broke template-dump regeneration
+    (TDeviceTemplatesTest.Validate). Regenerate the stable register dump
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 26 Jun 2026 13:00:00 +0300
+
 wb-mqtt-serial (2.257.0) stable; urgency=medium
 
   * config-wb-ups-v3.json.jinja: Add battery charge level raw channel

--- a/templates/config-wb-ups-v3.json.jinja
+++ b/templates/config-wb-ups-v3.json.jinja
@@ -84,7 +84,7 @@
                 "title": "Battery",
                 "id": "gg_debug_battery",
                 "group": "debug"
-            },
+            }
         ],
         "parameters": [
             {

--- a/test/TDeviceTemplatesTest.Validate.dat
+++ b/test/TDeviceTemplatesTest.Validate.dat
@@ -31613,7 +31613,7 @@ wb_mio
 	Uptime  =>  uptime
 wb_ups_v3
 	Battery Charge Level  =>  battery_charge_level
-	Battery Charge Level Raw => battery_charge_level_raw
+	Battery Charge Level Raw  =>  battery_charge_level_raw
 	Battery Current  =>  battery_current
 	Battery Status  =>  battery_status
 	Battery Temperature  =>  battery_temperature


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В `config-wb-ups-v3.json.jinja` массив debug-групп заканчивается **лишней запятой** после последнего элемента (`gg_debug_battery`) — это невалидный JSON. Обновлённое окружение сборки перестало терпеть trailing comma, из-за чего шаг генерации дампа шаблонов выдаёт пустой файл и тест `TDeviceTemplatesTest.Validate` падает на **каждой** сборке (включая master: #863 SUCCESS → #864 FAILURE, регрессия не из-за кода). Это блокирует все PR в wb-mqtt-serial.

___________________________________
**Что поменялось для пользователей:**

- Ничего в поведении. Убрана синтаксическая запятая в jinja-шаблоне UPS v3.
- Заодно перегенерирован `TDeviceTemplatesTest.Validate.dat`: строка `Battery Charge Level Raw` имела одинарные пробелы вокруг `=>` (её добавили вручную, т.к. регенерация уже была сломана этой же запятой) — теперь канонический формат с двойными пробелами.

___________________________________
**Как проверял/а:**

- `j2`-рендер `config-wb-ups-v3.json.jinja` → валидный JSON (раньше падал на line 81).
- `make dump-templates` отрабатывает целиком (раньше падал на парсинге ups) и даёт `.dat`, совпадающий с закоммиченным (после правки 1 строки спейсинга).
- Жду зелёную сборку CI на этом PR как подтверждение, что инфра-блокер снят.
