### PR TITLE
Feature/ft 636/regenerate empty config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.260.4) stable; urgency=medium
+
+  * Regenerate config if the existing one is empty
+
+ -- Vladimir Zuevskiy <vladimir.zuevskiy@wirenboard.com>  Fri, 24 Jul 2026 11:45:31 +0300
+
 wb-mqtt-serial (2.260.3) stable; urgency=medium
 
   * Fix clang-format, no functional changes

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -2,7 +2,7 @@
 
 CONFFILE=/etc/wb-mqtt-serial.conf
 
-[ -f "$CONFFILE" ] && exit 0
+[ -s "$CONFFILE" ] && exit 0
 
 . /usr/lib/wb-utils/wb_env.sh
 


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->

<!--
Если Вы изменили RPC или структуру файла настроек, обязательно напишите в README.md, в какой версии версии wb-mqtt-serial появились эти изменения.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

Во время тестирования контроллеров на производстве, тест сьют вначале тестирования останавливает кучу wb-* сервисов, один из них wb-mqtt-serial.
При удачном стечении обстоятельств, тест сьют прибивает его в момент выполнения `ExecStartPre=/usr/lib/wb-mqtt-serial/generate-system-config.sh` что приводит к появлени пустого файла `wb-mqtt-serial.conf`

Внутри скрипта `generate-system-config.sh` есть проверка на существование wb-mqtt-serial.conf файла. Поэтому он не заполняется при последующих перезапусках сервиса. 

Предлагаю проверять не только на существование файла, но и на то что он не пустой, т.е. заменить проверку `-f` на `-s`, чтобы гарантированно получить рабочий конфиг при следующем запуске контроллера/перезапуске сервиса
___________________________________
**Что поменялось для пользователей:**

Не придется обращаться в ТП за корректным конфиг файлом
___________________________________
**Как проверял/а:**

1. В скрипте на контроллере поменял -f на -s
2. Удалил конфиг wb-mqtt-serial.conf
3. Перезапустил сервис
4. Убедился, что конфиг сформировался
5. Очистил конфиг `truncte -s0 wb-mqtt-serial.conf`
6. Перезапустил сервис
7. Убедился, что конфиг  заполнился