### PR TITLE
Restore original continuous read register value after RPC requests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.267.1) stable; urgency=medium
+
+  * Restore continuous read register value after RPC requests
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Tue, 25 Aug 2026 10:29:06 +0300
+
 wb-mqtt-serial (2.267.0) stable; urgency=medium
 
   * Add wb_time_sync_interval device parameter

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -51,7 +51,7 @@ TModbusDevice::TModbusDevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits
       ModbusTraits(std::move(modbusTraits)),
       ResponseTime(std::chrono::milliseconds::zero()),
       EnableWbContinuousRead(config.EnableWbContinuousRead),
-      ContinuousReadEnabled(false)
+      ContinuousReadStatus(0)
 {}
 
 bool TModbusDevice::GetForceFrameTimeout()
@@ -59,9 +59,9 @@ bool TModbusDevice::GetForceFrameTimeout()
     return ModbusTraits->GetForceFrameTimeout();
 }
 
-bool TModbusDevice::GetContinuousReadEnabled()
+uint16_t TModbusDevice::GetContinuousReadStatus()
 {
-    return ContinuousReadEnabled;
+    return ContinuousReadStatus;
 }
 
 PRegisterRange TModbusDevice::CreateRegisterRange() const
@@ -74,7 +74,7 @@ void TModbusDevice::PrepareImpl(TPort& port)
     TSerialDevice::PrepareImpl(port);
     if (GetConnectionState() != TDeviceConnectionState::CONNECTED) {
         if (EnableWbContinuousRead) {
-            ContinuousReadEnabled =
+            ContinuousReadStatus =
                 Modbus::EnableWbContinuousRead(shared_from_this(), *ModbusTraits, port, SlaveId, ModbusCache);
         }
         if (!IsWbDevice()) {

--- a/src/devices/modbus_device.cpp
+++ b/src/devices/modbus_device.cpp
@@ -51,7 +51,7 @@ TModbusDevice::TModbusDevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits
       ModbusTraits(std::move(modbusTraits)),
       ResponseTime(std::chrono::milliseconds::zero()),
       EnableWbContinuousRead(config.EnableWbContinuousRead),
-      ContinuousReadStatus(0)
+      ContinuousReadStatus(TContinuousReadStatus::DISABLED)
 {}
 
 bool TModbusDevice::GetForceFrameTimeout()
@@ -59,7 +59,7 @@ bool TModbusDevice::GetForceFrameTimeout()
     return ModbusTraits->GetForceFrameTimeout();
 }
 
-uint16_t TModbusDevice::GetContinuousReadStatus()
+TContinuousReadStatus TModbusDevice::GetContinuousReadStatus()
 {
     return ContinuousReadStatus;
 }

--- a/src/devices/modbus_device.h
+++ b/src/devices/modbus_device.h
@@ -59,7 +59,7 @@ class TModbusDevice: public TSerialDevice, public TUInt32SlaveId
     Modbus::TRegisterCache ModbusCache;
     TRunningAverage<std::chrono::microseconds, 10> ResponseTime;
     bool EnableWbContinuousRead;
-    uint16_t ContinuousReadStatus;
+    TContinuousReadStatus ContinuousReadStatus;
 
 public:
     TModbusDevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits,
@@ -67,7 +67,7 @@ public:
                   PProtocol protocol);
 
     bool GetForceFrameTimeout();
-    uint16_t GetContinuousReadStatus();
+    TContinuousReadStatus GetContinuousReadStatus();
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(TPort& port, PRegisterRange range, bool breakOnError = false) override;

--- a/src/devices/modbus_device.h
+++ b/src/devices/modbus_device.h
@@ -59,7 +59,7 @@ class TModbusDevice: public TSerialDevice, public TUInt32SlaveId
     Modbus::TRegisterCache ModbusCache;
     TRunningAverage<std::chrono::microseconds, 10> ResponseTime;
     bool EnableWbContinuousRead;
