### PR TITLE
Finish UI text unification for remaining WB families (display-only)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+wb-mqtt-serial (2.262.6) stable; urgency=medium
+
+  * Finish unifying displayed UI texts across the remaining WB families
+    (display-only): WB-MAO4 (mao4, mao4-20ma, mao4-20ma-fw-2.9), WB-MDM3,
+    WB-MSW (v3/v4/v4_lora), WB-MIR (v2/v2-buttons/v3/v3-fw-4.35) — Serial
+    Number, Firmware Version, Supply Voltage, Min Supply/MCU Voltage Since
+    Startup; RU "одиночных нажатий"; for WB-MAO4 the press-counter display is
+    aligned (Short->Single, Shortlong) via translations only — channel names
+    (MQTT topics) are unchanged. Also add the missing Serial Number / Firmware
+    Version display texts to the WB-MAO4/MDM3/LED/MRGBW-D fw-variant templates
+    from the earlier migration, and fix a "воспроизведена" typo in WB-MSW/MIR
+    descriptions. Only current (g-wb) templates. Validate.dat unchanged.
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 06 Aug 2026 15:00:00 +0300
+
 wb-mqtt-serial (2.262.5) stable; urgency=medium
 
   * Unify displayed UI texts across several WB families (display-only): WB-MAI

--- a/templates/config-wb-led-fw-3.8.json.jinja
+++ b/templates/config-wb-led-fw-3.8.json.jinja
@@ -2245,6 +2245,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-LED_template_title": "WB-LED fw3.8 (4-channel CV LED Dimmer)",
 
                 "sp_title": "Short Press",

--- a/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-20ma-fw-2.9.json.jinja
@@ -881,6 +881,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Supply voltage": "Supply Voltage",
                 "template_title": "{{ title_en }}",
                 "encoder_steps_counter_desc": "Takes into account the 'Pulses per Step' parameter",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
@@ -942,7 +945,7 @@
                 {% for ch_number in range(1, INPUTS_NUMBER + 1) -%}
                 "Input {{ch_number}}": "Вход {{ch_number}}",
                 "Input {{ch_number}} Counter": "Счетчик {{ch_number}}",
-                "Input {{ch_number}} Single Press Counter": "Счетчик коротких нажатий входа {{ch_number}}",
+                "Input {{ch_number}} Single Press Counter": "Счетчик одиночных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Long Press Counter": "Счетчик длинных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Double Press Counter": "Счетчик двойных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ch_number}}",

--- a/templates/config-wb-mao4-20ma.json.jinja
+++ b/templates/config-wb-mao4-20ma.json.jinja
@@ -699,6 +699,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Supply voltage": "Supply Voltage",
                 "template_title": "{{ title_en }}",
                 "pwm_frequency_factor_description": "PWM frequency is calculated by formula: 20 kHz / Factor",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
@@ -743,7 +746,7 @@
                 {% for ch_number in range(1, INPUTS_NUMBER + 1) -%}
                 "Input {{ch_number}}": "Вход {{ch_number}}",
                 "Input {{ch_number}} Counter": "Счетчик {{ch_number}}",
-                "Input {{ch_number}} Single Press Counter": "Счетчик коротких нажатий входа {{ch_number}}",
+                "Input {{ch_number}} Single Press Counter": "Счетчик одиночных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Long Press Counter": "Счетчик длинных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Double Press Counter": "Счетчик двойных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ch_number}}",

