### PR TITLE
Use exported vars instead of MAKEFLAGS for coverage options

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.262.1) stable; urgency=medium
+
+  * Fix coverage reporting with GNU make 4.4 (trixie): export coverage
+    variables from debian/rules instead of MAKEFLAGS
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Fri, 31 Jul 2026 09:28:51 +0000
+
 wb-mqtt-serial (2.262.0) stable; urgency=medium
 
   * Add buttons functionality to WB-MCM8HV template

--- a/debian/rules
+++ b/debian/rules
@@ -3,14 +3,17 @@
 COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
 COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
 
+# NB: use exported env vars, not MAKEFLAGS: since GNU make 4.4 (trixie)
+# variable definitions added to MAKEFLAGS in a makefile are no longer
+# propagated to sub-makes spawned by debhelper (dh_auto_build/dh_auto_test).
 ifneq ($(COV_FAIL_UNDER),)
-	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+export COV_FAIL_UNDER
 endif
 ifneq ($(COV_REPORT),)
-	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+export COV_REPORT
 endif
 ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
-	MAKEFLAGS += DEBUG=1
+export DEBUG=1
 endif
 
 %:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

После перехода на trixie отправка репорта в Coveralls падает с «nothing to report». Make 4.4 перестал пробрасывать `MAKEFLAGS += VAR=x` в dh. Меняем `MAKEFLAGS +=` на `export`

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**

собирала пакетики

