### PR TITLE
Regenerate empty config (#1211)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
+               defaultScaWbdevTarget: 'bullseye-armhf',
                defaultRunCoverage: true,
                defaultCoverageMin: '73',
                defaultDoCoverallsReporting: false,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.248.1-wb103) stable; urgency=medium
+
+  * Regenerate config if the existing one is empty
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Fri, 24 Jul 2026 11:45:31 +0300
+
 wb-mqtt-serial (2.248.1-wb102) stable; urgency=medium
 
   * Convert numeric channel enum values to strings

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -2,7 +2,7 @@
 
 CONFFILE=/etc/wb-mqtt-serial.conf
 
-[ -f "$CONFFILE" ] && exit 0
+[ -s "$CONFFILE" ] && exit 0
 
 . /usr/lib/wb-utils/wb_env.sh
 


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

 бекпорт фикса пустых конфигов
https://github.com/wirenboard/wb-mqtt-serial/pull/1211
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