--- a/templates/config-wb-mao4-fw-2.9.json.jinja
+++ b/templates/config-wb-mao4-fw-2.9.json.jinja
@@ -1034,6 +1034,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 {# Align English display text with WB-MDM3 / WB-MRGBW-D and
                    WB-STD-001 6.3. Channel "name" is unchanged (it is the MQTT
                    topic and the key in wb-mqtt-serial.conf) - only the

--- a/templates/config-wb-mao4.json.jinja
+++ b/templates/config-wb-mao4.json.jinja
@@ -888,6 +888,14 @@
         ],
         "translations": {
             "en": {
+                {# Align English display with WB-STD-001 6.3; channel "name" (MQTT topic) is unchanged. -#}
+                {% for n in range(1, INPUTS_NUMBER + 1) -%}
+                "Input {{n}} Short Press Counter": "Input {{n}} Single Press Counter",
+                "Input {{n}} Short Long Press Counter": "Input {{n}} Shortlong Press Counter",
+                {% endfor -%}
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Supply voltage": "Supply Voltage",
                 "template_title": "{{ title_en }}",
                 "pwm_frequency_factor_description": "PWM frequency is calculated by formula: 24 kHz / Factor ",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
@@ -936,7 +944,7 @@
                 {% for ch_number in range(1, INPUTS_NUMBER + 1) -%}
                 "Input {{ch_number}}": "Вход {{ch_number}}",
                 "Input {{ch_number}} Counter": "Счетчик {{ch_number}}",
-                "Input {{ch_number}} Short Press Counter": "Счетчик коротких нажатий входа {{ch_number}}",
+                "Input {{ch_number}} Short Press Counter": "Счетчик одиночных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Long Press Counter": "Счетчик длинных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Double Press Counter": "Счетчик двойных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Short Long Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ch_number}}",

--- a/templates/config-wb-mdm3-fw-2.12.json.jinja
+++ b/templates/config-wb-mdm3-fw-2.12.json.jinja
@@ -893,6 +893,8 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 {# Align English display text with the sibling templates.
                    Channel "name" is unchanged - only the shown string. -#}
                 {% for n in range(1, INPUTS_NUMBER + 1) -%}

--- a/templates/config-wb-mdm3.json.jinja
+++ b/templates/config-wb-mdm3.json.jinja
@@ -733,6 +733,9 @@
 
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Supply voltage": "Supply Voltage",
                 "WB-MDM3_template_title": "WB-MDM3 (3-channel MOSFET dimmer)",
                 "inputs_mode_description": "Firmware up to version 2.6.6 supports only one and two button modes without the ability to freely bind inputs and outputs and process different types of presses. Starting from firmware version 2.7.0, there is no need to select the input mode. Inputs and outputs can be binded in any combinations",
                 "Legacy Inputs Mode": "Inputs Mode (up to firmware version 2.6.6 incl.)",
@@ -807,7 +810,7 @@
                 {% for ch_number in range(1, INPUTS_NUMBER + 1) -%}
                 "Input {{ch_number}}": "Вход {{ch_number}}",
                 "Input {{ch_number}} counter": "Счетчик {{ch_number}}",
-                "Input {{ch_number}} Single Press Counter": "Счетчик коротких нажатий входа {{ch_number}}",
+                "Input {{ch_number}} Single Press Counter": "Счетчик одиночных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Long Press Counter": "Счетчик длинных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Double Press Counter": "Счетчик двойных нажатий входа {{ch_number}}",
                 "Input {{ch_number}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{ch_number}}",

--- a/templates/config-wb-mir_v2.json
+++ b/templates/config-wb-mir_v2.json
@@ -1467,6 +1467,9 @@
         ],
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MIR-v2_template_title": "WB-MIR v.2 (Modbus IR remote control)",
                 "baud_rate_description": "Make sure that communication with device is established before changing this parameter. Select required baud rate, save configuration and then change port baud rate to the same value.",
                 "Uptime": "Uptime (s)"
@@ -1614,7 +1617,7 @@
                 "Uptime": "Время работы с момента включения (с)",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "1-Wire": "Датчик 1-Wire",
                 "External Temperature Sensor": "Датчик температуры",
                 "External Temperature Sensor OK": "Датчик температуры исправен",

--- a/templates/config-wb-mir_v2_buttons.json.jinja
+++ b/templates/config-wb-mir_v2_buttons.json.jinja
@@ -479,6 +479,9 @@
 
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MIR-v.2_template_title": "WB-MIR v.2 (Modbus IR remote control)",
 
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
@@ -533,7 +536,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме",
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме",
 
                 "temperature_readings_filter_deg_title": "Фильтр ошибочных значений датчика 1-Wire (°C)",
                 "temperature_readings_filter_deg_description": "Если значение температуры равно 85 °C, то оно отбрасывается, если оно отличается от предыдущего больше, чем на значение фильтра. Запишите 0, чтобы отключить фильтр. Значение по умолчанию - 1",
@@ -543,7 +546,7 @@
                 {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} Counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -571,7 +574,7 @@
                 "Uptime": "Время работы с момента включения (с)",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "1-Wire": "Датчик 1-Wire",
                 "Disabled": "Отключен",
                 "Mode": "Режим работы"

--- a/templates/config-wb-mir_v3-fw-4.35.json.jinja
+++ b/templates/config-wb-mir_v3-fw-4.35.json.jinja
@@ -693,6 +693,9 @@
 
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MIR-v.3_template_title": "WB-MIR v.3 fw4.35 (Modbus IR remote control)",
 
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
@@ -749,7 +752,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме",
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме",
 
                 "temperature_readings_filter_deg_title": "Фильтр ошибочных значений датчика 1-Wire (°C)",
                 "temperature_readings_filter_deg_description": "Если значение температуры равно 85 °C, то оно отбрасывается, если оно отличается от предыдущего больше, чем на значение фильтра. Запишите 0, чтобы отключить фильтр. Значение по умолчанию - 1",
@@ -759,7 +762,7 @@
 
                 "Input": "Вход",
                 "Input Counter": "Счетчик",
-                "Input Single Press Counter": "Счетчик коротких нажатий входа",
+                "Input Single Press Counter": "Счетчик одиночных нажатий входа",
                 "Input Long Press Counter": "Счетчик длинных нажатий входа",
                 "Input Double Press Counter": "Счетчик двойных нажатий входа",
                 "Input Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа",
@@ -789,7 +792,7 @@
                 "Uptime": "Время работы с момента включения (с)",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "Disabled": "Отключен",
                 "Mode": "Режим работы",
 

--- a/templates/config-wb-mir_v3.json.jinja
+++ b/templates/config-wb-mir_v3.json.jinja
@@ -476,6 +476,9 @@
 
         "translations": {
             "en": {
+                "Serial NO": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum MCU Voltage Since Startup": "Min MCU Voltage Since Startup",
                 "WB-MIR-v.3_template_title": "WB-MIR v.3 (Modbus IR remote control)",
 
                 "temperature_readings_filter_deg_title": "Erroneous 1-Wire Temperature Readings Filter (°C)",
@@ -529,7 +532,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме",
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме",
 
                 "temperature_readings_filter_deg_title": "Фильтр ошибочных значений датчика 1-Wire (°C)",
                 "temperature_readings_filter_deg_description": "Если значение температуры равно 85 °C, то оно отбрасывается, если оно отличается от предыдущего больше, чем на значение фильтра. Запишите 0, чтобы отключить фильтр. Значение по умолчанию - 1",
@@ -539,7 +542,7 @@
                 {% for in_num in range(FIRST_INPUT, INPUTS_NUMBER + 1) -%}
                 "Input {{in_num}}": "Вход {{in_num}}",
                 "Input {{in_num}} Counter": "Счетчик {{in_num}}",
-                "Input {{in_num}} Single Press Counter": "Счетчик коротких нажатий входа {{in_num}}",
+                "Input {{in_num}} Single Press Counter": "Счетчик одиночных нажатий входа {{in_num}}",
                 "Input {{in_num}} Long Press Counter": "Счетчик длинных нажатий входа {{in_num}}",
                 "Input {{in_num}} Double Press Counter": "Счетчик двойных нажатий входа {{in_num}}",
                 "Input {{in_num}} Shortlong Press Counter": "Счетчик коротких, а затем длинных нажатий входа {{in_num}}",
@@ -568,7 +571,7 @@
                 "Uptime": "Время работы с момента включения (с)",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
-                "Minimum MCU Voltage Since Startup": "Минимальное напряжение питания МК с момента включения",
+                "Minimum MCU Voltage Since Startup": "Мин. напряжение питания МК с момента включения",
                 "1-Wire": "Датчик 1-Wire",
                 "Disabled": "Отключен",
                 "Mode": "Режим работы"

--- a/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
+++ b/templates/config-wb-mrgbw-d-fw-3.8.json.jinja
@@ -3409,6 +3409,8 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
                 "WB-MRGBW-D_template_title": "WB-MRGBW-D fw3.8 (4-channel CV LED Dimmer)",
 
                 "sp_title": "Short Press",

--- a/templates/config-wb-msw_v3.json
+++ b/templates/config-wb-msw_v3.json
@@ -1706,6 +1706,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "WB-MSW-v3_template_title": "WB-MSW v.3 (wall-mounted Modbus sensor)",
                 "group_sound_level_title": "Sound Level",
                 "selfheating_compensation_deg_description": "Compensation value is subtracted from measured temperature",
@@ -1884,7 +1887,7 @@
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
                 "Disabled": "Отключен",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "Sound ADC Channel": "Канал ADC датчика шума",
@@ -1919,7 +1922,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме"
             }
         }
     }

--- a/templates/config-wb-msw_v4.json
+++ b/templates/config-wb-msw_v4.json
@@ -1681,6 +1681,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "WB-MSW-v4_template_title": "WB-MSW v.4 (wall-mounted Modbus sensor)",
                 "group_sound_level_title": "Sound Level",
                 "selfheating_compensation_deg_description": "Compensation value is subtracted from measured temperature",
@@ -1854,7 +1857,7 @@
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения",
                 "Disabled": "Отключен",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "Sound ADC Channel": "Канал ADC датчика шума",
@@ -1887,7 +1890,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме"
             }
         }
     }

