### PR TITLE
Fix clang-tidy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.260.4) stable; urgency=medium
+
+  * Fix clang-tidy, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 27 Jul 2026 10:20:00 +0400
+
 wb-mqtt-serial (2.260.3) stable; urgency=medium
 
   * Fix clang-format, no functional changes

--- a/src/port/tcp_port_settings.h
+++ b/src/port/tcp_port_settings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->

<!--
Если Вы изменили RPC или структуру файла настроек, обязательно напишите в README.md, в какой версии версии wb-mqtt-serial появились эти изменения.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
Не проходит проверка clang-tidy на дженкинсе:
```
Error while processing /home/jenkins/builder/workspace/wirenboard_wb-mqtt-serial_master/project/src/port/tcp_port_settings.h.
/home/jenkins/builder/workspace/wirenboard_wb-mqtt-serial_master/project/src/port/tcp_port_settings.h:8:64: error: unknown type name 'uint16_t' [clang-diagnostic-error]
    8 |     TTcpPortSettings(const std::string& address = "localhost", uint16_t port = 0): Address(address), Port(port)
      |                                                                ^
/home/jenkins/builder/workspace/wirenboard_wb-mqtt-serial_master/project/src/port/tcp_port_settings.h:19:5: error: unknown type name 'uint16_t' [clang-diagnostic-error]
   19 |     uint16_t Port;
      |     ^
Found compiler error(s).
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
