### PR TITLE
Unify UI texts in WB-MR relay family templates (display-only)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+wb-mqtt-serial (2.262.4) stable; urgency=medium
+
+  * WB-MR relay family templates (WB-MR3, WB-MR6C/-NC/CU/v.3, WB-MRM2-mini/NO,
+    WB-MRM2-mini/NC, WB-MRWM2): unify displayed UI texts for entities named
+    differently across templates — Serial Number, Firmware Version, Supply
+    Voltage, Min Supply Voltage Since Startup, Min MCU Voltage Since Startup;
+    RU "одиночных нажатий" for the single-press counter; fix a Cyrillic
+    homoglyph ("сhange"→"change") in the WB-MRWM2 safety-behaviour enum title.
+    Only current (g-wb) templates are touched; obsolete g-wb-old ones are left
+    as is. Channel names (MQTT topics) are not changed — backward compatible,
+    Validate.dat unchanged.
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Wed, 05 Aug 2026 18:02:10 +0300
+
 wb-mqtt-serial (2.262.3) stable; urgency=medium
 
   * WB-MAO4, WB-MDM3, WB-MRGBW-D, WB-LED templates: unify UI texts for

--- a/templates/config-wb-mr3.json.jinja
+++ b/templates/config-wb-mr3.json.jinja
@@ -1057,6 +1057,9 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -1112,7 +1115,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -1266,7 +1269,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК"
             }

--- a/templates/config-wb-mr6c-nc.json.jinja
+++ b/templates/config-wb-mr6c-nc.json.jinja
@@ -805,6 +805,9 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -848,7 +851,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -976,7 +979,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК"
             }

--- a/templates/config-wb-mr6c.json.jinja
+++ b/templates/config-wb-mr6c.json.jinja
@@ -1053,6 +1053,9 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -1108,7 +1111,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -1261,7 +1264,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК"
             }

--- a/templates/config-wb-mr6cu.json.jinja
+++ b/templates/config-wb-mr6cu.json.jinja
@@ -620,6 +620,9 @@
                 "WB-MR6CU_template_title": "WB-MR6CU v.2, WB-MRPS6 (6-channel relay)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
 
@@ -737,7 +740,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК"
             }

--- a/templates/config-wb-mr6cv3.json.jinja
+++ b/templates/config-wb-mr6cv3.json.jinja
@@ -1079,6 +1079,9 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before safety mode",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -1135,7 +1138,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -1297,7 +1300,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "Bus Power Supply": "Состояние питания на шине"

--- a/templates/config-wb-mrm2-mini-nc.json.jinja
+++ b/templates/config-wb-mrm2-mini-nc.json.jinja
@@ -821,6 +821,10 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -864,7 +868,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -994,10 +998,10 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения"
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения"
             }
         }
     }

--- a/templates/config-wb-mrm2-mini.json.jinja
+++ b/templates/config-wb-mrm2-mini.json.jinja
@@ -1050,6 +1050,10 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -1105,7 +1109,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -1262,10 +1266,10 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения"
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения"
             }
         }
     }

--- a/templates/config-wb-mrwm2.json.jinja
+++ b/templates/config-wb-mrwm2.json.jinja
@@ -377,7 +377,7 @@
                 "default": 0,
                 "enum": [0, 1],
                 "enum_titles": [
-                    "Don't сhange output state",
+                    "Don't change output state",
                     "Switch output to safety state"
                 ]
             },
@@ -961,6 +961,9 @@
                 "outputs_state_after_power_on_description": "Option \"According to inputs\" works for latching switch mode only, firmware v1.18.4 or newer is required",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
 
                 "poll_timeout_description": "Time in seconds without modbus polling before activation safety mode. Actions in safety mode are configured using appropriate parameters",
                 "inputs_control_in_safety_mode_description": "Sets change of control from the inputs when module switches to safety mode",
@@ -1007,7 +1010,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -1111,7 +1114,7 @@
                 "On": "Включен",
 
                 "Safety Behaviour": "Действие в безопасном режиме",
-                "Don't сhange output state": "Ничего не делать",
+                "Don't change output state": "Ничего не делать",
                 "Switch output to safety state": "Перевести выход в безопасное состояние",
                 "Inputs Control In Safety Mode": "Управление с входов в безопасном режиме",
                 "Don't change": "Не блокировать",
@@ -1155,7 +1158,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "AP energy L1": "Энергия AP L1",


### PR DESCRIPTION
## Что и зачем

Приводим **отображаемые UI-тексты** каналов **семейства реле WB-MR** к единому виду по WB-STD-001 §6 — одинаковые по смыслу сущности сейчас называются по-разному в разных шаблонах. Правки **только display-only** (`translations`), продолжение линии #1219.

Берём **только актуальные шаблоны** (`group: g-wb`); устаревшие (`group: g-wb-old`) и `deprecated` — не трогаем.

Затронуты (все `g-wb`):
`wb-mr3`, `wb-mr6c`, `wb-mr6c-nc`, `wb-mr6cu`, `wb-mr6cv3`, `wb-mrm2-mini`, `wb-mrm2-mini-nc`, `wb-mrwm2`.

Унифицировано:
- **Служебные каналы** (EN-переопределения, `name` заморожен): `Serial` → **Serial Number**, `FW Version` → **Firmware Version**, `Supply voltage` → **Supply Voltage**, `Minimum Voltage Since Startup` → **Min Supply Voltage Since Startup**, `Minimum MCU Voltage Since Startup` → **Min MCU Voltage Since Startup** (+ соответствующие RU: «Мин. напряжение питания…»).
- **Счётчики нажатий**: RU одиночного счётчика «коротких» → **«одиночных»** нажатий.

## Обратная совместимость

**Полностью сохранена.** Менялись только `translations` — имена каналов (`name`, т.е. MQTT-топики) заморожены.

- `test/TDeviceTemplatesTest.Validate.dat` не изменён.
- Проверено: чистый ре-рендер всех шаблонов + `dump_templates.py` на ветке и на `master` дают **побайтово идентичный** `.dat` (32229 строк) — ни один топик не поменялся.
- Все шаблоны загружены реальным драйвером `wb-mqtt-serial` на стенде (ssh wb851) без ошибок (ни ERROR-уровня, ни parse/schema).

## Не входит (по критерию `group`)

`g-wb-old`: `wb-mr11`, `wb-mr14`, `wb-mrm2` (base), `wb-mrm2-old`; а также `*-deprecated.json`.