--- a/templates/config-wb-msw_v4_lora.json
+++ b/templates/config-wb-msw_v4_lora.json
@@ -1639,6 +1639,9 @@
         ],
         "translations": {
             "en": {
+                "Serial": "Serial Number",
+                "FW Version": "Firmware Version",
+                "Minimum Voltage Since Startup": "Min Supply Voltage Since Startup",
                 "WB-MSW-v4_template_title": "WB-MSW-LORA v.4 (wall-mounted Modbus sensor)",
                 "group_sound_level_title": "Sound Level",
                 "selfheating_compensation_deg_description": "Compensation value is subtracted from measured temperature",
@@ -1811,7 +1814,7 @@
                 "Supply Voltage": "Напряжение питания",
                 "Uptime": "Время работы с момента включения (с)",
                 "Disabled": "Отключен",
-                "Minimum Voltage Since Startup": "Минимальное напряжение с момента включения",
+                "Minimum Voltage Since Startup": "Мин. напряжение питания с момента включения",
                 "MCU Temperature": "Температура МК",
                 "MCU Voltage": "Напряжение питания МК",
                 "Sound ADC Channel": "Канал ADC датчика шума",
@@ -1844,7 +1847,7 @@
                 "No Action": "Ничего не делать",
                 "Play IR Command": "Воспроизвести ИК-команду",
                 "Safety Command": "ИК-команда",
-                "safety_command_description": "ИК-команда, которая будет воcпроизведена в безопасном режиме"
+                "safety_command_description": "ИК-команда, которая будет воспроизведена в безопасном режиме"
             }
         }
     }


