### PR TITLE
Unify UI texts across several WB families (display-only)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+wb-mqtt-serial (2.262.5) stable; urgency=medium
+
+  * Unify displayed UI texts across several WB families (display-only): WB-MAI
+    (MAI11/MAI2-CC/MAI6), WB-MIO, WB-UPS v.3, WB-DALI, WB-MCM8, WB-MS v.2,
+    WB-MWAC (MWAC/MWAC2/MWAC2 ver.2), WB-M1W2, WB-LED, WB-MRGBW-D. Canonical
+    texts — Serial Number, Firmware Version, Supply Voltage, Min Supply Voltage
+    Since Startup, Min MCU Voltage Since Startup; RU "одиночных нажатий" for the
+    single-press counter; fix a Cyrillic homoglyph ("сhange"->"change") in the
+    WB-MWAC/WB-MWAC2 safety-behaviour enum title. Only current (g-wb) templates
+    are touched. Channel names (MQTT topics) are not changed — backward
+    compatible, Validate.dat unchanged.
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 06 Aug 2026 12:00:00 +0300
+
 wb-mqtt-serial (2.262.4) stable; urgency=medium
 
   * WB-MR relay family templates (WB-MR3, WB-MR6C/-NC/CU/v.3, WB-MRM2-mini/NO,

--- a/templates/config-wb-dali.json.jinja
+++ b/templates/config-wb-dali.json.jinja
@@ -429,6 +429,10 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-DALI_template_title": "WB-DALI (3-channel RS485-DALI gateway)",
                 "debounce_time_title": "Debounce Time (ms)",
                 "lp_hold_time_title": "Long Press Time (ms)",
@@ -498,10 +502,10 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
 
                 "Baud rate": "Скорость обмена"
             }

--- a/templates/config-wb-led.json.jinja
+++ b/templates/config-wb-led.json.jinja
@@ -1516,6 +1516,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-LED_template_title": "WB-LED (4-channel CV LED Dimmer)",
 
                 "sp_title": "Short Press",
@@ -1800,7 +1802,7 @@
                 {% for in_num in range(1, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} Counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",

--- a/templates/config-wb-m1w2-buttons.json.jinja
+++ b/templates/config-wb-m1w2-buttons.json.jinja
@@ -345,6 +345,10 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
                 "temperature_readings_filter_deg_description": "If the new value equals 85 °C, it is discarded if it differs from the previous one by more than the filter value. Write 0 to disable the filter. The default value is 1",
                 "temperature_readings_period_s_title": "Temperature sensors poll period (s)",
@@ -367,7 +371,7 @@
                 {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -403,10 +407,10 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения"
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения"
             }
         }
     }

--- a/templates/config-wb-m1w2.json
+++ b/templates/config-wb-m1w2.json
@@ -277,6 +277,8 @@
         ],
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-M1W2_template_title": "WB-M1W2 (2-channel temperature measurement module)",
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
                 "temperature_readings_filter_deg_description": "New value is discarded if it differs from previous one by more than filter value. Write 0 to disable filter",

--- a/templates/config-wb-m1w2_v3-multiple_w1.json.jinja
+++ b/templates/config-wb-m1w2_v3-multiple_w1.json.jinja
@@ -560,6 +560,10 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
                 "temperature_readings_filter_deg_description": "If the new value equals 85 °C, it is discarded if it differs from the previous one by more than the filter value. Write 0 to disable the filter. The default value is 1",
                 "temperature_readings_period_s_title": "Temperature sensors poll period (s)",
@@ -583,7 +587,7 @@
                 {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -621,10 +625,10 @@
                 "FW Version": "Версия прошивки",
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
 
                 {% for sens_num in range(FIRST_SENSOR, SENSORS_NUMBER + FIRST_SENSOR) -%}
                 "Sensor {{sens_num}} ID": "ID датчика {{sens_num}}",

--- a/templates/config-wb-mai11.json.jinja
+++ b/templates/config-wb-mai11.json.jinja
@@ -1061,6 +1061,8 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MAI11_template_title": "WB-MAI11 (11-channel analog input module)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
 {%- for ch_num in range(1, CHANNELS_NUMBER + 1) %}

--- a/templates/config-wb-mai2-cc-fw-4.32.json.jinja
+++ b/templates/config-wb-mai2-cc-fw-4.32.json.jinja
@@ -266,6 +266,9 @@
 
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MAI2-mini_template_title": "WB-MAI2-mini/CC fw 4.32 (2-channel analog input module)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "minimum_value_title": "Lower Limit of the Measurement Range",
@@ -300,7 +303,7 @@
                 "HW Batch Number": "Номер партии",
                 "FW Version": "Версия прошивки",
                 "Input Voltage": "Напряжение питания",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "Uptime": "Время работы с момента включения"
             }
         }

