### PR TITLE
Fix deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.262.2) stable; urgency=medium
+
+  * Fix deps
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 03 Aug 2026 12:20:00 +0400
+
 wb-mqtt-serial (2.262.1) stable; urgency=medium
 
   * Fix coverage reporting with GNU make 4.4 (trixie): export coverage

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4t64, ucf, bsdutils (>= 2.29), wb-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.150.0~~)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
У сорс пакета есть зависимость от libcurl4-openssl-dev, у байнари пакета можно явно не указывать, нужная зависимость пропишется автоматически при сборке.
Например в булзае это libcurl4, в трикси это libcurl4t64.
Еще пример libcurl4-gnutls-dev - даже в рамках одного trixie зависимости разные: libcurl3t64-gnutls или libcurl4-gnutls (если из trixie-bckports репы).

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