### PR DESCRIPTION
## Что и зачем

**Финальный PR** серии унификации UI-текстов (#1219, #1221, #1222). Закрывает оставшиеся актуальные (`group: g-wb`) семейства. Правки **только display-only** (`translations`).

> ⚠️ Ответвлён от ветки PR #1222 (`feature/unify-ui-wb-analog-io`). **Мёржить после #1222** — тогда база автоматически переключится на master.

Семейства (15 шаблонов):
- **WB-MAO4**: mao4 (base), mao4-20ma, mao4-20ma-fw-2.9
- **WB-MDM3**: mdm3 (base) · **WB-MSW**: msw_v3, msw_v4, msw_v4_lora
- **WB-MIR**: mir_v2, mir_v2_buttons, mir_v3, mir_v3-fw-4.35

Унифицировано (EN-переопределения, `name` заморожен): `Serial`/`Serial NO`→**Serial Number**, `FW Version`→**Firmware Version**, `Supply voltage`→**Supply Voltage**, `Minimum…`→**Min Supply/MCU Voltage Since Startup**; RU счётчика «коротких»→«одиночных».

**WB-MAO4**: у базового шаблона счётчики названы старой схемой в **топиках** (`… Short Press Counter`). Топики **не менял** — привёл только отображение через цикл на стороне переводов (`Short`→`Single`, `Short Long`→`Shortlong`), как в #1219.

**Заодно закрыл пробел #1219:** в шаблонах `mao4-fw-2.9`, `mdm3-fw-2.12`, `led-fw-3.8`, `mrgbw-d-fw-3.8` не были унифицированы `Serial`/`FW Version` (только Supply/счётчики). Добавил `Serial Number`/`Firmware Version` — теперь семейства консистентны.

**Опечатка:** `воcпроизведена` (латинская `c` в русском слове) → `воспроизведена` в описаниях WB-MSW/WB-MIR.

## Обратная совместимость
**Полностью сохранена.** Только `translations`; `.dat` branch==master (32229 строк), committed `Validate.dat` не изменён.

## Не вошло (осознанно)
- Шаблоны **без блока `translations`** (`*-lv`, `m1w2-di`, `mrps6`) — не трогаем (добавление i18n с нуля — отдельная задача).
- `group: g-wb-old`, `*-deprecated`.
- **Гомоглиф `Zero-Сross` в WB-MDM3** — он в **имени канала (топике)**, а не в отображении. Починить = переименовать топик = слом совместимости, поэтому оставлен как есть. Правка топиков-гомоглифов — отдельным решением (как MAP-миграция).
