### PR TITLE
Fix templates/Upload RPC and device/Load RPC emum channel bugs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-serial (2.263.1) stable; urgency=medium
+
+  * Fix templates/Upload RPC numeric channel enum values validation
+  * Fix device/Load RPC failure for WB devices with enum channels
+
+ -- Ilya Titov <mail@u236.org>  Tue, 11 Aug 2026 10:54:17 +0300
+
 wb-mqtt-serial (2.263.0) stable; urgency=medium
 
   * Move firmware release indexes download from port thread to RPC thread

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,13 +3,13 @@ wb-mqtt-serial (2.263.1) stable; urgency=medium
   * Fix templates/Upload RPC numeric channel enum values validation
   * Fix device/Load RPC failure for WB devices with enum channels
 
- -- Ilya Titov <mail@u236.org>  Tue, 11 Aug 2026 10:54:17 +0300
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 11 Aug 2026 10:54:17 +0300
 
 wb-mqtt-serial (2.263.0) stable; urgency=medium
 
   * Move firmware release indexes download from port thread to RPC thread
 
- -- Ilya Titov <mail@u236.org>  Fri, 07 Aug 2026 11:24:52 +0300
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Fri, 07 Aug 2026 11:24:52 +0300
 
 wb-mqtt-serial (2.262.6) stable; urgency=medium
 

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -325,11 +325,13 @@ TRPCRegisterList CreateRegisterList(const TDeviceProtocolParams& protocolParams,
             int unsupportedValue =
                 config.RegisterConfig->Format == S16 ? static_cast<int16_t>(0xFFFE) : static_cast<uint16_t>(0xFFFE);
             if (item.isMember("enum")) {
-                const auto& list = item["enum"];
-                for (auto it = list.begin(); it != list.end(); ++it) {
-                    if ((*it).asInt() == unsupportedValue) {
-                        reg.CheckUnsupported = false;
-                        break;
+                for (const auto& value: item["enum"]) {
+                    try {
+                        if (std::stoi(value.asString(), 0, 0) == unsupportedValue) {
+                            reg.CheckUnsupported = false;
+                            break;
+                        }
+                    } catch (const std::logic_error&) {
                     }
                 }
             } else {

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -249,6 +249,13 @@ namespace
         }
     }
 
+    //! Converts numeric channel enum values to strings and validates the template
+    void FixAndValidateDeviceTemplate(Json::Value& root, WBMQTT::JSON::TValidator& validator)
+    {
+        FixChannelsEnum(root);
+        ValidateDeviceTemplate(root, validator);
+    }
+
     //! Prepares a valid template for use: adds condition dependencies, normalizes parameters
     void AnnotateDeviceTemplate(Json::Value& root)
     {
@@ -412,8 +419,7 @@ void TTemplateMap::ValidateTemplate(const Json::Value& templateRoot)
         throw std::runtime_error("Device templates schema is not loaded");
     }
     Json::Value root(templateRoot);
-    FixChannelsEnum(root);
-    ValidateDeviceTemplate(root, *Validator);
+    FixAndValidateDeviceTemplate(root, *Validator);
 }
 
 PDeviceTemplate TTemplateMap::FindUserDefinedTemplate(const std::string& deviceType)
@@ -514,15 +520,16 @@ const Json::Value& TDeviceTemplate::GetTemplate()
 {
     if (Template.isNull()) {
         Json::Value root(WBMQTT::JSON::Parse(GetFilePath()));
-        FixChannelsEnum(root);
         // Skip deprecated template validation, it may be broken according to latest schema
         if (!IsDeprecated()) {
             try {
-                ValidateDeviceTemplate(root, *Validator);
+                FixAndValidateDeviceTemplate(root, *Validator);
             } catch (const std::runtime_error& e) {
                 throw std::runtime_error("File: " + GetFilePath() + " error: " + e.what());
             }
             AnnotateDeviceTemplate(root);
+        } else {
+            FixChannelsEnum(root);
         }
         Template = root["device"];
     }

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -249,10 +249,15 @@ namespace
         }
     }
 