-    bool ContinuousReadEnabled;
+    uint16_t ContinuousReadStatus;
 
 public:
     TModbusDevice(std::unique_ptr<Modbus::IModbusTraits> modbusTraits,
@@ -67,7 +67,7 @@ public:
                   PProtocol protocol);
 
     bool GetForceFrameTimeout();
-    bool GetContinuousReadEnabled();
+    uint16_t GetContinuousReadStatus();
 
     PRegisterRange CreateRegisterRange() const override;
     void ReadRegisterRange(TPort& port, PRegisterRange range, bool breakOnError = false) override;

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -144,7 +144,7 @@ namespace Modbus // modbus protocol common utilities
         auto continuousReadEnabled = false;
         auto forceFrameTimeout = false;
         if (device != nullptr) {
-            continuousReadEnabled = device->GetContinuousReadEnabled();
+            continuousReadEnabled = (device->GetContinuousReadStatus() != 0);
             forceFrameTimeout = device->GetForceFrameTimeout();
         }
 
@@ -996,11 +996,11 @@ namespace Modbus // modbus protocol common utilities
         }
     }
 
-    bool IsWbContinuousReadEnabled(PSerialDevice device,
-                                   IModbusTraits& traits,
-                                   TPort& port,
-                                   uint8_t slaveId,
-                                   const TRegisterConfig& config)
+    uint16_t ReadWbContinuousReadStatus(PSerialDevice device,
+                                        IModbusTraits& traits,
+                                        TPort& port,
+                                        uint8_t slaveId,
+                                        const TRegisterConfig& config)
     {
         try {
             auto value = Modbus::ReadRegister(traits,
@@ -1009,29 +1009,30 @@ namespace Modbus // modbus protocol common utilities
                                               config,
                                               device->DeviceConfig()->RequestDelay,
                                               device->GetResponseTimeout(port),
-                                              device->GetFrameTimeout(port))
-                             .Get<uint64_t>();
-            return (value == 1 || value == 2);
+                                              device->GetFrameTimeout(port));
+            return value.Get<uint16_t>();
         } catch (const Modbus::TErrorBase&) {
             RethrowSerialDeviceException(port);
         }
-        return false;
+        return 0;
     }
 
