### PR TITLE
Backport zeroed serial config recovery to wb-2606

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (2.248.1+wb100) stable; urgency=medium
+
+  * Regenerate the system config when its content is all NUL bytes
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 10 Sep 2026 09:42:08 +0000
+
 wb-mqtt-serial (2.248.1-wb107) stable; urgency=medium
 
   * Fix write retry on a disconnected device

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-serial
 
 Package: wb-mqtt-serial
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4, ucf, bsdutils (>= 2.29), wb-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4, ucf, bsdutils (>= 2.29), rsync, wb-utils
 Replaces: wb-homa-modbus (<< 1.14.1)
 Recommends: wb-mqtt-confed (>= 1.7.0)
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-confed (<< 1.7.0), wb-mqtt-homeui (<< 2.150.0~~)

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -2,7 +2,21 @@
 
 CONFFILE=/etc/wb-mqtt-serial.conf
 
-[ -s "$CONFFILE" ] && exit 0
+config_is_blank() {
+    if [ ! -s "$1" ]; then
+        return 0
+    fi
+
+    if [ "$(tr -d '\0' < "$1" | wc -c)" -eq 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if ! config_is_blank "$CONFFILE"; then
+    exit 0
+fi
 
 . /usr/lib/wb-utils/wb_env.sh
 
@@ -29,4 +43,5 @@ else
     BOARD_CONF="/usr/share/wb-mqtt-serial/wb-mqtt-serial.conf.default"
 fi
 
-cp "$BOARD_CONF" "$CONFFILE"
+CONFIG_TARGET="$(readlink -f "$CONFFILE")" || exit 1
+rsync --archive --ignore-times --fsync "$BOARD_CONF" "$CONFIG_TARGET"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Бекпорт исправления из [#1247](https://github.com/wirenboard/wb-mqtt-serial/pull/1247) в `release/wb-2606`. После аварийного отключения питания `/etc/wb-mqtt-serial.conf` может сохранить размер, но оказаться полностью заполненным NUL-байтами. Такой конфиг нужно считать пустым и восстановить при запуске.

___________________________________
**Что поменялось для пользователей:**

При запуске `wb-mqtt-serial` отсутствующий, пустой или целиком заполненный NUL-байтами системный конфиг восстанавливается из подходящего шаблона. Запись выполняется в фактическую цель симлинка через `rsync --fsync`, поэтому симлинк на постоянное хранилище сохраняется.

Версия пакета для бекпорта: `2.248.1+wb100`.

___________________________________
**Как проверял/а:**

- Исходный коммит `3a824bc88248c2d836849f3a7c4e73f93f726da7` успешно собрался в master: Jenkins build 953 — SUCCESS.
- `bash -n generate-system-config.sh`.
- `shellcheck -x -e SC1091 generate-system-config.sh` (`SC1091` исключён для runtime-файла `/usr/lib/wb-utils/wb_env.sh`).
- Генерация шаблонов локально проходит; полная C++-сборка требует системный `wblib` из штатного wbdev/Jenkins-окружения.
- [Jenkins PR build 1](https://jenkins.wirenboard.com/job/wirenboard/job/wb-mqtt-serial/job/PR-1255/1/) — SUCCESS: style, static analysis, Python checks, C++ tests, coverage, Lintian и сборка пакетов прошли.
- В логе сборки: `WBDEV_IMAGE=contactless/devenv:latest_bullseye`, `Distribution: bullseye`, цели `bullseye-armhf bullseye-arm64`.
- Проверены скачанные `.deb` для armhf и arm64: версия `2.248.1+wb100~exp~PR+1255~9~g35999a45`, зависимости включают `libc6 (>= 2.30)` и `rsync`; в пакет попал обновлённый генератор с NUL-проверкой.
- Codacy вернул `action_required` без annotations; Jenkins-проверки зелёные.

**Риски:**

Низкие. Изменение ограничено восстановлением заведомо пустого или целиком NUL-заполненного конфига. Конфиги с любым ненулевым содержимым не перезаписываются.

---
ИИ: текст подготовил ИИ-агент.
Модель: GPT-5 · Harness: Codex CLI 0.154.0 · Настройки: permission mode disabled; навыки defaults, workflow, wb-jenkins, backport, pr-author
Запустила и отвечает за содержимое: @ekateluv
