### PR TITLE
Fix writing to devices which have no registers to poll

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.274.1) stable; urgency=medium
+
+  * Fix writing to devices which have no registers to poll
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Wed, 09 Sep 2026 12:30:00 +0300
+
 wb-mqtt-serial (2.274.0) stable; urgency=medium
 
   * Add register write type option for Modbus device channels and parameters

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -332,16 +332,6 @@ void TSerialDevice::SetDisconnected()
     SetConnectionState(TDeviceConnectionState::DISCONNECTED);
 }
 
-bool TSerialDevice::HasRegistersToPoll() const
-{
-    for (const auto& reg: Registers) {
-        if (reg->GetConfig()->AccessType != TRegisterConfig::EAccessType::WRITE_ONLY) {
-            return true;
-        }
-    }
-    return false;
-}
-
 PRegister TSerialDevice::AddRegister(PRegisterConfig config)
 {
     auto reg = std::make_shared<TRegister>(shared_from_this(), config);
@@ -354,16 +344,6 @@ const std::list<PRegister>& TSerialDevice::GetRegisters() const
     return Registers;
 }
 
-std::chrono::steady_clock::time_point TSerialDevice::GetLastPrepareTime() const
-{
-    return LastPrepareTime;
-}
-
-void TSerialDevice::SetLastPrepareTime(std::chrono::steady_clock::time_point prepareTime)
-{
-    LastPrepareTime = prepareTime;
-}
-
 std::chrono::steady_clock::time_point TSerialDevice::GetLastReadTime() const
 {
     return LastReadTime;
@@ -372,6 +352,16 @@ std::chrono::steady_clock::time_point TSerialDevice::GetLastReadTime() const
 void TSerialDevice::SetLastReadTime(std::chrono::steady_clock::time_point readTime)
 {
     LastReadTime = readTime;
+}
+
+std::chrono::steady_clock::time_point TSerialDevice::GetLastWriteTime() const
+{
+    return LastWriteTime;
+}
+
+void TSerialDevice::SetLastWriteTime(std::chrono::steady_clock::time_point writeTime)
+{
+    LastWriteTime = writeTime;
 }
 
 void TSerialDevice::AddOnConnectionStateChangedCallback(TSerialDevice::TDeviceCallback callback)

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -332,6 +332,16 @@ void TSerialDevice::SetDisconnected()
     SetConnectionState(TDeviceConnectionState::DISCONNECTED);
 }
 
+bool TSerialDevice::HasRegistersToPoll() const
+{
+    for (const auto& reg: Registers) {
+        if (reg->GetConfig()->AccessType != TRegisterConfig::EAccessType::WRITE_ONLY) {
+            return true;
+        }
+    }
+    return false;
+}
+
 PRegister TSerialDevice::AddRegister(PRegisterConfig config)
 {
     auto reg = std::make_shared<TRegister>(shared_from_this(), config);

--- a/src/serial_device.cpp
+++ b/src/serial_device.cpp
@@ -354,6 +354,16 @@ const std::list<PRegister>& TSerialDevice::GetRegisters() const
     return Registers;
 }
 