-    //! Converts numeric channel enum values to strings and validates the template
-    void FixAndValidateDeviceTemplate(Json::Value& root, WBMQTT::JSON::TValidator& validator)
+    //! Converts numeric channel enum values to strings
+    void FixDeviceTemplate(Json::Value& root)
     {
         FixChannelsEnum(root);
+    }
+
+    void FixAndValidateDeviceTemplate(Json::Value& root, WBMQTT::JSON::TValidator& validator)
+    {
+        FixDeviceTemplate(root);
         ValidateDeviceTemplate(root, validator);
     }
 
@@ -529,7 +534,7 @@ const Json::Value& TDeviceTemplate::GetTemplate()
             }
             AnnotateDeviceTemplate(root);
         } else {
-            FixChannelsEnum(root);
+            FixDeviceTemplate(root);
         }
         Template = root["device"];
     }

--- a/src/templates_map.cpp
+++ b/src/templates_map.cpp
@@ -411,7 +411,9 @@ void TTemplateMap::ValidateTemplate(const Json::Value& templateRoot)
     if (!Validator) {
         throw std::runtime_error("Device templates schema is not loaded");
     }
-    ValidateDeviceTemplate(templateRoot, *Validator);
+    Json::Value root(templateRoot);
+    FixChannelsEnum(root);
+    ValidateDeviceTemplate(root, *Validator);
 }
 
 PDeviceTemplate TTemplateMap::FindUserDefinedTemplate(const std::string& deviceType)

--- a/test/device_load_config_test.cpp
+++ b/test/device_load_config_test.cpp
@@ -296,3 +296,34 @@ TEST(TDeviceLoadTest, GetParametersRegisterListThrowsOnUnknownParam)
     ASSERT_THROW(request.GetParametersRegisterList(), TRPCException)
         << "should throw when requested parameter does not exist in template";
 }
+
+/**
+ * Checks that unsupported value 0xFFFE is detected in channel enums,
+ * which are converted to strings on template load.
+ */
+TEST(TDeviceLoadTest, CheckUnsupportedInChannelEnum)
+{
+    TSerialDeviceFactory deviceFactory;
+    RegisterProtocols(deviceFactory);
+
+    TTemplateMap templateMap(GetTemplatesSchema());
+    templateMap.AddTemplatesDir(TLoggedFixture::GetDataFilePath("device_load_config_test/templates"), false);
+
+    TDeviceProtocolParams protocolParams = deviceFactory.GetProtocolParams("modbus");
+    auto deviceTemplate = templateMap.GetTemplate("channel_enum")->GetTemplate();
+
+    TRPCRegisterList registerList =
+        CreateRegisterList(protocolParams, nullptr, deviceTemplate["channels"], Json::Value(), std::string(), true);
+
+    std::map<std::string, bool> checkUnsupported;
+    for (const auto& reg: registerList) {
+        checkUnsupported[reg.Id] = reg.CheckUnsupported;
+    }
+
+    ASSERT_EQ(checkUnsupported.size(), 5u);
+    ASSERT_FALSE(checkUnsupported["unsupported_in_enum"]);
+    ASSERT_TRUE(checkUnsupported["supported_enum"]);
+    ASSERT_FALSE(checkUnsupported["signed_enum"]);
+    ASSERT_FALSE(checkUnsupported["hex_enum"]);
+    ASSERT_FALSE(checkUnsupported["range_with_unsupported"]);
+}

