### PR TITLE
Fix write retry on disconnect

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.260.1) stable; urgency=medium
+
+  * Fix write retry on a disconnected device
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 21 Jul 2026 11:11:31 +0300
+
 wb-mqtt-serial (2.260.0) stable; urgency=medium
 
   * config/Load RPC: device types with the active template loaded from

--- a/src/register_handler.cpp
+++ b/src/register_handler.cpp
@@ -71,6 +71,26 @@ void TRegisterHandler::Flush(TPort& port)
     }
 }
 
+bool TRegisterHandler::NeedRetryAfterWriteFail()
+{
+    std::lock_guard<std::mutex> lock(SetValueMutex);
+    if (!Dirty) {
+        return false;
+    }
+    if (!WriteFail) {
+        WriteFirstTryTime = steady_clock::now();
+        WriteFail = true;
+    }
+    if (duration_cast<seconds>(steady_clock::now() - WriteFirstTryTime) >
+        Reg->Device()->DeviceConfig()->MaxWriteFailTime)
+    {
+        Dirty = false;
+        WriteFail = false;
+        return false;
+    }
+    return true;
+}
+
 void TRegisterHandler::SetTextValue(const std::string& v)
 {
     std::lock_guard<std::mutex> lock(SetValueMutex);

--- a/src/register_handler.h
+++ b/src/register_handler.h
@@ -24,6 +24,11 @@ public:
      */
     void Flush(TPort& port);
 
+    /**
+     * @brief Returns false when MaxWriteFailTime has elapsed and the pending write is dropped.
+     */
+    bool NeedRetryAfterWriteFail();
+
     void SetTextValue(const std::string& v);
 
 private:

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -26,13 +26,19 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
         if (ErrorCallback) {
             ErrorCallback(Handler->Register());
         }
+        auto retry = true;
         std::string error;
         if (!port->IsOpen()) {
             error = "port is not open";
         } else if (!Handler->Register()->IsSupported()) {
+            retry = false;
             error = "register is not supported by device firmware";
         } else {
             error = "device is disconnected";
+        }
+        if (retry && Handler->NeedRetryAfterWriteFail()) {
+            LOG(Debug) << Handler->Register()->ToString() << " register write deferred: " << error;
+            return ISerialClientTask::TRunResult::RETRY;
         }
         LOG(Warn) << Handler->Register()->ToString() << " register write cancelled: " << error;
         return ISerialClientTask::TRunResult::OK;

--- a/test/TSerialClientTest.WriteToDisconnectedDeviceRetriesAfterReconnect.dat
+++ b/test/TSerialClientTest.WriteToDisconnectedDeviceRetriesAfterReconnect.dat
@@ -1,0 +1,39 @@
+>>> Cycle() [connected]
+Open()
+Sleep(100000)
+fake_serial_device '1': read address '20' value '0'
+fake_serial_device '1': transfer OK
+fake_serial_device '1': reconnected
+Read Callback: <fake:1:fake: 20> becomes 0
+Error Callback: <fake:1:fake: 20>: no error
+fake_serial_device: block address '20' for reading
+>>> Cycle() [read blocked]
+fake_serial_device '1': read address '20' failed: 'Serial protocol error: read blocked'
+fake_serial_device '1': transfer FAIL
+Error Callback: <fake:1:fake: 20>: read error
+>>> Cycle() [read blocked]
+fake_serial_device '1': read address '20' failed: 'Serial protocol error: read blocked'
+fake_serial_device '1': transfer FAIL
+fake_serial_device '1': disconnected
+>>> Cycle() [read blocked]
+Sleep(100000)
+fake_serial_device '1': read address '20' failed: 'Serial protocol error: read blocked'
+fake_serial_device '1': transfer FAIL
+>>> Cycle() [write while disconnected]
+Error Callback: <fake:1:fake: 20>: read+write error
+fake_serial_device: unblock address '20' for reading
+>>> Cycle() [reconnected]
+Sleep(100000)
+fake_serial_device '1': read address '20' value '0'
+fake_serial_device '1': transfer OK
+fake_serial_device '1': reconnected
+Error Callback: <fake:1:fake: 20>: write error
+>>> Cycle() [reconnected]
+fake_serial_device '1': write to address '20' value '42'
+Read Callback: <fake:1:fake: 20> becomes 42
+Error Callback: <fake:1:fake: 20>: no error
+fake_serial_device '1': read address '20' value '42'
+Read Callback: <fake:1:fake: 20> becomes 42 [unchanged]
+>>> Cycle() [reconnected]
+fake_serial_device '1': read address '20' value '42'
+Read Callback: <fake:1:fake: 20> becomes 42 [unchanged]

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -983,6 +983,40 @@ TEST_F(TSerialClientTest, Errors)
     SerialClient->Cycle();
 }
 
+TEST_F(TSerialClientTest, WriteToDisconnectedDeviceRetriesAfterReconnect)
+{
+    PRegister reg20 = Reg(20);
+    SerialClient->AddDevice(Device);
+    Device->DeviceConfig()->DeviceTimeout = std::chrono::milliseconds(0);
+
+    Note() << "Cycle() [connected]";
+    SerialClient->Cycle();
+    EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());
+
+    Device->BlockReadFor(20, true);
+    for (int i = 0; i < 3; ++i) {
+        Note() << "Cycle() [read blocked]";
+        SerialClient->Cycle();
+    }
+    EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
+
+    SerialClient->SetTextValue(reg20, "42");
+    Note() << "Cycle() [write while disconnected]";
+    SerialClient->Cycle();
+    EXPECT_NE(42, Device->Registers[20]);
+    EXPECT_TRUE(reg20->GetErrorState().test(TRegister::TError::WriteError));
+
+    Device->BlockReadFor(20, false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    for (int i = 0; i < 3; ++i) {
+        Note() << "Cycle() [reconnected]";
+        SerialClient->Cycle();
+    }
+    EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());
+    EXPECT_EQ(42, Device->Registers[20]);
+    EXPECT_FALSE(reg20->GetErrorState().test(TRegister::TError::WriteError));
+}
+
 TEST_F(TSerialClientTestWithSetupRegisters, SetupOk)
 {
     PRegister reg20 = Reg(20);


### PR DESCRIPTION
_________________________
**Что происходит; кому и зачем нужно:**
Если записать данные в `/on` топик, когда устройство не на связи (в статусе DISCONNECTED), служба делает ровно одну попытку записи, выставляет флаг ошибки `w` и не делает повторых попыток до следующей публикации в `/on` топик. 

Баг появился при исправлении другого бага: https://github.com/wirenboard/wb-mqtt-serial/pull/1081

___________________________________
**Что поменялось для пользователей:**
Теперь, перед явным прекращением повторных попыток записи, осуществляется проверка выхода времени, прошедшего с первой попытки, за пределы, установленные параметром `max_write_fail_time_s`. Если время не вышло, служба продолжает пытаться записать данные в устройство (другими словами - все работает так, как должно).

___________________________________
**Как проверял/а:**
Воспроизвел баг на железе, проверил что после доработки кода он больше не вопсроизводится, написал новый тест.