+std::chrono::steady_clock::time_point TSerialDevice::GetLastPrepareTime() const
+{
+    return LastPrepareTime;
+}
+
+void TSerialDevice::SetLastPrepareTime(std::chrono::steady_clock::time_point prepareTime)
+{
+    LastPrepareTime = prepareTime;
+}
+
 std::chrono::steady_clock::time_point TSerialDevice::GetLastReadTime() const
 {
     return LastReadTime;

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -263,8 +263,6 @@ public:
     TDeviceConnectionState GetConnectionState() const;
     void SetDisconnected();
 
-    bool HasRegistersToPoll() const;
-
     bool GetSupportsHoles() const;
     void SetSupportsHoles(bool supportsHoles);
 
@@ -284,11 +282,11 @@ public:
 
     const std::list<PRegister>& GetRegisters() const;
 
-    std::chrono::steady_clock::time_point GetLastPrepareTime() const;
-    void SetLastPrepareTime(std::chrono::steady_clock::time_point prepareTime);
-
     std::chrono::steady_clock::time_point GetLastReadTime() const;
     void SetLastReadTime(std::chrono::steady_clock::time_point readTime);
+
+    std::chrono::steady_clock::time_point GetLastWriteTime() const;
+    void SetLastWriteTime(std::chrono::steady_clock::time_point writeTime);
 
     void AddOnConnectionStateChangedCallback(TDeviceCallback callback);
 
@@ -324,8 +322,8 @@ private:
     bool TimeSyncUnsupported;
 
     std::list<PRegister> Registers;
-    std::chrono::steady_clock::time_point LastPrepareTime;
     std::chrono::steady_clock::time_point LastReadTime;
+    std::chrono::steady_clock::time_point LastWriteTime;
     std::vector<TDeviceCallback> ConnectionStateChangedCallbacks;
     PRegister SnRegister;
 

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -263,11 +263,6 @@ public:
     TDeviceConnectionState GetConnectionState() const;
     void SetDisconnected();
 
-    /**
-     * @brief Returns true if the device has registers to poll.
-     *        A device without them can't restore connection state by polling,
-     *        writing to its registers is the only way to communicate with it.
-     */
     bool HasRegistersToPoll() const;
 
     bool GetSupportsHoles() const;
@@ -288,6 +283,9 @@ public:
     PRegister AddRegister(PRegisterConfig config);
 
     const std::list<PRegister>& GetRegisters() const;
+
+    std::chrono::steady_clock::time_point GetLastPrepareTime() const;
+    void SetLastPrepareTime(std::chrono::steady_clock::time_point prepareTime);
 
     std::chrono::steady_clock::time_point GetLastReadTime() const;
     void SetLastReadTime(std::chrono::steady_clock::time_point readTime);
@@ -326,6 +324,7 @@ private:
     bool TimeSyncUnsupported;
 
     std::list<PRegister> Registers;
+    std::chrono::steady_clock::time_point LastPrepareTime;
     std::chrono::steady_clock::time_point LastReadTime;
     std::vector<TDeviceCallback> ConnectionStateChangedCallbacks;
     PRegister SnRegister;

--- a/src/serial_device.h
+++ b/src/serial_device.h
@@ -263,6 +263,13 @@ public:
     TDeviceConnectionState GetConnectionState() const;
     void SetDisconnected();
 
+    /**
+     * @brief Returns true if the device has registers to poll.
+     *        A device without them can't restore connection state by polling,
+     *        writing to its registers is the only way to communicate with it.
+     */
+    bool HasRegistersToPoll() const;
+
     bool GetSupportsHoles() const;
     void SetSupportsHoles(bool supportsHoles);
 

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -3,6 +3,13 @@
 
 #define LOG(logger) logger.Log() << "[serial client] "
 
+using namespace std::chrono_literals;
+
+namespace
+{
+    const auto DISCONNECTED_WRITE_INTERVAL = 1s;
+}
+
 TWriteChannelSerialClientTask::TWriteChannelSerialClientTask(PRegisterHandler handler,
                                                              TRegisterCallback readCallback,
                                                              TRegisterCallback errorCallback)
@@ -20,10 +27,11 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
     }
 
     auto device = Handler->Register()->Device();
-    auto isDisconnected =
-        device->GetConnectionState() == TDeviceConnectionState::DISCONNECTED && device->HasRegistersToPoll();
+    auto now = std::chrono::steady_clock::now();
+    auto isDisconnected = device->GetConnectionState() == TDeviceConnectionState::DISCONNECTED;
+    auto skipPrepare = device->HasRegistersToPoll() || now - device->GetLastPrepareTime() < DISCONNECTED_WRITE_INTERVAL;
 
