### PR TITLE
Backport zeroed config recovery to wb-2609

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+wb-mqtt-serial (2.268.0+wb100) stable; urgency=medium
+
+  * Regenerate the system config when its content is all NUL bytes
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 10 Sep 2026 09:42:08 +0000
 wb-mqtt-serial (2.268.0) stable; urgency=medium
 
   * Evaluate declaration conditions in device/Set and device/Load RPC: a

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), wb-utils, wb-release-info
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, bsdutils (>= 2.29), rsync, wb-utils, wb-release-info
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.150.0~~)

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -2,7 +2,21 @@
 
 CONFFILE=/etc/wb-mqtt-serial.conf
 
-[ -s "$CONFFILE" ] && exit 0
+config_is_blank() {
+    if [ ! -s "$1" ]; then
+        return 0
+    fi
+
+    if [ "$(tr -d '\0' < "$1" | wc -c)" -eq 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if ! config_is_blank "$CONFFILE"; then
+    exit 0
+fi
 
 . /usr/lib/wb-utils/wb_env.sh
 
@@ -29,4 +43,5 @@ else
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.default"
 fi
 
-cp "$BOARD_CONF" "$CONFFILE"
+CONFIG_TARGET="$(readlink -f "$CONFFILE")" || exit 1
+rsync --archive --ignore-times --fsync "$BOARD_CONF" "$CONFIG_TARGET"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

SOFT-7440. Это бэкпорт [исправления #1247](https://github.com/wirenboard/wb-mqtt-serial/pull/1247) в `release/wb-2609`.

После обрыва питания `/etc/wb-mqtt-serial.conf` может остаться правильного размера, но целиком состоять из NUL-байтов. Старая проверка `[ -s ]` считала такой файл пригодным и не восстанавливала системный конфиг.

___________________________________
**Что поменялось для пользователей:**

- Пустой или полностью заполненный NUL-байтами системный конфиг пересоздаётся из board default.
- Конфиг записывается в реальную цель симлинка через `rsync --archive --ignore-times --fsync`, поэтому симлинк в `/mnt/data` сохраняется, а данные принудительно переносятся и сбрасываются на файловую систему.
- В зависимости пакета добавлен `rsync`.

___________________________________
**Как проверял/а:**

- Squash-коммит `3a824bc8` успешно собран на `master`: [Jenkins build 953](https://jenkins.wirenboard.com/job/wirenboard/job/wb-mqtt-serial/job/master/953/).
- Кодовая часть бэкпорта совпадает с исходным патчем по стабильному `patch-id`; из отличий только release-версия `2.268.0+wb100`.
- `bash -n generate-system-config.sh` — успешно.
- `shellcheck -x -e SC1091 generate-system-config.sh` — успешно; `SC1091` исключён только потому, что runtime-файл `/usr/lib/wb-utils/wb_env.sh` отсутствует на рабочей машине.
- Порядок Debian-версий проверен: `2.268.0 < 2.268.0+wb100 < 2.274.2`.
- Стендовая проверка выполнялась в исходном PR на WB8.5 с `wb-2609/testing`; отдельно на release-ветке до сборки не повторялась.

**Риски:**

Изменение затрагивает восстановление системного конфига на старте и добавляет runtime-зависимость `rsync`. Перед вливанием нужно проверить `.deb` из Jenkins: версию, архитектуру, `Depends` и фактический Debian suite.

---
ИИ: текст подготовил ИИ-агент.
Модель: GPT-5 · Harness: Codex CLI 0.154.0 · Настройки: permission mode disabled; навыки defaults, workflow, wb-jenkins, backport, pr-author
Запустила и отвечает за содержимое: @ekateluv
