### PR TITLE
Clear fw-update RPC topics on service stop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-serial (2.264.3) stable; urgency=medium
 
-  * Clear fw-update RPC topics on service stop
+  * Clear fw-update RPC and firmware update state topics on service stop
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 18 Aug 2026 13:00:00 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.264.3) stable; urgency=medium
+
+  * Clear fw-update RPC topics on service stop
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 18 Aug 2026 13:00:00 +0400
+
 wb-mqtt-serial (2.264.2) stable; urgency=medium
 
   * Fix offset descriptions in templates with multisensor 1-Wire support (WB-MS v.2, WB-MIR v.3, WB-M1W2 v.3)

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils, wb-release-info
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.150.0~~)

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ export DEBUG=1
 endif
 
 %:
-	dh $@ --parallel
+	dh $@
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -389,6 +389,7 @@ int main(int argc, char* argv[])
 
         WBMQTT::SignalHandling::OnSignals({SIGINT, SIGTERM}, [=] {
             rpcServer->Stop();
+            fwUpdateRpcServer->Stop();
             if (serialDriver) {
                 serialDriver->Stop();
             } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,7 +392,9 @@ int main(int argc, char* argv[])
             fwUpdateRpcServer->Stop();
             if (serialDriver) {
                 serialDriver->Stop();
-            } else {
+            }
+            rpcFwUpdateHandler->Stop();
+            if (!serialDriver) {
                 mqtt->Stop();
             }
         });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,9 +392,9 @@ int main(int argc, char* argv[])
             fwUpdateRpcServer->Stop();
             if (serialDriver) {
                 serialDriver->Stop();
-            }
-            rpcFwUpdateHandler->Stop();
-            if (!serialDriver) {
+                rpcFwUpdateHandler->Stop();
+            } else {
+                rpcFwUpdateHandler->Stop();
                 mqtt->Stop();
             }
         });

--- a/src/rpc/rpc_fw_update_handler.cpp
+++ b/src/rpc/rpc_fw_update_handler.cpp
@@ -5,6 +5,7 @@
 #include "rpc_fw_update_task.h"
 
 #include <algorithm>
+#include <chrono>
 
 #ifndef __EMSCRIPTEN__
 #include "rpc_fw_get_firmware_info_task.h"
@@ -164,6 +165,16 @@ TRPCFwUpdateHandler::TRPCFwUpdateHandler(ITaskRunner& serialClientTaskRunner,
 
     RegisterRpcMethods(rpcServer);
     rpcServer->Start();
+}
+
+void TRPCFwUpdateHandler::Stop()
+{
+    if (!Mqtt) {
+        return;
+    }
+    if (!Mqtt->PublishSynced(WBMQTT::TMqttMessage(STATE_TOPIC, "", 1, true)).WaitFor(std::chrono::seconds(1))) {
+        LOG(Warn) << "Unable to cleanup topic '" << STATE_TOPIC << "': timed out";
+    }
 }
 
 TRPCFwUpdateHandler::TRPCFwUpdateHandler(ITaskRunner& taskRunner,

--- a/src/rpc/rpc_fw_update_handler.h
+++ b/src/rpc/rpc_fw_update_handler.h
@@ -20,6 +20,8 @@ public:
                         WBMQTT::PMqttClient mqtt,
                         PHttpClient httpClient = nullptr);
 
+    void Stop();
+
     struct TRequestParams
     {
         int SlaveId = 0;


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->

<!--
Если Вы изменили RPC или структуру файла настроек, обязательно напишите в README.md, в какой версии версии wb-mqtt-serial появились эти изменения.
-->
___________________________________
**Что происходит; кому и зачем нужно:**
* при остановке сириала fw-update rpc топики не очищаются, так как теперь они на отдельном fwUpdateRpcServer, который не останавливался (см https://github.com/wirenboard/wb-mqtt-serial/pull/1097)
* wb-release-info в зависимости, так как читаем `/usr/lib/wb-release`
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на вб