--- a/templates/config-wb-mai2-cc.json
+++ b/templates/config-wb-mai2-cc.json
@@ -132,6 +132,9 @@
         ],
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MAI2-mini_template_title": "WB-MAI2-mini/CC (2-channel analog input module)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)"
@@ -151,7 +154,7 @@
                 "Serial NO": "Серийный номер",
                 "FW Version": "Версия прошивки",
                 "Input Voltage": "Напряжение питания",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "Uptime": "Время работы с момента включения (с)"
             }
         }

--- a/templates/config-wb-mai6-fw-2.2.json.jinja
+++ b/templates/config-wb-mai6-fw-2.2.json.jinja
@@ -1259,6 +1259,8 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "template_title": "{{ title_en }}",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "IN_P_title": "Channel P",

--- a/templates/config-wb-mai6-fw-2.4.json.jinja
+++ b/templates/config-wb-mai6-fw-2.4.json.jinja
@@ -1276,6 +1276,8 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "template_title": "{{ title_en }}",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "IN_P_title": "Channel P",

--- a/templates/config-wb-mai6.json.jinja
+++ b/templates/config-wb-mai6.json.jinja
@@ -1199,6 +1199,8 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "template_title": "{{ title_en }}",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "IN_P_title": "Channel P",

--- a/templates/config-wb-mcm8.json.jinja
+++ b/templates/config-wb-mcm8.json.jinja
@@ -414,6 +414,10 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Supply voltage": "Supply Voltage",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "template_title": "{{ title_en }}",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
@@ -437,7 +441,7 @@
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
                 "Input {{in_num}} freq": "Частота {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -466,7 +470,7 @@
                 "FW Version": "Версия прошивки",
                 "Supply voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
 

--- a/templates/config-wb-mio.json.jinja
+++ b/templates/config-wb-mio.json.jinja
@@ -213,6 +213,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "template_title": "{{ title_en }}",
                 "g_general_description": "To control WBIO input/output modules, add a device manually and select the template for the corresponding module (its name starts with WBIO-...).<br>In the “Device address” field, specify the WBIO address in the format Modbus gateway address: WBIO index, for example, 15:1.",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",

--- a/templates/config-wb-mrgbw-d-fw3.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw3.json.jinja
@@ -2526,6 +2526,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MRGBW-D_template_title": "WB-MRGBW-D fw3 (4-channel CV LED Dimmer)",
 
                 "sp_title": "Short Press",
@@ -2786,9 +2788,9 @@
                 "Input 1 Counter": "Счетчик 1",
                 "Input 2 Counter": "Счетчик 2",
                 "Input 3 Counter": "Счетчик 3",
-                "Input 1 Single Press Counter": "Счетчик коротких нажатий входа 1",
-                "Input 2 Single Press Counter": "Счетчик коротких нажатий входа 2",
-                "Input 3 Single Press Counter": "Счетчик коротких нажатий входа 3",
+                "Input 1 Single Press Counter": "Счетчик одиночных нажатий входа 1",
+                "Input 2 Single Press Counter": "Счетчик одиночных нажатий входа 2",
+                "Input 3 Single Press Counter": "Счетчик одиночных нажатий входа 3",
                 "Input 1 Long Press Counter": "Счетчик длинных нажатий входа 1",
                 "Input 2 Long Press Counter": "Счетчик длинных нажатий входа 2",
                 "Input 3 Long Press Counter": "Счетчик длинных нажатий входа 3",

--- a/templates/config-wb-mrgbw-d.json
+++ b/templates/config-wb-mrgbw-d.json
@@ -271,6 +271,8 @@
 
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MRGBW-D_template_title": "WB-MRGBW-D (4-channel CV LED dimmer)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",

--- a/templates/config-wb-ms_v2-fw-4.36.json.jinja
+++ b/templates/config-wb-ms_v2-fw-4.36.json.jinja
@@ -788,6 +788,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
                 "temperature_readings_filter_deg_description": "If the new value equals 85 °C, it is discarded if it differs from the previous one by more than the filter value. Write 0 to disable the filter. The default value is 1",
                 "temperature_readings_period_s_title": "Temperature sensors poll period (s)",
