### PR TITLE
Convert numeric channel enum values to strings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.259.1) stable; urgency=medium
+
+  * Convert numeric channel enum values to strings
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 14 Jul 2026 10:37:12 +0300
+
 wb-mqtt-serial (2.259.0) stable; urgency=medium
 
   * ONOKOM templates update (external contribution):

--- a/src/old_serial_config.cpp
+++ b/src/old_serial_config.cpp
@@ -19,6 +19,14 @@ namespace
 
     void FixChannel(Json::Value& channel)
     {
+        if (channel.isMember("enum") && channel["enum"].isArray()) {
+            for (Json::Value& value: channel["enum"]) {
+                if (value.isNumeric()) {
+                    value = value.asString();
+                }
+            }
+        }
+
         ConvertPollIntervalToReadRateLimit(channel);
     }
 

--- a/src/old_serial_config.cpp
+++ b/src/old_serial_config.cpp
@@ -19,15 +19,8 @@ namespace
 
     void FixChannel(Json::Value& channel)
     {
-        if (channel.isMember("enum") && channel["enum"].isArray()) {
-            for (Json::Value& value: channel["enum"]) {
-                if (value.isNumeric()) {
-                    value = value.asString();
-                }
-            }
-        }
-
         ConvertPollIntervalToReadRateLimit(channel);
+        FixChannelEnum(channel);
     }
 
     void FixChannels(Json::Value& device, TTemplateMap& templates)

--- a/src/serial_config.cpp
+++ b/src/serial_config.cpp
@@ -876,6 +876,17 @@ bool IsSubdeviceChannel(const Json::Value& channelSchema)
     return (channelSchema.isMember("oneOf") || channelSchema.isMember("device_type"));
 }
 
+void FixChannelEnum(Json::Value& channel)
+{
+    if (channel.isMember("enum") && channel["enum"].isArray()) {
+        for (Json::Value& value: channel["enum"]) {
+            if (value.isNumeric()) {
+                value = value.asString();
+            }
+        }
+    }
+}
+
 std::string GetProtocolName(const Json::Value& deviceDescription)
 {
     std::string p;

--- a/src/serial_config.h
+++ b/src/serial_config.h
@@ -251,6 +251,7 @@ PHandlerConfig LoadConfig(const std::string& configFileName,
                           TPortFactoryFn portFactory = DefaultPortFactory);
 
 bool IsSubdeviceChannel(const Json::Value& channelSchema);
+void FixChannelEnum(Json::Value& channel);
 
 void SetIfExists(Json::Value& dst, const std::string& dstKey, const Json::Value& src, const std::string& srcKey);
 std::string DecorateIfNotEmpty(const std::string& prefix,

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -20,6 +20,24 @@ namespace
         return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
     }
 
+    void FixChannelsEnum(Json::Value& node)
+    {
+        if (node.isObject()) {
+            if (node.isMember("channels") && node["channels"].isArray()) {
+                for (Json::Value& channel: node["channels"]) {
+                    FixChannelEnum(channel);
+                }
+            }
+            for (const auto& member: node.getMemberNames()) {
+                FixChannelsEnum(node[member]);
+            }
+        } else if (node.isArray()) {
+            for (Json::Value& item: node) {
+                FixChannelsEnum(item);
+            }
+        }
+    }
+
     void CheckNesting(const Json::Value& root, size_t nestingLevel, TSubDevicesTemplateMap& templates)
     {
         if (nestingLevel > 5) {
@@ -414,6 +432,7 @@ const Json::Value& TDeviceTemplate::GetTemplate()
 {
     if (Template.isNull()) {
         Json::Value root(WBMQTT::JSON::Parse(GetFilePath()));
+        FixChannelsEnum(root);
         // Skip deprecated template validation, it may be broken according to latest schema
         if (!IsDeprecated()) {
             try {

--- a/test/serial_config_test.cpp
+++ b/test/serial_config_test.cpp
@@ -301,6 +301,31 @@ TEST_F(TConfigParserTest, ParseEnum)
     EXPECT_EQ(titles3["4"].size(), 0);
 }
 
+TEST(TFixChannelEnumTest, ConvertsNumbersToStrings)
+{
+    Json::Value channel;
+    channel["enum"][0] = 0;
+    channel["enum"][1] = 1;
+    channel["enum"][2] = "2";
+    channel["enum"][3] = "0x10";
+    FixChannelEnum(channel);
+    ASSERT_TRUE(channel["enum"][0].isString());
+    ASSERT_TRUE(channel["enum"][1].isString());
+    EXPECT_EQ(channel["enum"][0].asString(), "0");
+    EXPECT_EQ(channel["enum"][1].asString(), "1");
+    EXPECT_EQ(channel["enum"][2].asString(), "2");
+    EXPECT_EQ(channel["enum"][3].asString(), "0x10");
+}
+
+TEST(TFixChannelEnumTest, LeavesChannelWithoutEnumUntouched)
+{
+    Json::Value channel;
+    channel["name"] = "test";
+    FixChannelEnum(channel);
+    EXPECT_FALSE(channel.isMember("enum"));
+    EXPECT_EQ(channel["name"].asString(), "test");
+}
+
 TEST_F(TConfigParserTest, DefaultParamsForChannels)
 {
     auto portConfigs = GetConfig("configs/config-default-params.json")->PortConfigs;

--- a/wb-mqtt-serial-confed-common.schema.json
+++ b/wb-mqtt-serial-confed-common.schema.json
@@ -552,7 +552,7 @@
         "enum": {
           "title": "List of values",
           "type": "array",
-          "items": { "type": "integer" },
+          "items": { "type": "string" },
           "propertyOrder": 27
         },
         "enum_titles": {

--- a/wb-mqtt-serial-confed-common.schema.json
+++ b/wb-mqtt-serial-confed-common.schema.json
@@ -552,12 +552,7 @@
         "enum": {
           "title": "List of values",
           "type": "array",
-          "items": {
-            "oneOf": [
-              { "type": "string" },
-              { "type": "number" }
-            ]
-          },
+          "items": { "type": "integer" },
           "propertyOrder": 27
         },
         "enum_titles": {


### PR DESCRIPTION
## Проблема

У каналов кастомных устройств значения `enum` могли задаваться числами (как в конфигах, так и в шаблонах), тогда как редактор схемы ожидает строки. Из-за этого список значений enum в редакторе отображался пустым, и при сохранении затирался пустым массивом — устройство ломалось.

## Решение

- Схема: `register_channel_common.enum.items` теперь `string`.
- Добавлена `FixChannelEnum` — приводит числовые значения `enum` канала к строкам. Вызывается до валидации:
  - для конфигов — в `FixOldConfigFormat` (`FixChannel`);
  - для шаблонов — в `FixChannelsEnum` (рекурсивно по каналам, включая subdevice).
- Параметры не трогаем: у них своё числовое определение enum в схеме шаблонов.
- hex-значения (строки вида `0x10`) остаются как есть, в число не парсятся.

## Тесты

- Юнит-тесты на `FixChannelEnum` (числа→строки, hex сохраняется, канал без enum не меняется).
- Существующие `TConfigParserTest.ParseEnum` и `TDeviceTemplatesTest.Validate` покрывают конфиги и шаблоны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)