-    bool EnableWbContinuousRead(PSerialDevice device,
-                                IModbusTraits& traits,
-                                TPort& port,
-                                uint8_t slaveId,
-                                TRegisterCache& cache)
+    uint16_t EnableWbContinuousRead(PSerialDevice device,
+                                    IModbusTraits& traits,
+                                    TPort& port,
+                                    uint8_t slaveId,
+                                    TRegisterCache& cache)
     {
         auto config = WbRegisters::GetRegisterConfig("continuous_read");
         try {
-            if (!IsWbContinuousReadEnabled(device, traits, port, slaveId, *config)) {
+            auto value = ReadWbContinuousReadStatus(device, traits, port, slaveId, *config);
+            if (value != 1 && value != 2) {
+                value = 1;
                 Modbus::WriteRegister(traits,
                                       port,
                                       slaveId,
                                       *config,
-                                      TRegisterValue(1),
+                                      TRegisterValue(value),
                                       cache,
                                       device->DeviceConfig()->RequestDelay,
                                       device->GetResponseTimeout(port),
@@ -1044,12 +1045,12 @@ namespace Modbus // modbus protocol common utilities
             if (device->DeviceConfig()->MaxBitHole < MAX_HOLE_CONTINUOUS_1_BIT_REGISTERS) {
                 device->DeviceConfig()->MaxBitHole = MAX_HOLE_CONTINUOUS_1_BIT_REGISTERS;
             }
-            return true;
+            return value;
         } catch (const TSerialDevicePermanentRegisterException& e) {
             // A firmware doesn't support continuous read
             LOG(Warn) << "Continuous read is not enabled [slave_id is " << device->DeviceConfig()->SlaveId + "]";
         }
-        return false;
+        return 0;
     }
 
     std::string ReadWbFwVersion(PSerialDevice device, IModbusTraits& traits, TPort& port, uint8_t slaveId)

--- a/src/modbus_common.cpp
+++ b/src/modbus_common.cpp
@@ -144,7 +144,7 @@ namespace Modbus // modbus protocol common utilities
         auto continuousReadEnabled = false;
         auto forceFrameTimeout = false;
         if (device != nullptr) {
-            continuousReadEnabled = (device->GetContinuousReadStatus() != 0);
+            continuousReadEnabled = (device->GetContinuousReadStatus() != TContinuousReadStatus::DISABLED);
             forceFrameTimeout = device->GetForceFrameTimeout();
         }
 
@@ -996,11 +996,11 @@ namespace Modbus // modbus protocol common utilities
         }
     }
 
-    uint16_t ReadWbContinuousReadStatus(PSerialDevice device,
-                                        IModbusTraits& traits,
-                                        TPort& port,
-                                        uint8_t slaveId,
-                                        const TRegisterConfig& config)
+    TContinuousReadStatus ReadWbContinuousReadStatus(PSerialDevice device,
+                                                     IModbusTraits& traits,
+                                                     TPort& port,
+                                                     uint8_t slaveId,
+                                                     const TRegisterConfig& config)
     {
         try {
             auto value = Modbus::ReadRegister(traits,
@@ -1010,29 +1010,29 @@ namespace Modbus // modbus protocol common utilities
                                               device->DeviceConfig()->RequestDelay,
                                               device->GetResponseTimeout(port),
                                               device->GetFrameTimeout(port));
-            return value.Get<uint16_t>();
+            return static_cast<TContinuousReadStatus>(value.Get<uint16_t>());
         } catch (const Modbus::TErrorBase&) {
             RethrowSerialDeviceException(port);
         }
-        return 0;
+        return TContinuousReadStatus::DISABLED;
     }
 
-    uint16_t EnableWbContinuousRead(PSerialDevice device,
-                                    IModbusTraits& traits,
-                                    TPort& port,
-                                    uint8_t slaveId,
-                                    TRegisterCache& cache)
+    TContinuousReadStatus EnableWbContinuousRead(PSerialDevice device,
+                                                 IModbusTraits& traits,
+                                                 TPort& port,
+                                                 uint8_t slaveId,
+                                                 TRegisterCache& cache)
     {
         auto config = WbRegisters::GetRegisterConfig("continuous_read");
         try {
             auto value = ReadWbContinuousReadStatus(device, traits, port, slaveId, *config);
-            if (value != 1 && value != 2) {
-                value = 1;
+            if (value != TContinuousReadStatus::ENABLED_TEMPORARY && value != TContinuousReadStatus::ENABLED) {
+                value = TContinuousReadStatus::ENABLED_TEMPORARY;
                 Modbus::WriteRegister(traits,
                                       port,
                                       slaveId,
                                       *config,
-                                      TRegisterValue(value),
+                                      TRegisterValue(static_cast<uint16_t>(value)),
                                       cache,
                                       device->DeviceConfig()->RequestDelay,
                                       device->GetResponseTimeout(port),
@@ -1050,7 +1050,7 @@ namespace Modbus // modbus protocol common utilities
             // A firmware doesn't support continuous read
             LOG(Warn) << "Continuous read is not enabled [slave_id is " << device->DeviceConfig()->SlaveId + "]";
         }
-        return 0;
+        return TContinuousReadStatus::DISABLED;
     }
 
     std::string ReadWbFwVersion(PSerialDevice device, IModbusTraits& traits, TPort& port, uint8_t slaveId)

--- a/src/modbus_common.h
+++ b/src/modbus_common.h
@@ -4,6 +4,7 @@
 
 #include "modbus_base.h"
 #include "serial_device.h"
+#include "wb_registers.h"
 
 namespace Modbus // modbus protocol common utilities
 {
@@ -130,11 +131,11 @@ namespace Modbus // modbus protocol common utilities
                              bool breakOnError,
                              int shift = 0);
 
-    uint16_t EnableWbContinuousRead(PSerialDevice device,
-                                    IModbusTraits& traits,
-                                    TPort& port,
-                                    uint8_t slaveId,
-                                    TRegisterCache& cache);
+    TContinuousReadStatus EnableWbContinuousRead(PSerialDevice device,
+                                                 IModbusTraits& traits,
+                                                 TPort& port,
+                                                 uint8_t slaveId,
+                                                 TRegisterCache& cache);
 
     std::string ReadWbFwVersion(PSerialDevice device, IModbusTraits& traits, TPort& port, uint8_t slaveId);
 } // modbus protocol common utilities

--- a/src/modbus_common.h
+++ b/src/modbus_common.h
@@ -130,11 +130,11 @@ namespace Modbus // modbus protocol common utilities
                              bool breakOnError,
                              int shift = 0);
 
-    bool EnableWbContinuousRead(PSerialDevice device,
-                                IModbusTraits& traits,
-                                TPort& port,
-                                uint8_t slaveId,
-                                TRegisterCache& cache);
+    uint16_t EnableWbContinuousRead(PSerialDevice device,
+                                    IModbusTraits& traits,
+                                    TPort& port,
+                                    uint8_t slaveId,
+                                    TRegisterCache& cache);
 
     std::string ReadWbFwVersion(PSerialDevice device, IModbusTraits& traits, TPort& port, uint8_t slaveId);
 } // modbus protocol common utilities

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -376,7 +376,9 @@ void ReadRegisterList(TPort& port, PSerialDevice device, TRPCRegisterList& regis
                           << "Failed to read " << std::to_string(range->RegisterList().size())
                           << " registers starting from <" << first->GetConfig()->ToString() + ">: " + e.what();
                 auto modbusDevice = dynamic_cast<TModbusDevice*>(device.get());
-                if (modbusDevice != nullptr && modbusDevice->GetContinuousReadStatus() == 0) {
+                if (modbusDevice != nullptr &&
+                    modbusDevice->GetContinuousReadStatus() == TContinuousReadStatus::DISABLED)
+                {
                     for (const auto& reg: range->RegisterList()) {
                         reg->SetSupported(false);
                     }

--- a/src/rpc/rpc_device_handler.cpp
+++ b/src/rpc/rpc_device_handler.cpp
@@ -376,7 +376,7 @@ void ReadRegisterList(TPort& port, PSerialDevice device, TRPCRegisterList& regis
                           << "Failed to read " << std::to_string(range->RegisterList().size())
                           << " registers starting from <" << first->GetConfig()->ToString() + ">: " + e.what();
                 auto modbusDevice = dynamic_cast<TModbusDevice*>(device.get());
-                if (modbusDevice != nullptr && !modbusDevice->GetContinuousReadEnabled()) {
+                if (modbusDevice != nullptr && modbusDevice->GetContinuousReadStatus() == 0) {
                     for (const auto& reg: range->RegisterList()) {
                         reg->SetSupported(false);
                     }

--- a/src/rpc/rpc_helpers.cpp
+++ b/src/rpc/rpc_helpers.cpp
@@ -125,12 +125,12 @@ void WriteModbusRegister(TPort& port,
     }
 }
 
-void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, uint16_t value)
+void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, TContinuousReadStatus value)
 {
     std::string error;
     try {
         auto config = WbRegisters::GetRegisterConfig(WbRegisters::CONTINUOUS_READ_REGISTER_NAME);
-        WriteModbusRegister(port, request, config, TRegisterValue(value));
+        WriteModbusRegister(port, request, config, TRegisterValue(static_cast<uint16_t>(value)));
     } catch (const Modbus::TErrorBase& err) {
         error = err.what();
     } catch (const TResponseTimeoutException& e) {
@@ -184,7 +184,7 @@ void MarkUnsupportedRegisterItems(TPort& port,
         return;
     }
     auto status = device->GetContinuousReadStatus();
-    if (status == 0) {
+    if (status == TContinuousReadStatus::DISABLED) {
         return;
     }
     auto enabled = true;
@@ -193,7 +193,7 @@ void MarkUnsupportedRegisterItems(TPort& port,
             if (item.CheckUnsupported && CheckUnsupportedValue(*item.Register->GetConfig(), item.Register->GetValue()))
             {
                 if (enabled) {
-                    SetContinuousRead(port, request, 0);
+                    SetContinuousRead(port, request, TContinuousReadStatus::DISABLED);
                     enabled = false;
                 }
                 try {

--- a/src/rpc/rpc_helpers.cpp
+++ b/src/rpc/rpc_helpers.cpp
@@ -1,4 +1,5 @@
 #include "rpc_helpers.h"
+#include "devices/modbus_device.h"
 #include "log.h"
 #include "modbus_base.h"
 #include "modbus_common.h"
@@ -124,12 +125,12 @@ void WriteModbusRegister(TPort& port,
     }
 }
 
-void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, bool enabled)
+void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, uint16_t value)
 {
     std::string error;
     try {
         auto config = WbRegisters::GetRegisterConfig(WbRegisters::CONTINUOUS_READ_REGISTER_NAME);
-        WriteModbusRegister(port, request, config, TRegisterValue(enabled));
+        WriteModbusRegister(port, request, config, TRegisterValue(value));
     } catch (const Modbus::TErrorBase& err) {
         error = err.what();
     } catch (const TResponseTimeoutException& e) {
@@ -178,14 +179,22 @@ void MarkUnsupportedRegisterItems(TPort& port,
                                   TRPCRegisterList& registerList,
                                   Json::Value& data)
 {
-    auto continuousRead = true;
+    auto device = dynamic_cast<TModbusDevice*>(request.Device.get());
+    if (device == nullptr) {
+        return;
+    }
+    auto status = device->GetContinuousReadStatus();
+    if (status == 0) {
+        return;
+    }
+    auto enabled = true;
     for (const auto& item: registerList) {
         try {
             if (item.CheckUnsupported && CheckUnsupportedValue(*item.Register->GetConfig(), item.Register->GetValue()))
             {
-                if (continuousRead) {
-                    SetContinuousRead(port, request, false);
-                    continuousRead = false;
+                if (enabled) {
+                    SetContinuousRead(port, request, 0);
+                    enabled = false;
                 }
                 try {
                     TRegisterValue value;
@@ -197,7 +206,7 @@ void MarkUnsupportedRegisterItems(TPort& port,
         } catch (const TRegisterValueException& e) {
         }
     }
-    if (!continuousRead) {
-        SetContinuousRead(port, request, true);
+    if (!enabled) {
+        SetContinuousRead(port, request, status);
     }
 }

--- a/src/rpc/rpc_helpers.h
+++ b/src/rpc/rpc_helpers.h
@@ -27,9 +27,9 @@ void WriteModbusRegister(TPort& port,
                          const TRegisterValue& value);
 
 /**
- * @brief Sets continuous read register on/off (Wiren Board specific).
+ * @brief Writes continuous read register value (Wiren Board specific), 0 disables the mode.
  */
-void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, bool enabled);
+void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, uint16_t value);
 
 /**
  * @brief Checks if all 16-bit words in register value are 0xFFFE (unsupported marker).

--- a/src/rpc/rpc_helpers.h
+++ b/src/rpc/rpc_helpers.h
@@ -27,9 +27,9 @@ void WriteModbusRegister(TPort& port,
                          const TRegisterValue& value);
 
 /**
- * @brief Writes continuous read register value (Wiren Board specific), 0 disables the mode.
+ * @brief Writes continuous read register value (Wiren Board specific).
  */
-void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, uint16_t value);
+void SetContinuousRead(TPort& port, TRPCDeviceRequest& request, TContinuousReadStatus value);
 
 /**
  * @brief Checks if all 16-bit words in register value are 0xFFFE (unsupported marker).

--- a/src/wb_registers.h
+++ b/src/wb_registers.h
@@ -16,10 +16,13 @@ namespace WbRegisters
     const std::string SN_REGISTER_NAME = "sn";
     const std::string LOCAL_TIME_REGISTER_NAME = "local_time";
 
-    const uint16_t COUNTINUOUS_READ_DISABLED = 0;
-    const uint16_t COUNTINUOUS_READ_ENABLED_TEMPORARY = 1;
-    const uint16_t COUNTINUOUS_READ_ENABLED = 2;
-
     PRegisterConfig GetRegisterConfig(const std::string& name);
 
 } // namespace
+
+enum class TContinuousReadStatus : uint16_t
+{
+    DISABLED = 0,
+    ENABLED_TEMPORARY = 1,
+    ENABLED = 2
+};

--- a/test/TRPCContinuousReadTest.RestoresModeEnabledByDriver.dat
+++ b/test/TRPCContinuousReadTest.RestoresModeEnabledByDriver.dat
@@ -1,0 +1,18 @@
+Open()
+Sleep(20000)
+EnqueueHoldingRead()
+>> 01 03 00 72 00 01 24 11
+<< 01 03 02 00 00 B8 44
+EnqueueHoldingWrite()
+>> 01 06 00 72 00 01 E8 11
+<< 01 06 00 72 00 01 E8 11
+EnqueueHoldingWrite()
+>> 01 06 00 72 00 00 29 D1
+<< 01 06 00 72 00 00 29 D1
+EnqueueHoldingReadException()
+>> 01 03 00 C8 00 01 05 F4
+<< 01 83 02 C0 F1
+EnqueueHoldingWrite()
+>> 01 06 00 72 00 01 E8 11
+<< 01 06 00 72 00 01 E8 11
+Close()

--- a/test/TRPCContinuousReadTest.RestoresModeValue.dat
+++ b/test/TRPCContinuousReadTest.RestoresModeValue.dat
@@ -1,0 +1,15 @@
+Open()
+Sleep(20000)
+EnqueueHoldingRead()
+>> 01 03 00 72 00 01 24 11
+<< 01 03 02 00 02 39 85
+EnqueueHoldingWrite()
+>> 01 06 00 72 00 00 29 D1
+<< 01 06 00 72 00 00 29 D1
+EnqueueHoldingReadException()
+>> 01 03 00 C8 00 01 05 F4
+<< 01 83 02 C0 F1
+EnqueueHoldingWrite()
+>> 01 06 00 72 00 02 A8 10
+<< 01 06 00 72 00 02 A8 10
+Close()

--- a/test/TRPCContinuousReadTest.SkipsDisabledMode.dat
+++ b/test/TRPCContinuousReadTest.SkipsDisabledMode.dat
@@ -1,0 +1,3 @@
+Open()
+Sleep(20000)
+Close()

--- a/test/TRPCContinuousReadTest.SkipsSupportedValues.dat
+++ b/test/TRPCContinuousReadTest.SkipsSupportedValues.dat
@@ -1,0 +1,6 @@
+Open()
+Sleep(20000)
+EnqueueHoldingRead()
+>> 01 03 00 72 00 01 24 11
+<< 01 03 02 00 02 39 85
+Close()

--- a/test/rpc_continuous_read_test.cpp
+++ b/test/rpc_continuous_read_test.cpp
@@ -1,0 +1,164 @@
+#include "devices/modbus_device.h"
+#include "fake_serial_port.h"
+#include "modbus_expectations_base.h"
+#include "rpc/rpc_device_handler.h"
+#include "rpc/rpc_helpers.h"
+#include "templates_map.h"
+#include "test_utils.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    const uint8_t SLAVE_ID = 1;
+    const uint16_t CONTINUOUS_READ_ADDRESS = 114;
+    const uint16_t PARAMETER_ADDRESS = 200;
+    const int ILLEGAL_DATA_ADDRESS_CODE = 0x02;
+}
+
+class TRPCContinuousReadTest: public TSerialDeviceTest, public TModbusExpectationsBase
+{
+protected:
+    void SetUp() override
+    {
+        SelectModbusType(MODBUS_RTU);
+        SetModbusRTUSlaveId(SLAVE_ID);
+        TSerialDeviceTest::SetUp();
+        SerialPort->Open();
+        TemplateMap = std::make_unique<TTemplateMap>(GetTemplatesSchema());
+        TemplateMap->AddTemplatesDir(TLoggedFixture::GetDataFilePath("device_load_config_test/templates"), false);
+        DeviceTemplate = TemplateMap->GetTemplate("parameters_array");
+    }
+
+    void CreateDevice(bool enableWbContinuousRead)
+    {
+        TModbusDeviceConfig config;
+        config.CommonConfig = std::make_shared<TDeviceConfig>("modbus", std::to_string(SLAVE_ID), "modbus");
+        config.EnableWbContinuousRead = enableWbContinuousRead;
+        Device = std::make_shared<TModbusDevice>(std::make_unique<Modbus::TModbusRTUTraits>(),
+                                                 config,
+                                                 DeviceFactory.GetProtocol("modbus"));
+        Parameter = Device->AddRegister(TRegisterConfig::Create(Modbus::REG_HOLDING, PARAMETER_ADDRESS, U16));
+    }
+
+    void EnqueueHoldingRead(uint16_t address, uint16_t value)
+    {
+        Expector()->Expect(
+            WrapPDU({0x03, static_cast<int>(address >> 8), static_cast<int>(address & 0xFF), 0x00, 0x01}),
+            WrapPDU({0x03, 0x02, static_cast<int>(value >> 8), static_cast<int>(value & 0xFF)}),
+            __func__);
+    }
+
+    void EnqueueHoldingReadException(uint16_t address)
+    {
+        Expector()->Expect(
+            WrapPDU({0x03, static_cast<int>(address >> 8), static_cast<int>(address & 0xFF), 0x00, 0x01}),
+            WrapPDU({0x83, ILLEGAL_DATA_ADDRESS_CODE}),
+            __func__);
+    }
+
+    void EnqueueHoldingWrite(uint16_t address, uint16_t value)
+    {
+        std::vector<int> pdu = {0x06,
+                                static_cast<int>(address >> 8),
+                                static_cast<int>(address & 0xFF),
+                                static_cast<int>(value >> 8),
+                                static_cast<int>(value & 0xFF)};
+        Expector()->Expect(WrapPDU(pdu), WrapPDU(pdu), __func__);
+    }
+
+    TRPCRegisterList MakeRegisterList(uint16_t value)
+    {
+        Parameter->SetValue(TRegisterValue(value));
+        return {TRPCRegister{"parameter", std::string(), Parameter, true}};
+    }
+
+    std::unique_ptr<TTemplateMap> TemplateMap;
+    PDeviceTemplate DeviceTemplate;
+    std::shared_ptr<TModbusDevice> Device;
+    PRegister Parameter;
+};
+
+/**
+ * Checks that continuous read mode is restored with the value read from the device,
+ * not with a hardcoded one.
+ */
+TEST_F(TRPCContinuousReadTest, RestoresModeValue)
+{
+    CreateDevice(true);
+    EnqueueHoldingRead(CONTINUOUS_READ_ADDRESS, 2);
+    Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), 2);
+
+    EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 0);
+    EnqueueHoldingReadException(PARAMETER_ADDRESS);
+    EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 2);
+
+    TRPCDeviceRequest request(DeviceFactory.GetProtocolParams("modbus"), Device, DeviceTemplate, false);
+    auto registerList = MakeRegisterList(0xFFFE);
+    Json::Value data;
+    MarkUnsupportedRegisterItems(*SerialPort, request, registerList, data);
+
+    ASSERT_EQ(data["parameter"].asString(), UNSUPPORTED_VALUE);
+    SerialPort->Close();
+}
+
+/**
+ * Checks that continuous read mode enabled by the driver is restored after the check.
+ */
+TEST_F(TRPCContinuousReadTest, RestoresModeEnabledByDriver)
+{
+    CreateDevice(true);
+    EnqueueHoldingRead(CONTINUOUS_READ_ADDRESS, 0);
+    EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 1);
+    Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), 1);
+
+    EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 0);
+    EnqueueHoldingReadException(PARAMETER_ADDRESS);
+    EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 1);
+
+    TRPCDeviceRequest request(DeviceFactory.GetProtocolParams("modbus"), Device, DeviceTemplate, false);
+    auto registerList = MakeRegisterList(0xFFFE);
+    Json::Value data;
+    MarkUnsupportedRegisterItems(*SerialPort, request, registerList, data);
+
+    ASSERT_EQ(data["parameter"].asString(), UNSUPPORTED_VALUE);
+    SerialPort->Close();
+}
+
+/**
+ * Checks that continuous read register is not written if the mode is disabled for the device.
+ */
+TEST_F(TRPCContinuousReadTest, SkipsDisabledMode)
+{
+    CreateDevice(false);
+    Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), 0);
+
+    TRPCDeviceRequest request(DeviceFactory.GetProtocolParams("modbus"), Device, DeviceTemplate, false);
+    auto registerList = MakeRegisterList(0xFFFE);
+    Json::Value data;
+    MarkUnsupportedRegisterItems(*SerialPort, request, registerList, data);
+
+    ASSERT_TRUE(data["parameter"].isNull());
+    SerialPort->Close();
+}
+
+/**
+ * Checks that continuous read register is not written if there are no unsupported values.
+ */
+TEST_F(TRPCContinuousReadTest, SkipsSupportedValues)
+{
+    CreateDevice(true);
+    EnqueueHoldingRead(CONTINUOUS_READ_ADDRESS, 2);
+    Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
+
+    TRPCDeviceRequest request(DeviceFactory.GetProtocolParams("modbus"), Device, DeviceTemplate, false);
+    auto registerList = MakeRegisterList(0x1234);
+    Json::Value data;
+    MarkUnsupportedRegisterItems(*SerialPort, request, registerList, data);
+
+    ASSERT_TRUE(data["parameter"].isNull());
+    SerialPort->Close();
+}