--- a/test/device_load_config_test/templates/config-channel-enum.json
+++ b/test/device_load_config_test/templates/config-channel-enum.json
@@ -1,0 +1,50 @@
+{
+    "device_type": "channel_enum",
+    "device": {
+        "name": "channel enum",
+        "id": "channel enum",
+        "channels": [
+            {
+                "name": "unsupported in enum",
+                "id": "unsupported_in_enum",
+                "reg_type": "input",
+                "address": 0,
+                "enum": [1, 65534],
+                "enum_titles": ["one", "unsupported"]
+            },
+            {
+                "name": "supported enum",
+                "id": "supported_enum",
+                "reg_type": "input",
+                "address": 1,
+                "enum": [0, 1],
+                "enum_titles": ["off", "on"]
+            },
+            {
+                "name": "signed enum",
+                "id": "signed_enum",
+                "reg_type": "input",
+                "format": "s16",
+                "address": 2,
+                "enum": [-2, 0],
+                "enum_titles": ["unsupported", "zero"]
+            },
+            {
+                "name": "hex enum",
+                "id": "hex_enum",
+                "reg_type": "input",
+                "address": 3,
+                "enum": ["0xFFFE", "0x10"],
+                "enum_titles": ["unsupported", "sixteen"]
+            },
+            {
+                "name": "range with unsupported",
+                "id": "range_with_unsupported",
+                "reg_type": "input",
+                "address": 4,
+                "min": 0,
+                "max": 65535
+            }
+        ]
+    }
+}

--- a/test/rpc_templates_handler_test.cpp
+++ b/test/rpc_templates_handler_test.cpp
@@ -414,6 +414,28 @@ TEST_F(TRPCTemplatesHandlerTest, UploadInvalidCondition)
     EXPECT_THROW(Templates->GetTemplate(NEW_TYPE), std::out_of_range);
 }
 
+TEST_F(TRPCTemplatesHandlerTest, UploadNumericChannelEnum)
+{
+    // Templates use numeric channel enums, the schema allows strings only,
+    // so the values must be converted before validation, as it is done on disk load
+    auto root = MakeTemplateJson(NEW_TYPE, "Uploaded device");
+    auto& channel = root["device"]["channels"][0];
+    channel["enum"].append(0);
+    channel["enum"].append(1);
+    channel["enum_titles"].append("off");
+    channel["enum_titles"].append("on");
+
+    Upload(MakeUploadRequest(SerializeJson(root), "numeric-enum.json"));
+
+    EXPECT_EQ(std::vector<std::string>{"numeric-enum.json"}, ListUserTemplatesDir());
+    // The file keeps the original values, the loaded template has them converted
+    auto stored = WBMQTT::JSON::Parse((UserTemplatesDir / "numeric-enum.json").string());
+    EXPECT_TRUE(stored["device"]["channels"][0]["enum"][0].isNumeric());
+    auto loaded = Templates->GetTemplate(NEW_TYPE)->GetTemplate();
+    EXPECT_EQ("0", loaded["channels"][0]["enum"][0].asString());
+    EXPECT_EQ("1", loaded["channels"][0]["enum"][1].asString());
+}
+
 TEST_F(TRPCTemplatesHandlerTest, DeleteOverride)
 {
     Upload(MakeUploadRequest(MakeTemplateContent(USED_TYPE, "MSU34 uploaded", "g-relay"), "msu34.json", true));


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->

<!--
Если Вы изменили RPC или структуру файла настроек, обязательно напишите в README.md, в какой версии версии wb-mqtt-serial появились эти изменения.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

При добавлении новых RPC `templates/Upload` (#1206) забыли про то, что теперь схема конфигурации устройств ограничивает тип даных для `emum` в каналах строкой (#1207), это привело к тому, что шаблоны с числовыми `enum` в каналах не могут пройти валидацию.

Попутно обнаружилась регрессия, вызваная ограничением типов - в RPC `device/Load` сломалась проверка `enum` на предмет содержания невалидного значения регистра `0xFFFE` для устройств WB. Проверка стала вызывать исключение из-за попытки вызвать `JsonValue::asInt` для элемента, содержащего строку.

___________________________________
**Что поменялось для пользователей:**

В RPC `templates/Upload` перед валидацией шаблона теперь вызывается метод `FixChannelEnum`, сам шаблон, в случае успешного прохождения валидации, сохраняется на диск неизмененнным.

RPC `device/Load` значение `enum` теперь приводится к числу через `stoi` с базой 0, что позволяет проверить как изначально числовое значение, приведенное к строке, так и HEX строку.

___________________________________
**Как проверял/а:**

Потыкал RPC, добавил новые тесты.