@@ -814,7 +817,7 @@
                 {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -902,7 +905,7 @@
                 "Input Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
                 "Disabled": "Отключен",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "VOC Sensor Installed": "Датчик VOC установлен",

--- a/templates/config-wb-ms_v2.json
+++ b/templates/config-wb-ms_v2.json
@@ -446,6 +446,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "WB-MS-v2_template_title": "WB-MS v.2 (Modbus sensor)",
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
                 "temperature_readings_filter_deg_description": "New value is discarded if it differs from previous one by more than filter value. Write 0 to disable filter",
@@ -488,7 +491,7 @@
                 "Input Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
                 "Disabled": "Отключен",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "VOC Sensor Installed": "Датчик VOC установлен",

--- a/templates/config-wb-mwac.json.jinja
+++ b/templates/config-wb-mwac.json.jinja
@@ -410,7 +410,7 @@
                 "default": 0,
                 "enum": [0, 1],
                 "enum_titles": [
-                    "Don't сhange state",
+                    "Don't change state",
                     "Switch to safety state"
                 ]
             },
@@ -637,6 +637,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MWAC_template_title": "WB-MWAC (water leak and meters controller)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)",
@@ -687,7 +689,7 @@
                 {% set letter = "S" if in_num < 4 else "F" -%}
                 {% set in_num_offset = 0 if in_num < 4 else 3 -%}
                 "Input {{ letter }}{{ in_num - in_num_offset }}": "Вход {{ letter }}{{ in_num - in_num_offset }}",
-                "Input {{ letter }}{{ in_num - in_num_offset }} Single Press Counter": "Счетчик коротких нажатий входа {{ letter }}{{ in_num - in_num_offset }}",
+                "Input {{ letter }}{{ in_num - in_num_offset }} Single Press Counter": "Счетчик одиночных нажатий входа {{ letter }}{{ in_num - in_num_offset }}",
                 "Input {{ letter }}{{ in_num - in_num_offset }} Long Press Counter": "Счетчик длинных нажатий входа {{ letter }}{{ in_num - in_num_offset }}",
                 "Input {{ letter }}{{ in_num - in_num_offset }} Double Press Counter": "Счетчик двойных нажатий входа {{ letter }}{{ in_num - in_num_offset }}",
                 "Input {{ letter }}{{ in_num - in_num_offset }} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ letter }}{{ in_num - in_num_offset }}",
@@ -742,7 +744,7 @@
                 "mapping_matrix_actions_description": "Назначение действия для режима \"Влажная уборка\" доступно начиная с прошивки версии 1.21.0",
                 "poll_timeout_description": "Параметр определяет время отсутствия опроса в секундах, после которого будет активирован безопасный режим. 1 — 65534 с, 10 по умолчанию.",
                 "safety_behaviour_description": "Безопасное состояние настраивается на вкладке \"Выходы\".",
-                "Don't сhange state": "Ничего не делать",
+                "Don't change state": "Ничего не делать",
                 "Switch to safety state": "Перевести в безопасное состояние",
                 "Inputs Control In Safety Mode": "Управление с входов в безопасном режиме",
                 "Don't change": "Не блокировать",

--- a/templates/config-wb-mwac2.json.jinja
+++ b/templates/config-wb-mwac2.json.jinja
@@ -435,7 +435,7 @@
                 "default": 0,
                 "enum": [0, 1],
                 "enum_titles": [
-                    "Don't сhange state",
+                    "Don't change state",
                     "Switch to the safety state"
                 ]
             },
@@ -700,6 +700,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MWAC_template_title": "WB-MWAC v.2 (water leak and meters controller)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime",
@@ -753,7 +755,7 @@
                 {% for in_num in range(1, INPUTS_NUMBER + 1) -%}
                 {% set letter = "F" if in_num < IN_NUM_SHORT_CLEANING_ON_LONG_RES_ALARM else "S" -%}
                 "Input {{ letter }}{{ in_num }}": "Вход {{ letter }}{{ in_num }}",
-                "Input {{ letter }}{{ in_num }} Single Press Counter": "Счетчик коротких нажатий входа {{ letter }}{{ in_num }}",
+                "Input {{ letter }}{{ in_num }} Single Press Counter": "Счетчик одиночных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Long Press Counter": "Счетчик длинных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Double Press Counter": "Счетчик двойных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ letter }}{{ in_num }}",
@@ -810,7 +812,7 @@
                 "restore_outputs_state_after_leakage_fix_description": "\"Включен\" — реле устанавливются в положение до протечки, затем анализируются настройки взаимодействия входов с реле. \"Выключен\" — сразу анализируются настройки взаимодействия входов с реле.",
                 "safety_behaviour_description": "Безопасное состояние настраивается на вкладке \"Выходы\".",
                 "inputs_control_in_safety_mode_description": "Не влияет на режим \"Датчик протечки\".",