--- a/test/rpc_continuous_read_test.cpp
+++ b/test/rpc_continuous_read_test.cpp
@@ -88,7 +88,7 @@ TEST_F(TRPCContinuousReadTest, RestoresModeValue)
     CreateDevice(true);
     EnqueueHoldingRead(CONTINUOUS_READ_ADDRESS, 2);
     Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
-    ASSERT_EQ(Device->GetContinuousReadStatus(), 2);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), TContinuousReadStatus::ENABLED);
 
     EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 0);
     EnqueueHoldingReadException(PARAMETER_ADDRESS);
@@ -112,7 +112,7 @@ TEST_F(TRPCContinuousReadTest, RestoresModeEnabledByDriver)
     EnqueueHoldingRead(CONTINUOUS_READ_ADDRESS, 0);
     EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 1);
     Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
-    ASSERT_EQ(Device->GetContinuousReadStatus(), 1);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), TContinuousReadStatus::ENABLED_TEMPORARY);
 
     EnqueueHoldingWrite(CONTINUOUS_READ_ADDRESS, 0);
     EnqueueHoldingReadException(PARAMETER_ADDRESS);
@@ -134,7 +134,7 @@ TEST_F(TRPCContinuousReadTest, SkipsDisabledMode)
 {
     CreateDevice(false);
     Device->Prepare(*SerialPort, TDevicePrepareMode::WITHOUT_SETUP);
-    ASSERT_EQ(Device->GetContinuousReadStatus(), 0);
+    ASSERT_EQ(Device->GetContinuousReadStatus(), TContinuousReadStatus::DISABLED);
 
     TRPCDeviceRequest request(DeviceFactory.GetProtocolParams("modbus"), Device, DeviceTemplate, false);
     auto registerList = MakeRegisterList(0xFFFE);


### PR DESCRIPTION
**Что происходит; кому и зачем нужно:**

RPC-запросы `device/Load` и `device/LoadConfig` временно выключают режим непрерывного чтения, чтобы отличить неподдерживаемые регистры от реальных значений, а потом вклбчают его обратно, записав в регистр `1`.

Устройство могло работать в режиме `2`, а после после RPC оно оставалось в режиме `1`. 

**Что поменялось для пользователей:**

Теперь RPC после проверок записывает в регистр значение, которые было в нем до отключения непрерывного чтения. Если непрерывное чтение вообще не было включено, то проверка пропускается.

**Как проверял/а:**

Добавил новые тесты, проверил на железе (добавил несуществующий регистр в шаблон устройства).