-    if (!port->IsOpen() || !Handler->Register()->IsSupported() || isDisconnected) {
+    if (!port->IsOpen() || !Handler->Register()->IsSupported() || (isDisconnected && skipPrepare)) {
         Handler->Register()->SetError(TRegister::TError::WriteError);
         if (ErrorCallback) {
             ErrorCallback(Handler->Register());
@@ -46,6 +54,7 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
         return ISerialClientTask::TRunResult::OK;
     }
 
+    device->SetLastPrepareTime(now);
     if (lastAccessedDevice.PrepareToAccess(*port, device)) {
         Handler->Flush(*port);
     } else {

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -7,7 +7,10 @@ using namespace std::chrono_literals;
 
 namespace
 {
-    const auto DISCONNECTED_WRITE_INTERVAL = 1s;
+    // A device which is not polled can be reconnected only by writing to it,
+    // but writes retried in every cycle occupy the port and slow down other requests,
+    // so a disconnected device is accessed not more often than once per interval
+    const auto DISCONNECTED_WRITE_INTERVAL = 5s;
 }
 
 TWriteChannelSerialClientTask::TWriteChannelSerialClientTask(PRegisterHandler handler,
@@ -27,11 +30,10 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
     }
 
     auto device = Handler->Register()->Device();
-    auto now = std::chrono::steady_clock::now();
     auto isDisconnected = device->GetConnectionState() == TDeviceConnectionState::DISCONNECTED;
-    auto skipPrepare = device->HasRegistersToPoll() || now - device->GetLastPrepareTime() < DISCONNECTED_WRITE_INTERVAL;
-
-    if (!port->IsOpen() || !Handler->Register()->IsSupported() || (isDisconnected && skipPrepare)) {
+    auto skipWrite =
+        std::chrono::steady_clock::now() - device->GetLastWriteTime() < DISCONNECTED_WRITE_INTERVAL;
+    if (!port->IsOpen() || !Handler->Register()->IsSupported() || (isDisconnected && skipWrite)) {
         Handler->Register()->SetError(TRegister::TError::WriteError);
         if (ErrorCallback) {
             ErrorCallback(Handler->Register());
@@ -54,7 +56,6 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
         return ISerialClientTask::TRunResult::OK;
     }
 
-    device->SetLastPrepareTime(now);
     if (lastAccessedDevice.PrepareToAccess(*port, device)) {
         Handler->Flush(*port);
     } else {
@@ -69,5 +70,7 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
             ReadCallback(Handler->Register());
         }
     }
+
+    device->SetLastWriteTime(std::chrono::steady_clock::now());
     return Handler->NeedToFlush() ? ISerialClientTask::TRunResult::RETRY : ISerialClientTask::TRunResult::OK;
 }

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -31,8 +31,7 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
 
     auto device = Handler->Register()->Device();
     auto isDisconnected = device->GetConnectionState() == TDeviceConnectionState::DISCONNECTED;
-    auto skipWrite =
-        std::chrono::steady_clock::now() - device->GetLastWriteTime() < DISCONNECTED_WRITE_INTERVAL;
+    auto skipWrite = std::chrono::steady_clock::now() - device->GetLastWriteTime() < DISCONNECTED_WRITE_INTERVAL;
     if (!port->IsOpen() || !Handler->Register()->IsSupported() || (isDisconnected && skipWrite)) {
         Handler->Register()->SetError(TRegister::TError::WriteError);
         if (ErrorCallback) {

--- a/src/write_channel_serial_client_task.cpp
+++ b/src/write_channel_serial_client_task.cpp
@@ -19,9 +19,11 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
         return ISerialClientTask::TRunResult::OK;
     }
 
-    if (!port->IsOpen() || !Handler->Register()->IsSupported() ||
-        Handler->Register()->Device()->GetConnectionState() == TDeviceConnectionState::DISCONNECTED)
-    {
+    auto device = Handler->Register()->Device();
+    auto isDisconnected =
+        device->GetConnectionState() == TDeviceConnectionState::DISCONNECTED && device->HasRegistersToPoll();
+
+    if (!port->IsOpen() || !Handler->Register()->IsSupported() || isDisconnected) {
         Handler->Register()->SetError(TRegister::TError::WriteError);
         if (ErrorCallback) {
             ErrorCallback(Handler->Register());
@@ -44,7 +46,7 @@ ISerialClientTask::TRunResult TWriteChannelSerialClientTask::Run(PFeaturePort po
         return ISerialClientTask::TRunResult::OK;
     }
 
-    if (lastAccessedDevice.PrepareToAccess(*port, Handler->Register()->Device())) {
+    if (lastAccessedDevice.PrepareToAccess(*port, device)) {
         Handler->Flush(*port);
     } else {
         Handler->Register()->SetError(TRegister::TError::WriteError);

--- a/test/TSerialClientTest.WriteIsCancelledAfterMaxWriteFailTime.dat
+++ b/test/TSerialClientTest.WriteIsCancelledAfterMaxWriteFailTime.dat
@@ -1,0 +1,11 @@
+fake_serial_device: block address '20' for writing
+>>> Cycle() [write is blocked]
+Open()
+Sleep(100000)
+fake_serial_device '1': write address '20' failed: 'Serial protocol error: write blocked'
+fake_serial_device '1': transfer FAIL
+fake_serial_device '1': disconnected
+Error Callback: <fake:1:(type 123): 20>: write error
+>>> Cycle() [write fail time is over]
+fake_serial_device: unblock address '20' for writing
+>>> Cycle() [value is dropped, nothing is written]

--- a/test/TSerialClientTest.WriteOnlyDeviceReconnectsOnWrite.dat
+++ b/test/TSerialClientTest.WriteOnlyDeviceReconnectsOnWrite.dat
@@ -7,6 +7,7 @@ fake_serial_device '1': transfer FAIL
 fake_serial_device '1': disconnected
 Error Callback: <fake:1:(type 123): 20>: write error
 fake_serial_device: unblock address '20' for writing
+>>> Cycle() [write attempts are rate limited]
 >>> Cycle() [write is retried]
 Sleep(100000)
 fake_serial_device '1': write to address '20' value '42'

--- a/test/TSerialClientTest.WriteOnlyDeviceReconnectsOnWrite.dat
+++ b/test/TSerialClientTest.WriteOnlyDeviceReconnectsOnWrite.dat
@@ -1,0 +1,16 @@
+fake_serial_device: block address '20' for writing
+>>> Cycle() [write is blocked]
+Open()
+Sleep(100000)
+fake_serial_device '1': write address '20' failed: 'Serial protocol error: write blocked'
+fake_serial_device '1': transfer FAIL
+fake_serial_device '1': disconnected
+Error Callback: <fake:1:(type 123): 20>: write error
+fake_serial_device: unblock address '20' for writing
+>>> Cycle() [write is retried]
+Sleep(100000)
+fake_serial_device '1': write to address '20' value '42'
+fake_serial_device '1': transfer OK
+fake_serial_device '1': reconnected
+Read Callback: <fake:1:(type 123): 20> becomes 42
+Error Callback: <fake:1:(type 123): 20>: no error

--- a/test/TSerialClientTest.WriteToDisconnectedDeviceRetriesAfterReconnect.dat
+++ b/test/TSerialClientTest.WriteToDisconnectedDeviceRetriesAfterReconnect.dat
@@ -7,6 +7,7 @@ fake_serial_device '1': reconnected
 Read Callback: <fake:1:fake: 20> becomes 0
 Error Callback: <fake:1:fake: 20>: no error
 fake_serial_device: block address '20' for reading
+fake_serial_device: block address '20' for writing
 >>> Cycle() [read blocked]
 fake_serial_device '1': read address '20' failed: 'Serial protocol error: read blocked'
 fake_serial_device '1': transfer FAIL
@@ -20,8 +21,12 @@ Sleep(100000)
 fake_serial_device '1': read address '20' failed: 'Serial protocol error: read blocked'
 fake_serial_device '1': transfer FAIL
 >>> Cycle() [write while disconnected]
+Sleep(100000)
+fake_serial_device '1': write address '20' failed: 'Serial protocol error: write blocked'
+fake_serial_device '1': transfer FAIL
 Error Callback: <fake:1:fake: 20>: read+write error
 fake_serial_device: unblock address '20' for reading
+fake_serial_device: unblock address '20' for writing
 >>> Cycle() [reconnected]
 Sleep(100000)
 fake_serial_device '1': read address '20' value '0'

--- a/test/fake_serial_device.cpp
+++ b/test/fake_serial_device.cpp
@@ -123,7 +123,7 @@ void TFakeSerialDevice::WriteRegisterImpl(TPort& port, const TRegisterConfig& re
             throw TSerialDeviceTransientErrorException("device disconnected");
         }
 
-        auto addr = GetUint32RegisterAddress(reg.GetAddress());
+        auto addr = GetUint32RegisterAddress(reg.GetWriteAddress());
 
         if (Blockings[addr].second) {
             throw TSerialDeviceTransientErrorException("write blocked");
@@ -146,11 +146,11 @@ void TFakeSerialDevice::WriteRegisterImpl(TPort& port, const TRegisterConfig& re
             SetValue(&Registers[addr], reg.Get16BitWidth(), value.Get<uint64_t>());
         }
         FakePort->GetFixture().Emit() << "fake_serial_device '" << SlaveId << "': write to address '"
-                                      << reg.GetAddress() << "' value '" << value << "'";
+                                      << reg.GetWriteAddress() << "' value '" << value << "'";
 
     } catch (const exception& e) {
-        FakePort->GetFixture().Emit() << "fake_serial_device '" << SlaveId << "': write address '" << reg.GetAddress()
-                                      << "' failed: '" << e.what() << "'";
+        FakePort->GetFixture().Emit() << "fake_serial_device '" << SlaveId << "': write address '"
+                                      << reg.GetWriteAddress() << "' failed: '" << e.what() << "'";
 
         throw;
     }

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -1054,6 +1054,33 @@ TEST_F(TSerialClientTest, WriteOnlyDeviceReconnectsOnWrite)
     EXPECT_FALSE(reg20->GetErrorState().test(TRegister::TError::WriteError));
 }
 
+TEST_F(TSerialClientTest, WriteIsCancelledAfterMaxWriteFailTime)
+{
+    TRegisterDesc regDesc;
+    regDesc.WriteAddress = std::make_shared<TUint32RegisterAddress>(20);
+    PRegister reg20 = Device->AddRegister(TRegisterConfig::Create(TFakeSerialDevice::REG_FAKE, regDesc));
+    SerialClient->AddDevice(Device);
+    Device->DeviceConfig()->DeviceTimeout = std::chrono::milliseconds(0);
+
+    Device->BlockWriteFor(20, true);
+    SerialClient->SetTextValue(reg20, "42");
+    Note() << "Cycle() [write is blocked]";
+    SerialClient->Cycle();
+    EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
+    EXPECT_TRUE(reg20->GetErrorState().test(TRegister::TError::WriteError));
+
+    Device->DeviceConfig()->MaxWriteFailTime = std::chrono::seconds(-1);
+    Note() << "Cycle() [write fail time is over]";
+    SerialClient->Cycle();
+
+    Device->BlockWriteFor(20, false);
+    Device->SetLastWriteTime(std::chrono::steady_clock::now() - std::chrono::minutes(1));
+    Note() << "Cycle() [value is dropped, nothing is written]";
+    SerialClient->Cycle();
+    EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
+    EXPECT_NE(42, Device->Registers[20]);
+}
+
 TEST_F(TSerialClientTestWithSetupRegisters, SetupOk)
 {
     PRegister reg20 = Reg(20);

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -1000,6 +1000,7 @@ TEST_F(TSerialClientTest, WriteToDisconnectedDeviceRetriesAfterReconnect)
     EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());
 
     Device->BlockReadFor(20, true);
+    Device->BlockWriteFor(20, true);
     for (int i = 0; i < 3; ++i) {
         Note() << "Cycle() [read blocked]";
         SerialClient->Cycle();
@@ -1013,6 +1014,7 @@ TEST_F(TSerialClientTest, WriteToDisconnectedDeviceRetriesAfterReconnect)
     EXPECT_TRUE(reg20->GetErrorState().test(TRegister::TError::WriteError));
 
     Device->BlockReadFor(20, false);
+    Device->BlockWriteFor(20, false);
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
     for (int i = 0; i < 3; ++i) {
         Note() << "Cycle() [reconnected]";
@@ -1025,9 +1027,6 @@ TEST_F(TSerialClientTest, WriteToDisconnectedDeviceRetriesAfterReconnect)
 
 TEST_F(TSerialClientTest, WriteOnlyDeviceReconnectsOnWrite)
 {
-    // A device with write-only registers only is never polled,
-    // so a write is the only thing which can reconnect it
-
     TRegisterDesc regDesc;
     regDesc.WriteAddress = std::make_shared<TUint32RegisterAddress>(20);
     PRegister reg20 = Device->AddRegister(TRegisterConfig::Create(TFakeSerialDevice::REG_FAKE, regDesc));
@@ -1047,7 +1046,7 @@ TEST_F(TSerialClientTest, WriteOnlyDeviceReconnectsOnWrite)
     EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
     EXPECT_NE(42, Device->Registers[20]);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    Device->SetLastWriteTime(std::chrono::steady_clock::now() - std::chrono::minutes(1));
     Note() << "Cycle() [write is retried]";
     SerialClient->Cycle();
     EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -33,6 +33,13 @@ namespace
     {
         return ConvertFromRawValue(*reg->GetConfig(), reg->GetValue());
     }
+
+    const IRegisterAddress& GetAddress(PRegister reg)
+    {
+        const auto& config = *reg->GetConfig();
+        return config.AccessType == TRegisterConfig::EAccessType::WRITE_ONLY ? config.GetWriteAddress()
+                                                                             : config.GetAddress();
+    }
 }
 
 class TSerialClientTest: public TLoggedFixture
@@ -63,7 +70,7 @@ class TSerialClientTest: public TLoggedFixture
             what = "no";
         }
         Emit() << "Error Callback: <" << reg->Device()->ToString() << ":" << reg->GetConfig()->TypeName << ": "
-               << reg->GetConfig()->GetAddress() << ">: " << what << " error";
+               << GetAddress(reg) << ">: " << what << " error";
         LastRegErrors[reg] = reg->GetErrorState();
     }
 
@@ -159,7 +166,7 @@ void TSerialClientTest::SetUp()
         std::string value = GetTextValue(reg);
         bool unchanged = (LastRegValues.count(reg) && LastRegValues[reg] == value);
         Emit() << "Read Callback: <" << reg->Device()->ToString() << ":" << reg->GetConfig()->TypeName << ": "
-               << reg->GetConfig()->GetAddress() << "> becomes " << value << (unchanged ? " [unchanged]" : "");
+               << GetAddress(reg) << "> becomes " << value << (unchanged ? " [unchanged]" : "");
         LastRegValues[reg] = value;
         if (!reg->GetErrorState().count()) {
             EmitErrorMsg(reg);
@@ -1011,6 +1018,32 @@ TEST_F(TSerialClientTest, WriteToDisconnectedDeviceRetriesAfterReconnect)
         Note() << "Cycle() [reconnected]";
         SerialClient->Cycle();
     }
+    EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());
+    EXPECT_EQ(42, Device->Registers[20]);
+    EXPECT_FALSE(reg20->GetErrorState().test(TRegister::TError::WriteError));
+}
+
+TEST_F(TSerialClientTest, WriteOnlyDeviceReconnectsOnWrite)
+{
+    // A device with write-only registers only is never polled,
+    // so a write is the only thing which can reconnect it
+
+    TRegisterDesc regDesc;
+    regDesc.WriteAddress = std::make_shared<TUint32RegisterAddress>(20);
+    PRegister reg20 = Device->AddRegister(TRegisterConfig::Create(TFakeSerialDevice::REG_FAKE, regDesc));
+    SerialClient->AddDevice(Device);
+    Device->DeviceConfig()->DeviceTimeout = std::chrono::milliseconds(0);
+
+    Device->BlockWriteFor(20, true);
+    SerialClient->SetTextValue(reg20, "42");
+    Note() << "Cycle() [write is blocked]";
+    SerialClient->Cycle();
+    EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
+    EXPECT_TRUE(reg20->GetErrorState().test(TRegister::TError::WriteError));
+
+    Device->BlockWriteFor(20, false);
+    Note() << "Cycle() [write is retried]";
+    SerialClient->Cycle();
     EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());
     EXPECT_EQ(42, Device->Registers[20]);
     EXPECT_FALSE(reg20->GetErrorState().test(TRegister::TError::WriteError));

--- a/test/serial_client_test.cpp
+++ b/test/serial_client_test.cpp
@@ -1042,6 +1042,12 @@ TEST_F(TSerialClientTest, WriteOnlyDeviceReconnectsOnWrite)
     EXPECT_TRUE(reg20->GetErrorState().test(TRegister::TError::WriteError));
 
     Device->BlockWriteFor(20, false);
+    Note() << "Cycle() [write attempts are rate limited]";
+    SerialClient->Cycle();
+    EXPECT_EQ(TDeviceConnectionState::DISCONNECTED, Device->GetConnectionState());
+    EXPECT_NE(42, Device->Registers[20]);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     Note() << "Cycle() [write is retried]";
     SerialClient->Cycle();
     EXPECT_EQ(TDeviceConnectionState::CONNECTED, Device->GetConnectionState());


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Устройство, у которого все каналы настроены только на запись (`write_address` без `address`), не попадает в опрос: `TPollableDevice` берёт принимает не-write-only регистры. Вернуть его в состояние `CONNECTED` может успешный обмен, а обмен возможен только через опрос, которого нет, или через запись, которую блокирует проверка на `DISCONNECTED`. Получается тупик - после первой же ошибки записи устройство навсегда остаётся отключённым навсегда.

Проверка на `DISCONNECTED` при записи теперь применяется только к устройствам, которые опрашиваются. Для остальных запись сама выполняет функцию проверки связи.

Чтобы такие попытки не забивали линию, пока устройство отключено, они ограничены одной попыткой раз в 5 секунд.

___________________________________
**Что поменялось для пользователей:**

Устройства только с каналами управления (Modbus TCP шлюзы Arlight из оригинального тикета) теперь переживают обрыв связи - запись после разрыва восстанавливает соединение. Для устройств с каналами на чтение поведение прежнее — записи в недоступное устройство по-прежнему не занимают порт.

___________________________________
**Как проверял/а:**

Написал новые тесты, доработал эмулятор шлюза, который рвёт сессию по таймауту и подтвердил с его помощью работоспособность фикса на контроллере.