-                "Don't сhange state": "Ничего не делать",
+                "Don't change state": "Ничего не делать",
                 "Outputs Control By Inputs In Safety Mode": "Управление выходами с входов в безопасном режиме",
                 "Don't change": "Не блокировать",
                 "Disable in safety mode": "Блокировать в безопасном режиме",

--- a/templates/config-wb-mwac2_ver2.json.jinja
+++ b/templates/config-wb-mwac2_ver2.json.jinja
@@ -938,6 +938,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MWAC_template_title": "WB-MWAC v.2 (water leak and meters controller)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime",
@@ -1003,7 +1005,7 @@
                 {% for in_num in range(1, INPUTS_NUMBER + 1) -%}
                 {% set letter = "F" if in_num < IN_NUM_SHORT_CLEANING_ON_LONG_RES_ALARM else "S" -%}
                 "Input {{ letter }}{{ in_num }}": "Вход {{ letter }}{{ in_num }}",
-                "Input {{ letter }}{{ in_num }} Single Press Counter": "Счетчик коротких нажатий входа {{ letter }}{{ in_num }}",
+                "Input {{ letter }}{{ in_num }} Single Press Counter": "Счетчик одиночных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Long Press Counter": "Счетчик длинных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Double Press Counter": "Счетчик двойных нажатий входа {{ letter }}{{ in_num }}",
                 "Input {{ letter }}{{ in_num }} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ letter }}{{ in_num }}",

--- a/templates/config-wb-ups-v3.json.jinja
+++ b/templates/config-wb-ups-v3.json.jinja
@@ -535,6 +535,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "template_title": "{{ title_en }}",
 
                 "g_output_voltage_description": "When powered up via button, the output voltage is fixed at 11.5 V.<br><br>In automatic mode, the output voltage is set 0.7 V below the input, provided the input remains stable and within range for 10 seconds.<br>In manual mode, the output voltage is fixed and configured via the setpoint.<br><br>Backup mode is activated if input voltage drops below the output voltage.",


### PR DESCRIPTION
## Что и зачем

Унификация **отображаемых UI-текстов** служебных каналов ещё нескольких небольших семейств по WB-STD-001 §6 (продолжение #1219, #1221). Правки **только display-only** (`translations`); несколько семейств объединены в один PR.

Берём **только актуальные** шаблоны (`group: g-wb`).

Семейства (21 шаблон, все `g-wb`):
- **WB-MAI**: mai11, mai2-cc, mai2-cc-fw-4.32, mai6, mai6-fw-2.2, mai6-fw-2.4
- **WB-MIO**: mio · **WB-UPS v.3**: ups-v3 · **WB-DALI**: dali
- **WB-MCM8**: mcm8 · **WB-MS v.2**: ms_v2, ms_v2-fw-4.36
- **WB-MWAC**: mwac, mwac2, mwac2_ver2
- **WB-M1W2**: m1w2, m1w2-buttons, m1w2_v3-multiple_w1
- **WB-LED**: led (base) · **WB-MRGBW-D**: mrgbw-d (base), mrgbw-d-fw3

Унифицировано (EN-переопределения, `name` заморожен):
- `Serial` / `Serial NO` → **Serial Number**; `FW Version` → **Firmware Version**
- `Supply voltage` → **Supply Voltage**
- `Minimum Voltage Since Startup` → **Min Supply Voltage Since Startup** (+ RU «Мин. напряжение питания с момента включения»)
- `Minimum MCU Voltage Since Startup` → **Min MCU Voltage Since Startup** (+ RU «Мин. напряжение питания МК…»)
- Счётчики: RU одиночного счётчика «коротких» → **«одиночных»** нажатий
- Гомоглиф: кириллическая `с` в «Don't сhange state» → латинская (**WB-MWAC/WB-MWAC2**)

## Обратная совместимость

**Полностью сохранена.** Менялись только `translations`.
- `test/TDeviceTemplatesTest.Validate.dat` не изменён.
- Проверено: чистый ре-рендер всех шаблонов + `dump_templates.py` на ветке и на `master` → **побайтово идентичный** `.dat` (32229 строк).

## Вне scope
`group: g-wb-old` (напр. mcm16, mr11/14), `*-deprecated`, шаблоны без блока `translations` (`*-lv`, `m1w2-di`, `mrps6`). Более сложные семейства с переименованием топиков счётчиков (mao4) и прочими гомоглифами (mdm3 `Zero-Сross`, mir/msw `воcпроизведена`) — отдельными PR.
