### PR TITLE
Correct wb-2609 serial backport version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-serial (2.268.0+wb100) stable; urgency=medium
+wb-mqtt-serial (2.268.0-wb100) stable; urgency=medium
 
   * Regenerate the system config when its content is all NUL bytes
 


### PR DESCRIPTION
<!--
Если Вы сделали новый шаблон устройства, прочитайте, пожалуйста, эту 
инструкцию https://docs.google.com/document/d/1QuC7aIOph28jpWhG23iRglvHc9igXZJHnHpeEDYG0tU/edit#heading=h.y1udrz334w6y

Ваши изменения должны ей соответствовать!

При необходимости обновите `TDeviceTemplatesTest.Validate.dat` с помощью `make dump-templates`.
-->

<!--
Если Вы изменили RPC или структуру файла настроек, обязательно напишите в README.md, в какой версии версии wb-mqtt-serial появились эти изменения.
-->
___________________________________
**Что происходит; кому и зачем нужно:**

Исправляет версию уже влитого бекпорта #1254 для `release/wb-2609`: вместо ошибочной `2.268.0+wb100` пакет должен иметь release-версию `2.268.0-wb100`.

Ошибочные сборки `wb-mqtt-serial` версии `2.268.0+wb100` для armhf и arm64 удалены из release-пула джобами [remove-deb #29](https://jenkins.wirenboard.com/job/pipelines/job/remove-deb/29/) и [remove-deb #30](https://jenkins.wirenboard.com/job/pipelines/job/remove-deb/30/).

___________________________________
**Что поменялось для пользователей:**

Функциональных изменений нет. Меняется только Debian-версия бекпорта на `2.268.0-wb100`.

___________________________________
**Как проверял/а:**

- `dpkg-parsechangelog -S Version` → `2.268.0-wb100`;
- `dpkg --compare-versions 2.268.0 lt 2.268.0-wb100`;
- `git diff --check`;
- удаление ошибочных пакетов завершилось успешно в Jenkins #29 и #30.

**Риски:**

`2.268.0-wb100` по правилам Debian ниже уже созданной `2.268.0+wb100`, поэтому корректная публикация зависит от выполненного удаления ошибочной версии из пула. Тег `v2.268.0+wb100` в git остаётся как исторический.

---
ИИ: текст подготовил ИИ-агент.
Модель: GPT-5 · Harness: Codex CLI 0.154.0 · Настройки: permission mode disabled; навыки backport, wb-jenkins, workflow, pr-author, defaults
Запустила и отвечает за содержимое: @ekateluv
