### PR TITLE
Fix crash on live reload of a template with a unique device type

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.259.1) stable; urgency=medium
+
+  * Fix possible crash on live reload of a device template file
+    with a unique device type
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 13 Jul 2026 10:44:18 +0500
+
 wb-mqtt-serial (2.259.0) stable; urgency=medium
 
   * ONOKOM templates update (external contribution):

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -301,7 +301,9 @@ std::vector<std::string> TTemplateMap::UpdateTemplate(const std::string& path)
     auto deviceTemplate = MakeTemplateFromJson(WBMQTT::JSON::Parse(path), path);
     auto& typeArray = Templates.try_emplace(deviceTemplate->Type, std::vector<PDeviceTemplate>{}).first->second;
     if (!PreferredTemplatesDir.empty() && WBMQTT::StringStartsWith(path, PreferredTemplatesDir)) {
-        TemplateUpdatedWarning(typeArray.back(), path);
+        if (!typeArray.empty()) {
+            TemplateUpdatedWarning(typeArray.back(), path);
+        }
         typeArray.push_back(deviceTemplate);
     } else {
         typeArray.insert(typeArray.begin(), deviceTemplate);

--- a/test/device_templates_file_extension_test.cpp
+++ b/test/device_templates_file_extension_test.cpp
@@ -176,3 +176,16 @@ TEST_F(TDeviceTemplatesTest, AlarmControlType)
     templateMap.AddTemplatesDir(TLoggedFixture::GetDataFilePath("device-templates"), false);
     EXPECT_NO_THROW(templateMap.GetTemplate("alarm_type_test")->GetTemplate());
 }
+
+// Reloading a file whose device type is defined only in that file must not access
+// the emptied type array before the reloaded template is inserted
+TEST_F(TDeviceTemplatesTest, UpdateTemplateWithUniqueDeviceType)
+{
+    TTemplateMap templateMap(GetTemplatesSchema());
+    templateMap.AddTemplatesDir(TLoggedFixture::GetDataFilePath("device-templates"), false);
+    auto path = TLoggedFixture::GetDataFilePath("device-templates/config-msu34.json");
+    std::vector<std::string> updatedTypes;
+    ASSERT_NO_THROW(updatedTypes = templateMap.UpdateTemplate(path));
+    EXPECT_EQ(std::vector<std::string>{"MSU34"}, updatedTypes);
+    EXPECT_EQ(path, templateMap.GetTemplate("MSU34")->GetFilePath());
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

`TTemplateMap::UpdateTemplate` сначала удаляет старую запись шаблона из карты, затем добавляет перечитанную. Если тип устройства определён только в изменённом файле (типичный пользовательский шаблон в `/etc/wb-mqtt-serial.conf.d/templates`, не перекрывающий штатный), после удаления вектор шаблонов типа пуст, и `typeArray.back()` перед выводом предупреждения — UB. На практике сервис падает с SIGSEGV при создании или сохранении такого шаблона на работающем сервисе (срабатывание вотчера). Баг существует с v2.127.2, когда вотчер начал следить за обеими директориями шаблонов.

___________________________________
**Что поменялось для пользователей:**

Драйвер больше не падает (и не прерывает опрос до рестарта systemd) при создании/редактировании в `/etc/wb-mqtt-serial.conf.d/templates` шаблона с уникальным типом устройства.

___________________________________
**Как проверял/а:**

- Воспроизведено на контроллере со стоковым 2.259.0: запись минимального шаблона с уникальным `device_type` в `/etc/wb-mqtt-serial.conf.d/templates` → в журнале `Main process exited, code=killed, status=11/SEGV`, сервис перезапущен systemd.
- Регрессионный тест `TDeviceTemplatesTest.UpdateTemplateWithUniqueDeviceType`: на коде без фикса падает с Segmentation fault под valgrind, с фиксом проходит.
- Полный `make test`: 363 теста из 76 сьютов PASSED под valgrind (debian trixie, libwbmqtt1 5.7.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
